### PR TITLE
Single Channel Health Check — Profile Opt-In Enforcement

### DIFF
--- a/backend/apps/api/stream_checker_handlers.py
+++ b/backend/apps/api/stream_checker_handlers.py
@@ -270,8 +270,12 @@ def check_single_channel_now_response(
             return jsonify({"error": "channel_id required"}), 400
 
         channel_id = data["channel_id"]
+        # profile_id is optionally supplied when the user explicitly chose a profile
+        # via the ProfilePickerDialog (multi-period channel). When present it is
+        # forwarded to the service so the correct profile governs the check.
+        forced_profile_id = data.get("profile_id")
         service = get_stream_checker_service()
-        result = service.check_single_channel(channel_id)
+        result = service.check_single_channel(channel_id, forced_profile_id=forced_profile_id)
 
         if result.get("success"):
             return jsonify(result), 200

--- a/backend/apps/api/stream_checker_handlers.py
+++ b/backend/apps/api/stream_checker_handlers.py
@@ -247,7 +247,23 @@ def check_single_channel_now_response(
     payload: Any,
     get_stream_checker_service: Callable[[], Any],
 ):
-    """Handle immediate synchronous check for one channel."""
+    """Handle immediate synchronous check for one channel.
+
+    The backend enforces the opt-in model: a channel must have an automation
+    profile assigned (via an automation period or, for EPG checks, an EPG
+    scheduled profile override) before a health check can run. When neither
+    resolves, the service returns error='no_profile'.
+
+    Returns:
+        200  — check ran successfully
+        400  — channel_id missing, OR channel has no automation profile assigned
+               (no_profile). 400 is used for no_profile rather than 500 because
+               this is a user configuration error, not an internal server fault.
+               The frontend pre-flight catches this before reaching the API in
+               the normal path; the backend guard fires as a safety net (e.g.
+               periods exist but none are currently active at execution time).
+        500  — unexpected internal error
+    """
     try:
         data = payload
         if not data or "channel_id" not in data:
@@ -258,8 +274,16 @@ def check_single_channel_now_response(
         result = service.check_single_channel(channel_id)
 
         if result.get("success"):
-            return jsonify(result)
+            return jsonify(result), 200
+
+        # no_profile: user configuration error — channel has no automation profile.
+        # Return 400 so the frontend can distinguish this from a generic failure
+        # and surface a precise, actionable message rather than "Check Failed".
+        if result.get("error") == "no_profile":
+            return jsonify(result), 400
+
         return jsonify(result), 500
+
     except Exception as exc:
         logger.error(f"Error checking single channel: {exc}")
         return jsonify({"error": "Internal Server Error"}), 500

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -3127,35 +3127,71 @@ class StreamCheckerService:
                     'channel_name': channel_name
                 }
             
-            # Check channel settings for matching and checking modes
-            # Check channel settings for matching and checking modes via Automation Profiles
+            # Resolve the automation profile that governs this check.
+            #
+            # Resolution order:
+            #   1. EPG scheduled profile override (channel-level then group-level).
+            #      Only consulted when is_epg_scheduled=True.
+            #   2. Active period-based profile via get_effective_configuration.
+            #   3. Hard halt — no fallback to global automation controls.
+            #
+            # Rationale: the opt-in model requires an explicit profile. Without one
+            # the system cannot know the user's intent (matching flags, checking flags,
+            # scoring weights, loop detection, minimum thresholds, etc.) and must not
+            # act. Global automation controls are a system-wide on/off switch, not a
+            # per-channel configuration, and are never an appropriate fallback here.
             from apps.automation.automation_config_manager import get_automation_config_manager
             automation_config = get_automation_config_manager()
-            
-            # channel dict is available in local scope
+
             channel_group_id = channel.get('channel_group_id')
 
-            # If this is an EPG scheduled check, prefer the EPG scheduled profile override
+            # Step 1: EPG scheduled profile override (EPG-triggered checks only)
             profile = None
             if is_epg_scheduled:
-                epg_profile = automation_config.get_effective_epg_scheduled_profile(channel_id, channel_group_id)
+                epg_profile = automation_config.get_effective_epg_scheduled_profile(
+                    channel_id, channel_group_id
+                )
                 if epg_profile:
                     profile = epg_profile
-                    logger.info(f"Channel {channel_name}: using EPG scheduled profile '{epg_profile.get('name')}'")
+                    logger.info(
+                        f"Channel {channel_name}: using EPG scheduled profile "
+                        f"'{epg_profile.get('name')}'"
+                    )
 
-            # Fall back to the active period-based profile if no EPG profile was found
+            # Step 2: Active period-based profile
             if profile is None:
                 config = automation_config.get_effective_configuration(channel_id, channel_group_id)
                 profile = config.get('profile') if config else None
-            
-            # Default to global automation controls when no channel/group profile applies.
-            matching_enabled = self.config.get('automation_controls.auto_stream_matching', True)
-            checking_enabled = self.config.get('automation_controls.auto_quality_checking', True)
-            if profile:
-                matching_enabled = profile.get('stream_matching', {}).get('enabled', False)
-                checking_enabled = profile.get('stream_checking', {}).get('enabled', False)
-            
-            logger.info(f"Channel {channel_name} settings: matching={matching_enabled}, checking={checking_enabled}")
+
+            # Step 3: Hard halt — no profile means no check.
+            # This replaces the former global-controls fallback which silently ran
+            # checks with system-wide defaults, ignoring per-channel intent entirely.
+            if profile is None:
+                logger.warning(
+                    f"⛔ Channel {channel_name} (ID: {channel_id}) has no automation "
+                    f"profile assigned. Health check cannot proceed without an explicit "
+                    f"profile. Assign an automation period, or for EPG checks an EPG "
+                    f"scheduled profile override."
+                )
+                return {
+                    'success': False,
+                    'error': 'no_profile',
+                    'message': (
+                        f"Channel {channel_name} has no automation profile assigned. "
+                        f"Assign an automation period with a profile before running "
+                        f"a health check."
+                    ),
+                    'channel_id': channel_id,
+                    'channel_name': channel_name,
+                }
+
+            matching_enabled = profile.get('stream_matching', {}).get('enabled', False)
+            checking_enabled = profile.get('stream_checking', {}).get('enabled', False)
+
+            logger.info(
+                f"Channel {channel_name} settings: "
+                f"matching={matching_enabled}, checking={checking_enabled}"
+            )
 
             # Signal to the frontend that this is a single channel check so the
             # stale batch progress card from the previous automation run is suppressed.

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -3067,7 +3067,7 @@ class StreamCheckerService:
                 
         return results
 
-    def check_single_channel(self, channel_id: int, program_name: Optional[str] = None, is_epg_scheduled: bool = False) -> Dict:
+    def check_single_channel(self, channel_id: int, program_name: Optional[str] = None, is_epg_scheduled: bool = False, forced_profile_id: Optional[str] = None) -> Dict:
         """Check a single channel immediately and return results.
         
         This performs a targeted channel refresh for a single channel:
@@ -3145,9 +3145,25 @@ class StreamCheckerService:
 
             channel_group_id = channel.get('channel_group_id')
 
-            # Step 1: EPG scheduled profile override (EPG-triggered checks only)
+            # Step 0: Explicitly chosen profile (from ProfilePickerDialog, multi-period channels).
+            # When the user selected a specific profile via the picker we honour it
+            # directly, skipping the schedule-based resolution entirely.
             profile = None
-            if is_epg_scheduled:
+            if forced_profile_id:
+                profile = automation_config.get_profile(forced_profile_id)
+                if profile:
+                    logger.info(
+                        f"Channel {channel_name}: using explicitly selected profile "
+                        f"'{profile.get('name')}' (id={forced_profile_id})"
+                    )
+                else:
+                    logger.warning(
+                        f"Channel {channel_name}: forced_profile_id={forced_profile_id!r} "
+                        f"not found — falling back to standard resolution"
+                    )
+
+            # Step 1: EPG scheduled profile override (EPG-triggered checks only)
+            if profile is None and is_epg_scheduled:
                 epg_profile = automation_config.get_effective_epg_scheduled_profile(
                     channel_id, channel_group_id
                 )

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -890,7 +890,7 @@ class StreamCheckerService:
 
     # Removed _refine_sorted_streams in favor of lexicographical Sort Keys.
     
-    def _check_channel(self, channel_id: int, skip_batch_changelog: bool = False):
+    def _check_channel(self, channel_id: int, skip_batch_changelog: bool = False, forced_profile_id: Optional[str] = None):
         """Check and reorder streams for a specific channel.
         
         Routes to either concurrent or sequential checking based on configuration.
@@ -902,11 +902,11 @@ class StreamCheckerService:
         concurrent_enabled = self.config.get('concurrent_streams.enabled', True)
         
         if concurrent_enabled:
-            return self._check_channel_concurrent(channel_id, skip_batch_changelog=skip_batch_changelog)
+            return self._check_channel_concurrent(channel_id, skip_batch_changelog=skip_batch_changelog, forced_profile_id=forced_profile_id)
         else:
-            return self._check_channel_sequential(channel_id, skip_batch_changelog=skip_batch_changelog)
+            return self._check_channel_sequential(channel_id, skip_batch_changelog=skip_batch_changelog, forced_profile_id=forced_profile_id)
     
-    def _check_channel_concurrent(self, channel_id: int, skip_batch_changelog: bool = False, target_stream_ids: Optional[List[str]] = None):
+    def _check_channel_concurrent(self, channel_id: int, skip_batch_changelog: bool = False, target_stream_ids: Optional[List[str]] = None, forced_profile_id: Optional[str] = None):
         """Check and reorder streams for a specific channel using parallel thread pool.
         
         Args:
@@ -954,8 +954,19 @@ class StreamCheckerService:
             channel = udi.get_channel_by_id(channel_id)
             group_id = channel.get('channel_group_id') if channel else None
             
-            config = automation_config.get_effective_configuration(channel_id, group_id)
-            profile = config.get('profile') if config else None
+            # If a profile was explicitly selected (via ProfilePickerDialog), use it
+            # directly so all checking parameters (weights, limits, revive, loop detection)
+            # reflect the user's intent rather than whichever period is currently active.
+            if forced_profile_id:
+                profile = automation_config.get_profile(forced_profile_id)
+                if not profile:
+                    logger.warning(
+                        f"forced_profile_id={forced_profile_id!r} not found in _check_channel "
+                        f"— falling back to active period resolution"
+                    )
+            if not forced_profile_id or not profile:
+                config = automation_config.get_effective_configuration(channel_id, group_id)
+                profile = config.get('profile') if config else None
             if profile:
                 profile_stream_checking = profile.get('stream_checking', {})
                 stream_limit = profile_stream_checking.get('stream_limit', 0)
@@ -1696,7 +1707,7 @@ class StreamCheckerService:
             log_function_return(logger, "_check_channel_concurrent")
 
     
-    def _check_channel_sequential(self, channel_id: int, skip_batch_changelog: bool = False, target_stream_ids: Optional[List[str]] = None):
+    def _check_channel_sequential(self, channel_id: int, skip_batch_changelog: bool = False, target_stream_ids: Optional[List[str]] = None, forced_profile_id: Optional[str] = None):
         """Check and reorder streams for a specific channel using sequential checking.
         
         Args:
@@ -1737,8 +1748,19 @@ class StreamCheckerService:
             channel = udi.get_channel_by_id(channel_id)
             group_id = channel.get('channel_group_id') if channel else None
             
-            config = automation_config.get_effective_configuration(channel_id, group_id)
-            profile = config.get('profile') if config else None
+            # If a profile was explicitly selected (via ProfilePickerDialog), use it
+            # directly so all checking parameters (weights, limits, revive, loop detection)
+            # reflect the user's intent rather than whichever period is currently active.
+            if forced_profile_id:
+                profile = automation_config.get_profile(forced_profile_id)
+                if not profile:
+                    logger.warning(
+                        f"forced_profile_id={forced_profile_id!r} not found in _check_channel "
+                        f"— falling back to active period resolution"
+                    )
+            if not forced_profile_id or not profile:
+                config = automation_config.get_effective_configuration(channel_id, group_id)
+                profile = config.get('profile') if config else None
             if profile:
                 profile_stream_checking = profile.get('stream_checking', {})
                 stream_limit = profile_stream_checking.get('stream_limit', 0)
@@ -3127,9 +3149,18 @@ class StreamCheckerService:
                     'channel_name': channel_name
                 }
             
+            # Check channel settings for matching and checking modes
+            # Check channel settings for matching and checking modes via Automation Profiles
+            from apps.automation.automation_config_manager import get_automation_config_manager
+            automation_config = get_automation_config_manager()
+            
+            # channel dict is available in local scope
+            channel_group_id = channel.get('channel_group_id')
+
             # Resolve the automation profile that governs this check.
             #
             # Resolution order:
+            #   0. Explicitly forced profile (from ProfilePickerDialog, multi-period channels).
             #   1. EPG scheduled profile override (channel-level then group-level).
             #      Only consulted when is_epg_scheduled=True.
             #   2. Active period-based profile via get_effective_configuration.
@@ -3140,10 +3171,6 @@ class StreamCheckerService:
             # scoring weights, loop detection, minimum thresholds, etc.) and must not
             # act. Global automation controls are a system-wide on/off switch, not a
             # per-channel configuration, and are never an appropriate fallback here.
-            from apps.automation.automation_config_manager import get_automation_config_manager
-            automation_config = get_automation_config_manager()
-
-            channel_group_id = channel.get('channel_group_id')
 
             # Step 0: Explicitly chosen profile (from ProfilePickerDialog, multi-period channels).
             # When the user selected a specific profile via the picker we honour it
@@ -3164,15 +3191,10 @@ class StreamCheckerService:
 
             # Step 1: EPG scheduled profile override (EPG-triggered checks only)
             if profile is None and is_epg_scheduled:
-                epg_profile = automation_config.get_effective_epg_scheduled_profile(
-                    channel_id, channel_group_id
-                )
+                epg_profile = automation_config.get_effective_epg_scheduled_profile(channel_id, channel_group_id)
                 if epg_profile:
                     profile = epg_profile
-                    logger.info(
-                        f"Channel {channel_name}: using EPG scheduled profile "
-                        f"'{epg_profile.get('name')}'"
-                    )
+                    logger.info(f"Channel {channel_name}: using EPG scheduled profile '{epg_profile.get('name')}'")
 
             # Step 2: Active period-based profile
             if profile is None:
@@ -3204,10 +3226,7 @@ class StreamCheckerService:
             matching_enabled = profile.get('stream_matching', {}).get('enabled', False)
             checking_enabled = profile.get('stream_checking', {}).get('enabled', False)
 
-            logger.info(
-                f"Channel {channel_name} settings: "
-                f"matching={matching_enabled}, checking={checking_enabled}"
-            )
+            logger.info(f"Channel {channel_name} settings: matching={matching_enabled}, checking={checking_enabled}")
 
             # Signal to the frontend that this is a single channel check so the
             # stale batch progress card from the previous automation run is suppressed.
@@ -3364,7 +3383,7 @@ class StreamCheckerService:
                 # Perform the check (this will now bypass immunity and check all streams)
                 # Returns dict with dead_streams_count and revived_streams_count
                 # Skip batch changelog since this is a single channel check
-                check_result = self._check_channel(channel_id, skip_batch_changelog=True)
+                check_result = self._check_channel(channel_id, skip_batch_changelog=True, forced_profile_id=forced_profile_id)
                 if not check_result or not isinstance(check_result, dict):
                     # This should not happen with updated methods, but provide safe fallback
                     logger.warning(f"_check_channel did not return expected result dict, using defaults")

--- a/backend/tests/test_single_channel_checking_mode.py
+++ b/backend/tests/test_single_channel_checking_mode.py
@@ -392,5 +392,156 @@ class TestSingleChannelHandlerNoProfileResponse(unittest.TestCase):
         self.assertEqual(data.get('error'), 'no_profile')
 
 
+
+class TestSingleChannelForcedProfileId(unittest.TestCase):
+    """Tests for scenario 3 — multi-period channel with explicit profile selection via picker."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_forced_profile_id_bypasses_period_resolution(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
+    ):
+        """When forced_profile_id is provided the service must use that profile directly,
+        skipping both EPG override and active-period resolution."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        channel_id = 301
+        forced_id = 'profile-abc'
+        forced_profile = _make_profile(matching_enabled=True, checking_enabled=True)
+        forced_profile['name'] = 'Picker Selected Profile'
+
+        mock_streams = [
+            {'id': 1, 'url': 'http://example.com/1', 'm3u_account': 1,
+             'stream_stats': {'status': 'ok'}},
+        ]
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'Multi-Period Channel', mock_streams)
+
+        mock_session_mgr = Mock()
+        mock_session_mgr.get_channels_in_active_sessions.return_value = []
+        mock_get_session_mgr.return_value = mock_session_mgr
+
+        mock_acm = Mock()
+        # get_profile called with forced_id should return the profile
+        mock_acm.get_profile.return_value = forced_profile
+        # These should NOT be called when forced_profile_id resolves
+        mock_acm.get_effective_epg_scheduled_profile.return_value = None
+        mock_acm.get_effective_configuration.return_value = None
+        mock_get_acm.return_value = mock_acm
+
+        service = StreamCheckerService()
+        service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0})
+
+        with patch('stream_checker_service.fetch_channel_streams', return_value=mock_streams),              patch('api_utils.refresh_m3u_playlists'),              patch('automated_stream_manager.AutomatedStreamManager') as mock_asm:
+            mock_asm.return_value.discover_and_assign_streams = Mock(return_value={})
+            result = service.check_single_channel(
+                channel_id=channel_id,
+                forced_profile_id=forced_id,
+            )
+
+        # Must not be a no_profile error
+        self.assertNotEqual(result.get('error'), 'no_profile',
+                            "Forced profile should prevent no_profile error")
+
+        # get_profile must have been called with the forced_id
+        mock_acm.get_profile.assert_called_once_with(forced_id)
+
+        # EPG and period resolution must NOT have been called
+        mock_acm.get_effective_epg_scheduled_profile.assert_not_called()
+        mock_acm.get_effective_configuration.assert_not_called()
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_forced_profile_id_not_found_falls_back_to_period_resolution(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
+    ):
+        """If forced_profile_id does not resolve (deleted profile), fall back to
+        standard period resolution rather than hard-halting."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        channel_id = 302
+        forced_id = 'deleted-profile-id'
+
+        mock_streams = [
+            {'id': 1, 'url': 'http://example.com/1', 'm3u_account': 1,
+             'stream_stats': {'status': 'ok'}},
+        ]
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'Channel With Deleted Profile', mock_streams)
+
+        mock_session_mgr = Mock()
+        mock_session_mgr.get_channels_in_active_sessions.return_value = []
+        mock_get_session_mgr.return_value = mock_session_mgr
+
+        mock_acm = Mock()
+        # forced_profile_id doesn't resolve
+        mock_acm.get_profile.return_value = None
+        # But a period-based profile exists as fallback
+        mock_acm.get_effective_epg_scheduled_profile.return_value = None
+        mock_acm.get_effective_configuration.return_value = {
+            'profile': _make_profile(matching_enabled=True, checking_enabled=True),
+            'periods': [],
+        }
+        mock_get_acm.return_value = mock_acm
+
+        service = StreamCheckerService()
+        service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0})
+
+        with patch('stream_checker_service.fetch_channel_streams', return_value=mock_streams),              patch('api_utils.refresh_m3u_playlists'),              patch('automated_stream_manager.AutomatedStreamManager') as mock_asm:
+            mock_asm.return_value.discover_and_assign_streams = Mock(return_value={})
+            result = service.check_single_channel(
+                channel_id=channel_id,
+                forced_profile_id=forced_id,
+            )
+
+        # Should not hard-halt — period profile is the fallback
+        self.assertNotEqual(result.get('error'), 'no_profile')
+        # get_effective_configuration must have been called as fallback
+        mock_acm.get_effective_configuration.assert_called_once()
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_forced_profile_id_none_uses_normal_resolution(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
+    ):
+        """forced_profile_id=None must behave identically to not passing it —
+        normal EPG/period resolution applies."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        channel_id = 303
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'Normal Channel')
+
+        mock_session_mgr = Mock()
+        mock_session_mgr.get_channels_in_active_sessions.return_value = []
+        mock_get_session_mgr.return_value = mock_session_mgr
+
+        mock_acm = Mock()
+        mock_acm.get_effective_epg_scheduled_profile.return_value = None
+        mock_acm.get_effective_configuration.return_value = None
+        mock_get_acm.return_value = mock_acm
+
+        service = StreamCheckerService()
+        result = service.check_single_channel(channel_id=channel_id, forced_profile_id=None)
+
+        # No forced_profile_id and no configured profile — must hard-halt
+        self.assertEqual(result.get('error'), 'no_profile')
+        # get_profile must NOT have been called (forced_profile_id is None/falsy)
+        mock_acm.get_profile.assert_not_called()
+
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/backend/tests/test_single_channel_checking_mode.py
+++ b/backend/tests/test_single_channel_checking_mode.py
@@ -1,278 +1,396 @@
 #!/usr/bin/env python3
 """
-Test to verify that single channel check respects checking_mode and matching_mode settings.
-
-This test verifies that when a single channel check is triggered:
-1. Stream matching only happens if matching_mode is enabled
-2. Stream quality checking only happens if checking_mode is enabled
+Test to verify that single channel check enforces the opt-in model:
+- No profile assigned -> hard halt, structured error response
+- Profile assigned, matching disabled -> skip matching, proceed with check
+- Profile assigned, checking disabled -> skip checking, proceed
+- Profile assigned, both enabled -> full check
+- EPG-scheduled path with no profile -> hard halt (same guard, different entry point)
 """
 
 import unittest
 import tempfile
-import json
+import shutil
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 import sys
 import os
 
-# Add backend to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-class TestSingleChannelCheckingMode(unittest.TestCase):
-    """Test that single channel check respects channel settings."""
-    
+def _make_mock_config(side_effect=None):
+    mock_config = Mock()
+    mock_config.get = Mock(side_effect=side_effect or (lambda key, default=None: default))
+    return mock_config
+
+
+def _make_mock_udi(channel_id, channel_name, streams=None):
+    mock_udi_instance = Mock()
+    mock_udi_instance.get_channel_by_id.return_value = {
+        'id': channel_id,
+        'name': channel_name,
+        'channel_group_id': None,
+        'logo_id': None,
+    }
+    mock_udi_instance.is_channel_active.return_value = False
+    mock_udi_instance.refresh_streams = Mock()
+    mock_udi_instance.refresh_channels = Mock()
+    mock_udi_instance.get_streams = Mock(return_value=streams or [])
+    return mock_udi_instance
+
+
+def _make_profile(matching_enabled=True, checking_enabled=True):
+    return {
+        'name': 'Test Profile',
+        'stream_matching': {'enabled': matching_enabled},
+        'stream_checking': {'enabled': checking_enabled},
+    }
+
+
+class TestSingleChannelNoProfileGuard(unittest.TestCase):
+    """Tests for the no-profile hard halt — the core opt-in enforcement."""
+
     def setUp(self):
-        """Set up test fixtures."""
-        # Create temporary directory for test files
         self.temp_dir = tempfile.mkdtemp()
-        
+
     def tearDown(self):
-        """Clean up test fixtures."""
-        import shutil
         shutil.rmtree(self.temp_dir, ignore_errors=True)
-    
-    @patch('stream_checker_service.StreamCheckConfig')
+
     @patch('stream_checker_service.get_udi_manager')
-    @patch('stream_checker_service.fetch_channel_streams')
-    @patch('api_utils.refresh_m3u_playlists')
-    def test_single_channel_check_skips_checking_when_disabled(
-        self, mock_refresh, mock_fetch_streams, mock_udi, mock_config_class
-    ):
-        """Test that check_single_channel skips checking when checking_mode is disabled."""
-        with patch('stream_checker_service.CONFIG_DIR', Path(self.temp_dir)):
-            with patch('channel_settings_manager.CONFIG_DIR', Path(self.temp_dir)):
-                # Reset singleton to ensure fresh instance
-                import channel_settings_manager
-                channel_settings_manager._channel_settings_manager = None
-                
-                from apps.stream.stream_checker_service import StreamCheckerService
-                from channel_settings_manager import get_channel_settings_manager
-                
-                # Mock config
-                mock_config = Mock()
-                mock_config.get = Mock(side_effect=lambda key, default=None: default)
-                mock_config_class.return_value = mock_config
-                
-                # Setup mocks
-                mock_udi_instance = Mock()
-                mock_udi.return_value = mock_udi_instance
-                
-                # Mock channel data
-                channel_id = 123
-                mock_channel = {
-                    'id': channel_id,
-                    'name': 'Test Channel',
-                    'logo_id': None
-                }
-                mock_udi_instance.get_channel_by_id.return_value = mock_channel
-                
-                # Mock streams
-                mock_streams = [
-                    {'id': 1, 'name': 'Stream 1', 'url': 'http://example.com/1', 'm3u_account': 1,
-                     'stream_stats': {'status': 'ok'}},
-                ]
-                mock_fetch_streams.return_value = mock_streams
-                
-                # Mock UDI refresh methods
-                mock_udi_instance.refresh_streams = Mock()
-                mock_udi_instance.refresh_channels = Mock()
-                mock_udi_instance.get_streams = Mock(return_value=mock_streams)
-                
-                # Configure channel settings: matching enabled, checking disabled
-                channel_settings = get_channel_settings_manager()
-                channel_settings.set_channel_settings(
-                    channel_id,
-                    matching_mode='enabled',
-                    checking_mode='disabled'
-                )
-                
-                # Create service instance
-                service = StreamCheckerService()
-                
-                # Mock _check_channel to track if it's called
-                service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0})
-                
-                # Mock automation manager (imported inside the function)
-                with patch('automated_stream_manager.AutomatedStreamManager') as mock_automation_class:
-                    mock_automation_instance = Mock()
-                    mock_automation_class.return_value = mock_automation_instance
-                    mock_automation_instance.discover_and_assign_streams = Mock(return_value={})
-                    
-                    # Call check_single_channel
-                    result = service.check_single_channel(channel_id=channel_id)
-                
-                # Verify results
-                self.assertTrue(result.get('success'), "Single channel check should succeed")
-                
-                # Verify that _check_channel was NOT called (checking is disabled)
-                service._check_channel.assert_not_called()
-                
-                # Verify that matching was attempted (matching is enabled)
-                # This is checked indirectly - the AutomatedStreamManager should be instantiated
-                # We can't easily verify the call without more complex mocking
-    
     @patch('stream_checker_service.StreamCheckConfig')
-    @patch('stream_checker_service.get_udi_manager')
-    @patch('stream_checker_service.fetch_channel_streams')
-    @patch('api_utils.refresh_m3u_playlists')
-    def test_single_channel_check_performs_checking_when_enabled(
-        self, mock_refresh, mock_fetch_streams, mock_udi, mock_config_class
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_no_profile_returns_no_profile_error(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
     ):
-        """Test that check_single_channel performs checking when checking_mode is enabled."""
-        with patch('stream_checker_service.CONFIG_DIR', Path(self.temp_dir)):
-            with patch('channel_settings_manager.CONFIG_DIR', Path(self.temp_dir)):
-                # Reset singleton to ensure fresh instance
-                import channel_settings_manager
-                channel_settings_manager._channel_settings_manager = None
-                
-                from apps.stream.stream_checker_service import StreamCheckerService
-                from channel_settings_manager import get_channel_settings_manager
-                
-                # Mock config
-                mock_config = Mock()
-                mock_config.get = Mock(side_effect=lambda key, default=None: default)
-                mock_config_class.return_value = mock_config
-                
-                # Setup mocks
-                mock_udi_instance = Mock()
-                mock_udi.return_value = mock_udi_instance
-                
-                # Mock channel data
-                channel_id = 456
-                mock_channel = {
-                    'id': channel_id,
-                    'name': 'Test Channel 2',
-                    'logo_id': None
-                }
-                mock_udi_instance.get_channel_by_id.return_value = mock_channel
-                
-                # Mock streams
-                mock_streams = [
-                    {'id': 2, 'name': 'Stream 2', 'url': 'http://example.com/2', 'm3u_account': 1,
-                     'stream_stats': {'status': 'ok'}},
-                ]
-                mock_fetch_streams.return_value = mock_streams
-                
-                # Mock UDI refresh methods
-                mock_udi_instance.refresh_streams = Mock()
-                mock_udi_instance.refresh_channels = Mock()
-                mock_udi_instance.get_streams = Mock(return_value=mock_streams)
-                
-                # Configure channel settings: both enabled (default)
-                channel_settings = get_channel_settings_manager()
-                channel_settings.set_channel_settings(
-                    channel_id,
-                    matching_mode='enabled',
-                    checking_mode='enabled'
-                )
-                
-                # Create service instance
-                service = StreamCheckerService()
-                
-                # Mock _check_channel to track if it's called
-                service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0})
-                
-                # Mock automation manager (imported inside the function)
-                with patch('automated_stream_manager.AutomatedStreamManager') as mock_automation_class:
-                    mock_automation_instance = Mock()
-                    mock_automation_class.return_value = mock_automation_instance
-                    mock_automation_instance.discover_and_assign_streams = Mock(return_value={})
-                    
-                    # Call check_single_channel
-                    result = service.check_single_channel(channel_id=channel_id)
-                
-                # Verify results
-                self.assertTrue(result.get('success'), "Single channel check should succeed")
-                
-                # Verify that _check_channel WAS called (checking is enabled)
-                service._check_channel.assert_called_once()
-                
-                # Verify the channel was marked for force check
-                self.assertTrue(
-                    service.update_tracker.should_force_check(channel_id),
-                    "Channel should be marked for force check"
-                )
-    
+        """When no automation period or EPG profile is assigned, check must hard-halt."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        channel_id = 101
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'ESPN')
+
+        # No monitoring sessions
+        mock_session_mgr = Mock()
+        mock_session_mgr.get_channels_in_active_sessions.return_value = []
+        mock_get_session_mgr.return_value = mock_session_mgr
+
+        # No EPG profile, no period-based config -> profile resolves to None
+        mock_acm = Mock()
+        mock_acm.get_effective_epg_scheduled_profile.return_value = None
+        mock_acm.get_effective_configuration.return_value = None
+        mock_get_acm.return_value = mock_acm
+
+        service = StreamCheckerService()
+        result = service.check_single_channel(channel_id=channel_id)
+
+        self.assertFalse(result.get('success'))
+        self.assertEqual(result.get('error'), 'no_profile')
+        self.assertIn('ESPN', result.get('message', ''))
+        self.assertEqual(result.get('channel_id'), channel_id)
+
+    @patch('stream_checker_service.get_udi_manager')
     @patch('stream_checker_service.StreamCheckConfig')
-    @patch('stream_checker_service.get_udi_manager')
-    @patch('stream_checker_service.fetch_channel_streams')
-    @patch('api_utils.refresh_m3u_playlists')
-    def test_single_channel_check_skips_matching_when_disabled(
-        self, mock_refresh, mock_fetch_streams, mock_udi, mock_config_class
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_no_profile_epg_path_also_hard_halts(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
     ):
-        """Test that check_single_channel skips matching when matching_mode is disabled."""
-        with patch('stream_checker_service.CONFIG_DIR', Path(self.temp_dir)):
-            with patch('channel_settings_manager.CONFIG_DIR', Path(self.temp_dir)):
-                # Reset singleton to ensure fresh instance
-                import channel_settings_manager
-                channel_settings_manager._channel_settings_manager = None
-                
-                from apps.stream.stream_checker_service import StreamCheckerService
-                from channel_settings_manager import get_channel_settings_manager
-                
-                # Mock config
-                mock_config = Mock()
-                mock_config.get = Mock(side_effect=lambda key, default=None: default)
-                mock_config_class.return_value = mock_config
-                
-                # Setup mocks
-                mock_udi_instance = Mock()
-                mock_udi.return_value = mock_udi_instance
-                
-                # Mock channel data
-                channel_id = 789
-                mock_channel = {
-                    'id': channel_id,
-                    'name': 'Test Channel 3',
-                    'logo_id': None
-                }
-                mock_udi_instance.get_channel_by_id.return_value = mock_channel
-                
-                # Mock streams
-                mock_streams = [
-                    {'id': 3, 'name': 'Stream 3', 'url': 'http://example.com/3', 'm3u_account': 1,
-                     'stream_stats': {'status': 'ok'}},
-                ]
-                mock_fetch_streams.return_value = mock_streams
-                
-                # Mock UDI refresh methods
-                mock_udi_instance.refresh_streams = Mock()
-                mock_udi_instance.refresh_channels = Mock()
-                mock_udi_instance.get_streams = Mock(return_value=mock_streams)
-                
-                # Configure channel settings: matching disabled, checking enabled
-                channel_settings = get_channel_settings_manager()
-                channel_settings.set_channel_settings(
-                    channel_id,
-                    matching_mode='disabled',
-                    checking_mode='enabled'
-                )
-                
-                # Create service instance
-                service = StreamCheckerService()
-                
-                # Mock _check_channel
-                service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0})
-                
-                # Mock automation manager (imported inside the function)
-                with patch('automated_stream_manager.AutomatedStreamManager') as mock_automation_class:
-                    mock_automation_instance = Mock()
-                    mock_automation_class.return_value = mock_automation_instance
-                    mock_automation_instance.discover_and_assign_streams = Mock(return_value={})
-                    
-                    # Call check_single_channel
-                    result = service.check_single_channel(channel_id=channel_id)
-                    
-                    # Verify that AutomatedStreamManager was NOT instantiated (matching is disabled)
-                    mock_automation_class.assert_not_called()
-                
-                # Verify results
-                self.assertTrue(result.get('success'), "Single channel check should succeed")
-                
-                # Verify that _check_channel WAS called (checking is enabled)
-                service._check_channel.assert_called_once()
+        """EPG-scheduled path with no resolvable profile must also hard-halt."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        channel_id = 102
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'Sky Sports')
+
+        mock_session_mgr = Mock()
+        mock_session_mgr.get_channels_in_active_sessions.return_value = []
+        mock_get_session_mgr.return_value = mock_session_mgr
+
+        # No EPG override, no period config
+        mock_acm = Mock()
+        mock_acm.get_effective_epg_scheduled_profile.return_value = None
+        mock_acm.get_effective_configuration.return_value = None
+        mock_get_acm.return_value = mock_acm
+
+        service = StreamCheckerService()
+        result = service.check_single_channel(channel_id=channel_id, is_epg_scheduled=True)
+
+        self.assertFalse(result.get('success'))
+        self.assertEqual(result.get('error'), 'no_profile')
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_epg_profile_override_allows_check(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
+    ):
+        """When EPG override profile is set, the check must proceed (not halt)."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        channel_id = 103
+        mock_streams = [
+            {'id': 1, 'url': 'http://example.com/1', 'm3u_account': 1,
+             'stream_stats': {'status': 'ok'}},
+        ]
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'BT Sport', mock_streams)
+
+        mock_session_mgr = Mock()
+        mock_session_mgr.get_channels_in_active_sessions.return_value = []
+        mock_get_session_mgr.return_value = mock_session_mgr
+
+        # EPG profile exists
+        mock_acm = Mock()
+        mock_acm.get_effective_epg_scheduled_profile.return_value = _make_profile()
+        mock_get_acm.return_value = mock_acm
+
+        service = StreamCheckerService()
+        # Stub the rest of the pipeline to avoid full ffmpeg execution
+        service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0})
+
+        with patch('stream_checker_service.fetch_channel_streams', return_value=mock_streams), \
+             patch('api_utils.refresh_m3u_playlists'), \
+             patch('automated_stream_manager.AutomatedStreamManager') as mock_asm:
+            mock_asm.return_value.discover_and_assign_streams = Mock(return_value={})
+            result = service.check_single_channel(channel_id=channel_id, is_epg_scheduled=True)
+
+        # Should not be a no_profile error
+        self.assertNotEqual(result.get('error'), 'no_profile')
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_period_profile_allows_check(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
+    ):
+        """When a period-based profile resolves, check must proceed (not halt)."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        channel_id = 104
+        mock_streams = [
+            {'id': 2, 'url': 'http://example.com/2', 'm3u_account': 1,
+             'stream_stats': {'status': 'ok'}},
+        ]
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'Fox News', mock_streams)
+
+        mock_session_mgr = Mock()
+        mock_session_mgr.get_channels_in_active_sessions.return_value = []
+        mock_get_session_mgr.return_value = mock_session_mgr
+
+        # No EPG override, but period config exists with profile
+        mock_acm = Mock()
+        mock_acm.get_effective_epg_scheduled_profile.return_value = None
+        mock_acm.get_effective_configuration.return_value = {
+            'profile': _make_profile(matching_enabled=True, checking_enabled=True),
+            'periods': [],
+        }
+        mock_get_acm.return_value = mock_acm
+
+        service = StreamCheckerService()
+        service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0})
+
+        with patch('stream_checker_service.fetch_channel_streams', return_value=mock_streams), \
+             patch('api_utils.refresh_m3u_playlists'), \
+             patch('automated_stream_manager.AutomatedStreamManager') as mock_asm:
+            mock_asm.return_value.discover_and_assign_streams = Mock(return_value={})
+            result = service.check_single_channel(channel_id=channel_id)
+
+        self.assertNotEqual(result.get('error'), 'no_profile')
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_config_with_none_profile_is_no_profile(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
+    ):
+        """Config dict exists but profile key is None -> still a no_profile halt."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        channel_id = 105
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'CNN')
+
+        mock_session_mgr = Mock()
+        mock_session_mgr.get_channels_in_active_sessions.return_value = []
+        mock_get_session_mgr.return_value = mock_session_mgr
+
+        # Config exists but profile is None (period assigned, no profile on assignment)
+        mock_acm = Mock()
+        mock_acm.get_effective_epg_scheduled_profile.return_value = None
+        mock_acm.get_effective_configuration.return_value = {'profile': None, 'periods': []}
+        mock_get_acm.return_value = mock_acm
+
+        service = StreamCheckerService()
+        result = service.check_single_channel(channel_id=channel_id)
+
+        self.assertFalse(result.get('success'))
+        self.assertEqual(result.get('error'), 'no_profile')
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_no_profile_does_not_consult_global_controls(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
+    ):
+        """Global automation controls must never be used as profile fallback."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        channel_id = 106
+
+        # Global controls say True/True — but no profile should still halt
+        def config_side_effect(key, default=None):
+            if key == 'automation_controls.auto_stream_matching':
+                return True
+            if key == 'automation_controls.auto_quality_checking':
+                return True
+            return default
+
+        mock_config_class.return_value = _make_mock_config(side_effect=config_side_effect)
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'MSNBC')
+
+        mock_session_mgr = Mock()
+        mock_session_mgr.get_channels_in_active_sessions.return_value = []
+        mock_get_session_mgr.return_value = mock_session_mgr
+
+        mock_acm = Mock()
+        mock_acm.get_effective_epg_scheduled_profile.return_value = None
+        mock_acm.get_effective_configuration.return_value = None
+        mock_get_acm.return_value = mock_acm
+
+        service = StreamCheckerService()
+        # Ensure _check_channel is NOT called (would prove global controls were used)
+        service._check_channel = Mock()
+
+        result = service.check_single_channel(channel_id=channel_id)
+
+        self.assertFalse(result.get('success'))
+        self.assertEqual(result.get('error'), 'no_profile')
+        service._check_channel.assert_not_called()
+
+
+class TestSingleChannelProfileRespected(unittest.TestCase):
+    """Tests that matching/checking flags from the resolved profile are honoured."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _setup_service_with_profile(self, channel_id, channel_name, profile,
+                                     mock_config_class, mock_get_udi,
+                                     mock_get_acm, mock_get_session_mgr,
+                                     streams=None):
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        mock_streams = streams or [
+            {'id': 1, 'url': 'http://example.com/1', 'm3u_account': 1,
+             'stream_stats': {'status': 'ok'}},
+        ]
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, channel_name, mock_streams)
+
+        mock_session_mgr = Mock()
+        mock_session_mgr.get_channels_in_active_sessions.return_value = []
+        mock_get_session_mgr.return_value = mock_session_mgr
+
+        mock_acm = Mock()
+        mock_acm.get_effective_epg_scheduled_profile.return_value = None
+        mock_acm.get_effective_configuration.return_value = {
+            'profile': profile,
+            'periods': [],
+        }
+        mock_get_acm.return_value = mock_acm
+
+        service = StreamCheckerService()
+        service._check_channel = Mock(return_value={
+            'dead_streams_count': 0, 'revived_streams_count': 0
+        })
+        return service, mock_streams
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_checking_disabled_in_profile_skips_check(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
+    ):
+        """Profile with stream_checking disabled must skip _check_channel."""
+        profile = _make_profile(matching_enabled=True, checking_enabled=False)
+        service, mock_streams = self._setup_service_with_profile(
+            200, 'Test Channel', profile,
+            mock_config_class, mock_get_udi, mock_get_acm, mock_get_session_mgr
+        )
+
+        with patch('stream_checker_service.fetch_channel_streams', return_value=mock_streams), \
+             patch('api_utils.refresh_m3u_playlists'), \
+             patch('automated_stream_manager.AutomatedStreamManager') as mock_asm:
+            mock_asm.return_value.discover_and_assign_streams = Mock(return_value={})
+            result = service.check_single_channel(channel_id=200)
+
+        self.assertNotEqual(result.get('error'), 'no_profile')
+        service._check_channel.assert_not_called()
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    def test_checking_enabled_in_profile_runs_check(
+        self, mock_get_session_mgr, mock_get_acm, mock_config_class, mock_get_udi
+    ):
+        """Profile with stream_checking enabled must call _check_channel."""
+        profile = _make_profile(matching_enabled=False, checking_enabled=True)
+        service, mock_streams = self._setup_service_with_profile(
+            201, 'Test Channel 2', profile,
+            mock_config_class, mock_get_udi, mock_get_acm, mock_get_session_mgr
+        )
+
+        with patch('stream_checker_service.fetch_channel_streams', return_value=mock_streams), \
+             patch('api_utils.refresh_m3u_playlists'), \
+             patch('automated_stream_manager.AutomatedStreamManager') as mock_asm:
+            mock_asm.return_value.discover_and_assign_streams = Mock(return_value={})
+            result = service.check_single_channel(channel_id=201)
+
+        self.assertNotEqual(result.get('error'), 'no_profile')
+        service._check_channel.assert_called_once()
+
+
+class TestSingleChannelHandlerNoProfileResponse(unittest.TestCase):
+    """Tests that the stream_checker_handlers layer surfaces no_profile cleanly."""
+
+    def test_handler_returns_400_for_no_profile(self):
+        """Handler must return 400 (not 500) when backend signals no_profile."""
+        from apps.api.stream_checker_handlers import check_single_channel_now_response
+
+        mock_service = Mock()
+        mock_service.check_single_channel.return_value = {
+            'success': False,
+            'error': 'no_profile',
+            'message': 'Channel ESPN has no automation profile assigned.',
+            'channel_id': 1,
+            'channel_name': 'ESPN',
+        }
+
+        result = check_single_channel_now_response(
+            payload={'channel_id': 1},
+            get_stream_checker_service=lambda: mock_service,
+        )
+
+        # check_single_channel_now_response returns a tuple (response, status_code)
+        response, status_code = result if isinstance(result, tuple) else (result, 200)
+        self.assertEqual(status_code, 400)
+
+        import json as json_mod
+        data = json_mod.loads(response.get_data(as_text=True))
+        self.assertEqual(data.get('error'), 'no_profile')
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/frontend/src/components/channel-configuration/ProfilePickerDialog.jsx
+++ b/frontend/src/components/channel-configuration/ProfilePickerDialog.jsx
@@ -1,0 +1,124 @@
+/**
+ * ProfilePickerDialog
+ *
+ * Shown when a channel has multiple automation periods with different profiles
+ * and the user clicks "Health Check". The user selects which profile should
+ * govern this one-time check invocation. The selection is NOT persisted.
+ *
+ * Props:
+ *   open          {boolean}   — controls dialog visibility
+ *   onOpenChange  {function}  — called with false when dialog should close
+ *   channelName   {string}    — displayed in the dialog title
+ *   periods       {Array}     — enriched period objects from getChannelPeriods
+ *                               each has: { id, name, profile_id, profile_name, schedule }
+ *   onSelect      {function}  — called with profileId when user confirms
+ */
+
+import { useState, useEffect } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog.jsx'
+import { Button } from '@/components/ui/button.jsx'
+import { Label } from '@/components/ui/label.jsx'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.jsx'
+import { Loader2 } from 'lucide-react'
+
+export function ProfilePickerDialog({
+  open,
+  onOpenChange,
+  channelName,
+  periods = [],
+  onSelect,
+}) {
+  const [selectedProfileId, setSelectedProfileId] = useState('')
+
+  // Build a deduplicated list of profiles from the periods array.
+  // A channel may have N periods that all share the same profile — in that
+  // case we show one entry, not N. Keyed on profile_id.
+  const uniqueProfiles = (() => {
+    const seen = new Map()
+    for (const period of periods) {
+      if (period.profile_id && !seen.has(period.profile_id)) {
+        seen.set(period.profile_id, {
+          profile_id: period.profile_id,
+          profile_name: period.profile_name || `Profile ${period.profile_id}`,
+        })
+      }
+    }
+    return Array.from(seen.values())
+  })()
+
+  // Reset selection when dialog opens so stale selection doesn't persist
+  useEffect(() => {
+    if (open) {
+      setSelectedProfileId('')
+    }
+  }, [open])
+
+  const handleConfirm = () => {
+    if (!selectedProfileId) return
+    onSelect(selectedProfileId)
+    onOpenChange(false)
+  }
+
+  const handleCancel = () => {
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>Select Check Profile</DialogTitle>
+          <DialogDescription>
+            <strong>{channelName}</strong> has multiple automation profiles assigned.
+            Select which profile should govern this health check.
+            This selection applies to this check only and is not saved.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-4 space-y-3">
+          <Label htmlFor="profile-select">Profile</Label>
+          <Select
+            value={selectedProfileId}
+            onValueChange={setSelectedProfileId}
+          >
+            <SelectTrigger id="profile-select">
+              <SelectValue placeholder="Choose a profile…" />
+            </SelectTrigger>
+            <SelectContent>
+              {uniqueProfiles.map((p) => (
+                <SelectItem key={p.profile_id} value={p.profile_id}>
+                  {p.profile_name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={!selectedProfileId}
+          >
+            Run Health Check
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/channel-configuration/RegexTableRow.jsx
+++ b/frontend/src/components/channel-configuration/RegexTableRow.jsx
@@ -1,5 +1,4 @@
-
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button.jsx'
 import { Checkbox } from '@/components/ui/checkbox.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
@@ -18,6 +17,227 @@ import {
 } from '@/components/channel-configuration/patternUtils.js'
 import { AssignPeriodsDialog } from '@/components/channel-configuration/PeriodDialogs.jsx'
 
+// ---------------------------------------------------------------------------
+// Helper: format a period's schedule into a human-readable string
+// ---------------------------------------------------------------------------
+function formatSchedule(schedule) {
+  if (!schedule) return 'Unknown schedule'
+  if (schedule.type === 'interval') {
+    const mins = Number(schedule.value)
+    if (mins >= 60 && mins % 60 === 0) return `Every ${mins / 60}h`
+    return `Every ${mins}m`
+  }
+  if (schedule.type === 'cron') return `Cron: ${schedule.value}`
+  return String(schedule.value ?? '')
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip: Channel Group column
+// Shows resolved automation profile source + EPG override source
+// ---------------------------------------------------------------------------
+function ChannelGroupTooltip({ children, channel, group, groupsConfig, profiles }) {
+  const channelGroupId = channel?.group_id ?? channel?.channel_group_id
+
+  // --- Automation profile resolution ---
+  const isPeriodChannelOverride =
+    channel?.automation_periods_source === 'channel' ||
+    Number(channel?.channel_periods_count || 0) > 0
+  const isPeriodGroupBased =
+    channel?.automation_periods_source === 'group' ||
+    (!isPeriodChannelOverride && Number(channel?.group_periods_count || 0) > 0)
+
+  // --- EPG profile resolution ---
+  const isEpgChannelOverride = Boolean(channel?.channel_epg_scheduled_profile_id)
+  const groupEpgProfileId = groupsConfig?.[channelGroupId]?.epg_profile_id
+  const isEpgGroupBased = !isEpgChannelOverride && Boolean(groupEpgProfileId)
+
+  // Resolve EPG profile name
+  const epgProfileId = channel?.channel_epg_scheduled_profile_id || groupEpgProfileId
+  const epgProfile = epgProfileId ? profiles?.find(p => String(p.id) === String(epgProfileId)) : null
+
+  // Automation source label
+  let automationSource = 'None'
+  if (isPeriodChannelOverride) automationSource = 'Channel override'
+  else if (isPeriodGroupBased) automationSource = 'Inherited from group'
+
+  // EPG source label
+  let epgSource = 'None'
+  if (isEpgChannelOverride) epgSource = 'Channel override'
+  else if (isEpgGroupBased) epgSource = 'Inherited from group'
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent className="max-w-[260px] space-y-2 p-3">
+        {/* Group name */}
+        <p className="font-semibold text-sm">{group?.name || 'Ungrouped'}</p>
+
+        <Separator className="my-1" />
+
+        {/* Automation profile */}
+        <div className="space-y-0.5">
+          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            Automation
+          </p>
+          <p className="text-xs">{automationSource}</p>
+        </div>
+
+        {/* EPG profile */}
+        <div className="space-y-0.5">
+          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            EPG Profile
+          </p>
+          {epgProfile ? (
+            <p className="text-xs flex items-center gap-1">
+              <CalendarClock className="h-3 w-3 shrink-0" />
+              <span>{epgProfile.name}</span>
+              <span className="text-muted-foreground">({epgSource})</span>
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">{epgSource}</p>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip: Nº of Periods column
+// Lazy-loads period details on first hover; caches result in a ref.
+// ---------------------------------------------------------------------------
+function PeriodsTooltip({ children, channel, profiles }) {
+  const [open, setOpen] = useState(false)
+  const [periods, setPeriods] = useState(null)   // null = not yet fetched
+  const [loading, setLoading] = useState(false)
+  const fetchedRef = useRef(false)
+
+  const handleOpenChange = useCallback(
+    async (nextOpen) => {
+      setOpen(nextOpen)
+      if (!nextOpen || fetchedRef.current) return
+      fetchedRef.current = true
+      setLoading(true)
+      try {
+        const res = await automationAPI.getChannelPeriods(channel.id)
+        setPeriods(Array.isArray(res.data) ? res.data : [])
+      } catch {
+        setPeriods([])
+      } finally {
+        setLoading(false)
+      }
+    },
+    [channel.id]
+  )
+
+  const periodCount = channel?.automation_periods_count ?? 0
+
+  return (
+    <Tooltip open={open} onOpenChange={handleOpenChange}>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent className="max-w-[280px] p-3 space-y-2">
+        <p className="font-semibold text-sm">
+          {periodCount} Automation {periodCount === 1 ? 'Period' : 'Periods'}
+        </p>
+
+        {loading && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground py-1">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Loading…
+          </div>
+        )}
+
+        {!loading && periods !== null && periods.length === 0 && (
+          <p className="text-xs text-muted-foreground italic">No periods assigned</p>
+        )}
+
+        {!loading && periods && periods.length > 0 && (
+          <div className="space-y-1.5">
+            {periods.map((period) => {
+              const profileName =
+                period.profile?.name ||
+                (period.profile_id
+                  ? profiles?.find(p => String(p.id) === String(period.profile_id))?.name
+                  : null)
+              return (
+                <div
+                  key={period.id}
+                  className="rounded-md bg-muted/50 px-2 py-1.5 space-y-0.5"
+                >
+                  <p className="text-xs font-medium leading-tight">{period.name}</p>
+                  <p className="text-[11px] text-muted-foreground leading-tight">
+                    {formatSchedule(period.schedule)}
+                    {profileName && (
+                      <span className="ml-1">· {profileName}</span>
+                    )}
+                  </p>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip: Regex Patterns column
+// All data is already in props — zero fetching needed.
+// ---------------------------------------------------------------------------
+function RegexPatternsTooltip({ children, channelPatterns, matchByTvgId, isTvgInherited, channel }) {
+  const normalizedPatterns = normalizePatternData(channelPatterns)
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent className="max-w-[320px] p-3 space-y-2">
+        <p className="font-semibold text-sm">Regex Patterns</p>
+
+        {/* TVG-ID matching */}
+        {matchByTvgId && (
+          <div className="rounded-md bg-muted/50 px-2 py-1.5">
+            <p className="text-xs font-medium flex items-center gap-1">
+              TVG-ID matching
+              {isTvgInherited && (
+                <Badge variant="outline" className="text-[10px] h-4 px-1 ml-1">Group</Badge>
+              )}
+            </p>
+            {channel?.tvg_id ? (
+              <p className="text-[11px] text-muted-foreground font-mono mt-0.5 break-all">
+                {channel.tvg_id}
+              </p>
+            ) : (
+              <p className="text-[11px] text-muted-foreground italic mt-0.5">No TVG-ID set</p>
+            )}
+          </div>
+        )}
+
+        {/* Regex patterns list */}
+        {normalizedPatterns.length > 0 ? (
+          <div className="space-y-1.5">
+            {normalizedPatterns.map((p, i) => (
+              <div key={i} className="rounded-md bg-muted/50 px-2 py-1.5 space-y-0.5">
+                <p className="text-xs font-mono break-all leading-snug">{p.pattern}</p>
+                {p.m3u_accounts && p.m3u_accounts.length > 0 && (
+                  <p className="text-[11px] text-muted-foreground">
+                    M3U filter: {p.m3u_accounts.join(', ')}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : !matchByTvgId ? (
+          <p className="text-xs text-muted-foreground italic">No patterns configured</p>
+        ) : null}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 export function RegexTableRow({
   channel,
   group,
@@ -61,80 +281,84 @@ export function RegexTableRow({
   const isPeriodChannelOverride =
     channel?.automation_periods_source === 'channel' || Number(channel?.channel_periods_count || 0) > 0
   const isPeriodGroupBased =
-    channel?.automation_periods_source === 'group' || (!isPeriodChannelOverride && Number(channel?.group_periods_count || 0) > 0)
+    channel?.automation_periods_source === 'group' ||
+    (!isPeriodChannelOverride && Number(channel?.group_periods_count || 0) > 0)
   const isEpgChannelOverride = Boolean(channel?.channel_epg_scheduled_profile_id)
   const isEpgGroupBased = !isEpgChannelOverride && Boolean(groupsConfig?.[channelGroupId]?.epg_profile_id)
   const groupMatchingPatternCount = Array.isArray(groupMatchingConfig?.regex_patterns)
     ? groupMatchingConfig.regex_patterns.length
     : 0
-  const isRegexChannelOverride = patternCount > 0
-  const isRegexGroupBased = !isRegexChannelOverride && groupMatchingPatternCount > 0
 
+  // Logo loading (unchanged)
+  useEffect(() => {
+    const cached = getCachedChannelLogoUrl(channel.id)
+    if (cached) { setLogoUrl(cached); return }
+    if (channel.logo_id) {
+      channelsAPI.getChannelLogo(channel.logo_id)
+        .then(res => {
+          const url = res.data?.url || res.data
+          if (url) { setLogoUrl(url); setCachedChannelLogoUrl(channel.id, url) }
+        })
+        .catch(() => setLogoError(true))
+    }
+  }, [channel.id, channel.logo_id])
+
+  // Period loading for the expanded row panel (unchanged behaviour)
   const loadChannelPeriods = useCallback(async () => {
+    setLoadingPeriods(true)
     try {
-      setLoadingPeriods(true)
-      const response = await automationAPI.getChannelPeriods(channel.id)
-      setChannelPeriods(response.data || [])
-    } catch (err) {
-      console.error('Failed to load channel periods:', err)
+      const res = await automationAPI.getChannelPeriods(channel.id)
+      setChannelPeriods(Array.isArray(res.data) ? res.data : [])
+    } catch {
+      setChannelPeriods([])
     } finally {
       setLoadingPeriods(false)
     }
   }, [channel.id])
 
   useEffect(() => {
-    if (expanded) {
-      loadChannelPeriods()
-    }
+    if (expanded) loadChannelPeriods()
   }, [expanded, loadChannelPeriods])
 
   const handleRemovePeriod = async (periodId) => {
     try {
       await automationAPI.removePeriodFromChannels(periodId, [channel.id])
-      toast({
-        title: 'Success',
-        description: 'Automation period removed from channel',
-      })
+      toast({ title: 'Success', description: 'Period removed' })
       loadChannelPeriods()
-      if (onRefresh) {
-        onRefresh()
-      }
-    } catch (err) {
-      console.error('Failed to remove period:', err)
-      toast({
-        title: 'Error',
-        description: 'Failed to remove automation period',
-        variant: 'destructive',
-      })
+      if (onRefresh) onRefresh()
+    } catch {
+      toast({ title: 'Error', description: 'Failed to remove period', variant: 'destructive' })
     }
   }
 
-  useEffect(() => {
-    const loadLogo = () => {
-      const cachedUrl = getCachedChannelLogoUrl(channel.id)
-      if (cachedUrl) {
-        setLogoUrl(cachedUrl)
-        return
-      }
-
-      if (channel.logo_id) {
-        const channelLogoUrl = channelsAPI.getLogoCached(channel.logo_id)
-        setLogoUrl(channelLogoUrl)
-        setCachedChannelLogoUrl(channel.id, channelLogoUrl)
-      }
-    }
-    loadLogo()
-  }, [channel.id, channel.logo_id])
+  // Matching mode helpers
+  const effectiveMatchingEnabled = effectiveMatchingConfig?.enabled !== false
+  const effectiveCheckingMode =
+    channel?.checking_mode || groupsConfig?.[channelGroupId]?.checking_mode || 'enabled'
 
   return (
-    <div key={channel.id}>
-      <div className="grid gap-4 p-4 hover:bg-muted/50 transition-colors" style={{ gridTemplateColumns: REGEX_TABLE_GRID_COLS }}>
-        <div className="flex items-center justify-center">
-          <Checkbox checked={selectedChannels.has(channel.id)} onCheckedChange={() => onToggleChannel(channel.id)} />
-        </div>
-        <div className="flex items-center text-sm font-medium">{channel.channel_number || '-'}</div>
+    <div className="border-b last:border-b-0">
+      {/* ── Collapsed row grid ── */}
+      <div
+        className="grid items-center gap-2 px-3 py-3 hover:bg-muted/30 transition-colors"
+        style={{ gridTemplateColumns: REGEX_TABLE_GRID_COLS }}
+      >
+        {/* Checkbox */}
         <div className="flex items-center">
-          <div className="w-16 h-10 flex-shrink-0 bg-muted rounded-md flex items-center justify-center overflow-hidden">
+          <Checkbox
+            checked={selectedChannels?.has(channel.id)}
+            onCheckedChange={() => onToggleChannel?.(channel.id)}
+          />
+        </div>
+
+        {/* Channel number */}
+        <div className="text-sm font-mono text-muted-foreground">
+          {channel.channel_number || '—'}
+        </div>
+
+        {/* Logo */}
+        <div className="flex items-center justify-center">
+          <div className="w-8 h-8 rounded bg-muted flex items-center justify-center overflow-hidden">
             {logoUrl && !logoError ? (
               <img
                 src={logoUrl}
@@ -143,49 +367,90 @@ export function RegexTableRow({
                 onError={() => setLogoError(true)}
               />
             ) : (
-              <span className="text-lg font-bold text-muted-foreground">{channel.name?.charAt(0) || '?'}</span>
+              <span className="text-xs font-bold text-muted-foreground">
+                {channel.name?.charAt(0) || '?'}
+              </span>
             )}
           </div>
         </div>
+
+        {/* Channel name */}
         <div className="flex items-center">
           <span className="font-medium truncate">{channel.name}</span>
         </div>
-        <div className="flex items-center text-sm text-muted-foreground">
-          <div className="min-w-0">
-            <div className="truncate">{group?.name || '-'}</div>
-            <div className="flex items-center gap-1 mt-1 flex-wrap">
-              <Badge variant={isPeriodChannelOverride ? 'default' : 'outline'} className="text-[10px] h-5 px-1.5">
-                Automation: {isPeriodChannelOverride ? 'Override' : isPeriodGroupBased ? 'Group' : 'None'}
-              </Badge>
-              <Badge variant={isEpgChannelOverride ? 'default' : 'outline'} className="text-[10px] h-5 px-1.5">
-                EPG Profile: {isEpgChannelOverride ? 'Override' : isEpgGroupBased ? 'Group' : 'None'}
+
+        {/* ── Channel Group column (with tooltip) ── */}
+        <div className="flex items-center text-sm text-muted-foreground min-w-0">
+          <ChannelGroupTooltip
+            channel={channel}
+            group={group}
+            groupsConfig={groupsConfig}
+            profiles={profiles}
+          >
+            <div className="min-w-0 cursor-default">
+              <div className="truncate">{group?.name || '-'}</div>
+              <div className="flex items-center gap-1 mt-1 flex-wrap">
+                <Badge
+                  variant={isPeriodChannelOverride ? 'default' : 'outline'}
+                  className="text-[10px] h-5 px-1.5"
+                >
+                  Automation: {isPeriodChannelOverride ? 'Override' : isPeriodGroupBased ? 'Group' : 'None'}
+                </Badge>
+                <Badge
+                  variant={isEpgChannelOverride ? 'default' : 'outline'}
+                  className="text-[10px] h-5 px-1.5"
+                >
+                  EPG Profile: {isEpgChannelOverride ? 'Override' : isEpgGroupBased ? 'Group' : 'None'}
+                </Badge>
+              </div>
+            </div>
+          </ChannelGroupTooltip>
+        </div>
+
+        {/* ── Nº of Periods column (with tooltip) ── */}
+        <div className="flex items-center">
+          <PeriodsTooltip channel={channel} profiles={profiles}>
+            <div className="cursor-default">
+              <Badge variant="outline" className="text-xs font-normal">
+                {channel.automation_periods_count || 0}{' '}
+                {channel.automation_periods_count !== 1 ? 'periods' : 'period'}
               </Badge>
             </div>
-          </div>
+          </PeriodsTooltip>
         </div>
-        <div className="flex items-center">
-          <Badge variant="outline" className="text-xs font-normal">
-            {channel.automation_periods_count || 0} period{channel.automation_periods_count !== 1 ? 's' : ''}
-          </Badge>
-        </div>
+
+        {/* ── Regex Patterns column (with tooltip) ── */}
         <div className="flex items-center gap-2 flex-wrap">
-          {patternCount > 0 ? (
-            <Badge variant="secondary">{patternCount} pattern{patternCount > 1 ? 's' : ''}</Badge>
-          ) : (
-            <span className="text-sm text-muted-foreground">No patterns</span>
-          )}
-          {matchByTvgId && (
-            <>
-              <Badge variant="default" className="text-xs">
-                TVG-ID
-              </Badge>
-              {isTvgInherited && (
-                <Badge variant="outline" className="text-xs">
-                  From Group
+          <RegexPatternsTooltip
+            channelPatterns={channelPatterns}
+            matchByTvgId={matchByTvgId}
+            isTvgInherited={isTvgInherited}
+            channel={channel}
+          >
+            <div className="flex items-center gap-2 flex-wrap cursor-default">
+              {patternCount > 0 ? (
+                <Badge variant="secondary">
+                  {patternCount} pattern{patternCount > 1 ? 's' : ''}
                 </Badge>
+              ) : groupMatchingPatternCount > 0 ? (
+                <Badge variant="outline" className="text-[10px]">
+                  {groupMatchingPatternCount} (group)
+                </Badge>
+              ) : (
+                <span className="text-sm text-muted-foreground">No patterns</span>
               )}
-            </>
-          )}
+              {matchByTvgId && (
+                <>
+                  <Badge variant="default" className="text-xs">TVG-ID</Badge>
+                  {isTvgInherited && (
+                    <Badge variant="outline" className="text-xs">From Group</Badge>
+                  )}
+                </>
+              )}
+            </div>
+          </RegexPatternsTooltip>
+
+          {/* Stream match count tooltip (pre-existing, unchanged) */}
           <Tooltip>
             <TooltipTrigger asChild>
               <span className="text-xs font-mono tabular-nums cursor-default select-none">
@@ -193,7 +458,7 @@ export function RegexTableRow({
                   {matchCount !== undefined ? matchCount : '—'}
                 </span>
                 <span className="text-muted-foreground">{' / '}</span>
-                <span className="text-muted-foreground">{(channel.streams?.length ?? 0)}</span>
+                <span className="text-muted-foreground">{channel.streams?.length ?? 0}</span>
               </span>
             </TooltipTrigger>
             <TooltipContent className="max-w-xs">
@@ -219,10 +484,12 @@ export function RegexTableRow({
             </TooltipContent>
           </Tooltip>
         </div>
+
+        {/* Actions */}
         <div className="flex items-center gap-2">
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="sm" onClick={() => onPreviewMatch(channel.id, 'global')}>
+              <Button variant="ghost" size="sm" onClick={() => onPreviewMatch?.(channel.id, 'global')}>
                 <Eye className="h-4 w-4 text-muted-foreground" />
               </Button>
             </TooltipTrigger>
@@ -233,71 +500,168 @@ export function RegexTableRow({
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => onCheckChannel(channel.id)}
+                onClick={() => onCheckChannel?.(channel.id)}
                 disabled={isChecking}
                 className="text-blue-600 dark:text-green-500 border-blue-600 dark:border-green-500 hover:bg-blue-50 dark:hover:bg-green-950"
               >
-                {isChecking ? <Loader2 className="h-4 w-4 animate-spin" /> : <Activity className="h-4 w-4" />}
+                {isChecking
+                  ? <Loader2 className="h-4 w-4 animate-spin" />
+                  : <Activity className="h-4 w-4" />}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>
-              <p>Health Check Channel</p>
-            </TooltipContent>
+            <TooltipContent>Health Check Channel</TooltipContent>
           </Tooltip>
-          <Button variant="outline" size="sm" onClick={() => onToggleExpanded(channel.id)}>
+          <Button variant="outline" size="sm" onClick={() => onToggleExpanded?.(channel.id)}>
             <ChevronDown className={`h-4 w-4 transition-transform ${expanded ? 'rotate-180' : ''}`} />
           </Button>
         </div>
       </div>
 
+      {/* ── Expanded panel (unchanged) ── */}
       {expanded && (
-        <div className="border-t p-4 bg-muted/50 space-y-6">
+        <div className="px-4 pb-4 space-y-4 bg-muted/20 border-t">
+          {/* Regex patterns editor */}
+          <div className="pt-4">
+            <div className="flex items-center justify-between mb-3">
+              <h4 className="font-medium text-sm flex items-center gap-2">
+                <Edit className="h-4 w-4" />
+                Regex Patterns
+                {hasChannelMatchingConfig ? null : channelGroupId && groupMatchingPatternCount > 0 ? (
+                  <Badge variant="outline" className="text-[10px]">Inherited from group</Badge>
+                ) : null}
+              </h4>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 text-xs"
+                onClick={() => onEditRegex?.(channel.id, null)}
+              >
+                <Plus className="h-3 w-3 mr-1" />
+                Add Pattern
+              </Button>
+            </div>
+
+            {normalizePatternData(channelPatterns).length > 0 ? (
+              <div className="space-y-2">
+                {normalizePatternData(channelPatterns).map((p, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center justify-between gap-2 rounded-md border bg-background px-3 py-2"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-mono break-all">{p.pattern}</p>
+                      {p.m3u_accounts && p.m3u_accounts.length > 0 && (
+                        <p className="text-[11px] text-muted-foreground mt-0.5">
+                          M3U: {p.m3u_accounts.join(', ')}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex gap-1 shrink-0">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 w-7 p-0"
+                        onClick={() => onEditRegex?.(channel.id, idx)}
+                      >
+                        <Edit className="h-3 w-3" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                        onClick={() => onDeletePattern?.(channel.id, idx)}
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground bg-background p-4 rounded-lg border border-dashed text-center">
+                {groupMatchingPatternCount > 0
+                  ? `Using ${groupMatchingPatternCount} pattern(s) inherited from group`
+                  : 'No patterns configured for this channel'}
+              </p>
+            )}
+          </div>
+
+          <Separator />
+
+          {/* TVG-ID matching toggle */}
+          {onUpdateMatchSettings && (
+            <div className="flex items-center justify-between">
+              <div>
+                <Label className="text-sm font-medium">TVG-ID Matching</Label>
+                <p className="text-xs text-muted-foreground">
+                  Match streams using the channel's TVG-ID
+                </p>
+              </div>
+              <Switch
+                checked={matchByTvgId}
+                onCheckedChange={(checked) =>
+                  onUpdateMatchSettings?.(channel.id, { match_by_tvg_id: checked })
+                }
+              />
+            </div>
+          )}
+
+          <Separator />
+
+          {/* Automation periods */}
           <div>
-            <div className="flex justify-between items-center mb-3">
+            <div className="flex items-center justify-between mb-3">
               <h4 className="font-medium text-sm flex items-center gap-2">
                 <Calendar className="h-4 w-4" />
                 Automation Periods
-                {isPeriodChannelOverride ? (
-                  <Badge variant="default" className="text-[10px]">Override</Badge>
-                ) : isPeriodGroupBased ? (
-                  <Badge variant="outline" className="text-[10px]">From Group</Badge>
-                ) : null}
               </h4>
-              <Button size="sm" variant="outline" onClick={() => setAssignDialogOpen(true)}>
-                <Plus className="h-4 w-4 mr-2" />
-                Assign to Period
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 text-xs"
+                onClick={() => setAssignDialogOpen(true)}
+              >
+                <Plus className="h-3 w-3 mr-1" />
+                Assign Period
               </Button>
             </div>
 
             {loadingPeriods ? (
-              <div className="flex items-center justify-center py-4">
-                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              <div className="flex items-center gap-2 text-xs text-muted-foreground p-2">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Loading periods…
               </div>
             ) : channelPeriods.length > 0 ? (
-              <div className="grid gap-2 grid-cols-1 md:grid-cols-2">
-                {channelPeriods.map((period) => (
-                  <div key={period.id} className="flex items-center justify-between p-3 bg-background border rounded-lg">
-                    <div className="min-w-0">
-                      <div className="font-medium text-sm truncate">{period.name}</div>
-                      <div className="flex items-center gap-2 mt-1">
-                        <Badge variant="secondary" className="text-[10px] font-normal">
-                          {period.profile_name || 'No Profile'}
-                        </Badge>
-                        <span className="text-[10px] text-muted-foreground">
-                          {period.schedule?.type === 'interval' ? `${period.schedule.value}m` : 'Cron'}
-                        </span>
-                      </div>
-                    </div>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => handleRemovePeriod(period.id)}
-                      className="text-destructive hover:text-destructive hover:bg-destructive/10 h-7 w-7 p-0"
+              <div className="space-y-2">
+                {channelPeriods.map((period) => {
+                  const profileName =
+                    period.profile?.name ||
+                    (period.profile_id
+                      ? profiles?.find(p => String(p.id) === String(period.profile_id))?.name
+                      : null)
+                  return (
+                    <div
+                      key={period.id}
+                      className="flex items-center justify-between gap-2 rounded-md border bg-background px-3 py-2"
                     >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))}
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xs font-medium">{period.name}</p>
+                        <p className="text-[11px] text-muted-foreground mt-0.5">
+                          {formatSchedule(period.schedule)}
+                          {profileName && <span className="ml-1">· {profileName}</span>}
+                        </p>
+                      </div>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleRemovePeriod(period.id)}
+                        className="text-destructive hover:text-destructive hover:bg-destructive/10 h-7 w-7 p-0"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  )
+                })}
               </div>
             ) : (
               <p className="text-sm text-muted-foreground bg-background p-4 rounded-lg border border-dashed text-center">
@@ -312,15 +676,14 @@ export function RegexTableRow({
               channelName={channel.name}
               onSuccess={() => {
                 loadChannelPeriods()
-                if (onRefresh) {
-                  onRefresh()
-                }
+                if (onRefresh) onRefresh()
               }}
             />
           </div>
 
           <Separator />
 
+          {/* EPG Scheduled Profile override */}
           {onAssignEpgProfile && (
             <div>
               <h4 className="font-medium text-sm flex items-center gap-2 mb-2">
@@ -334,17 +697,15 @@ export function RegexTableRow({
               </h4>
               <Select
                 value={channel.channel_epg_scheduled_profile_id || ''}
-                onValueChange={(v) => onAssignEpgProfile(channel.id, v === 'none' ? null : v)}
+                onValueChange={(v) => onAssignEpgProfile?.(channel.id, v === 'none' ? null : v)}
               >
                 <SelectTrigger className="h-8 text-xs">
                   <SelectValue placeholder="Use period profile (default)" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="none">— Use period profile (default) —</SelectItem>
-                  {profiles.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.name}
-                    </SelectItem>
+                  {profiles?.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>
@@ -353,98 +714,6 @@ export function RegexTableRow({
               </p>
             </div>
           )}
-
-          <Separator />
-
-          <div>
-            <div className="flex items-center justify-between mb-4 p-3 bg-muted rounded-md">
-              <div className="flex items-center space-x-2">
-                <Switch
-                  id={`tvg-match-${channel.id}`}
-                  checked={matchByTvgId}
-                  onCheckedChange={(checked) => onUpdateMatchSettings(channel.id, { match_by_tvg_id: checked })}
-                />
-                <Label htmlFor={`tvg-match-${channel.id}`} className="flex flex-col cursor-pointer">
-                  <span className="font-medium flex items-center gap-2">
-                    Match by TVG-ID
-                    {isTvgInherited && (
-                      <Badge variant="outline" className="text-[10px]">
-                        From Group
-                      </Badge>
-                    )}
-                  </span>
-                  <span className="font-normal text-xs text-muted-foreground">
-                    Automatically match streams with TVG-ID "{channel.tvg_id || 'N/A'}"
-                  </span>
-                </Label>
-              </div>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => onPreviewMatch(channel.id, 'tvg_only')}
-                disabled={!channel.tvg_id}
-                title={!channel.tvg_id ? 'No TVG-ID set' : 'Preview only TVG-ID matches (ignoring profile/regex)'}
-              >
-                <Eye className="h-4 w-4 mr-2" />
-                Preview Results
-              </Button>
-            </div>
-
-            <div className="flex justify-between items-center mb-3">
-              <h4 className="font-medium text-sm flex items-center gap-2">
-                Regex Patterns
-                {isRegexChannelOverride ? (
-                  <Badge variant="default" className="text-[10px]">Override</Badge>
-                ) : isRegexGroupBased ? (
-                  <Badge variant="outline" className="text-[10px]">From Group</Badge>
-                ) : null}
-              </h4>
-              <Button size="sm" variant="outline" onClick={() => onEditRegex(channel.id, null)}>
-                <Plus className="h-4 w-4 mr-2" />
-                Add Pattern
-              </Button>
-            </div>
-
-            {(() => {
-              const normalizedPatterns = normalizePatternData(channelPatterns)
-              return normalizedPatterns.length > 0 ? (
-                <div className="space-y-2">
-                  {normalizedPatterns.map((patternObj, index) => {
-                    const accountNames =
-                      patternObj.m3u_accounts && patternObj.m3u_accounts.length > 0
-                        ? patternObj.m3u_accounts
-                            .map((id) => {
-                              const account = m3uAccounts?.find((item) => item.id === id)
-                              return account ? account.name : `Account ${id}`
-                            })
-                            .join(', ')
-                        : 'All M3U Accounts'
-
-                    return (
-                      <div key={index} className="space-y-1">
-                        <div className="flex items-center justify-between gap-2 p-2 bg-background rounded-md">
-                          <div className="flex-1 space-y-1">
-                            <code className="text-sm break-all">{patternObj.pattern}</code>
-                            <div className="text-xs text-muted-foreground">M3U Sources: {accountNames}</div>
-                          </div>
-                          <div className="flex gap-1">
-                            <Button size="sm" variant="ghost" onClick={() => onEditRegex(channel.id, index)}>
-                              <Edit className="h-4 w-4" />
-                            </Button>
-                            <Button size="sm" variant="ghost" onClick={() => onDeletePattern(channel.id, index)}>
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
-                          </div>
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">No regex patterns configured</p>
-              )
-            })()}
-          </div>
         </div>
       )}
     </div>

--- a/frontend/src/pages/ChannelConfiguration.jsx
+++ b/frontend/src/pages/ChannelConfiguration.jsx
@@ -26,6 +26,7 @@ import {
   BatchPeriodEditDialog,
 } from '@/components/channel-configuration/PeriodDialogs.jsx'
 import { MatchPreviewDialog, MatchResultsList } from '@/components/channel-configuration/MatchPreviewDialog.jsx'
+import { ProfilePickerDialog } from '@/components/channel-configuration/ProfilePickerDialog.jsx'
 import {
   DndContext,
 
@@ -402,6 +403,9 @@ export default function ChannelConfiguration() {
 
   const [loading, setLoading] = useState(true)
   const [checkingChannel, setCheckingChannel] = useState(null)
+  const [profilePickerOpen, setProfilePickerOpen] = useState(false)
+  const [profilePickerData, setProfilePickerData] = useState(null)
+  // profilePickerData shape: { channelId, channelName, periods }
   const [searchQuery, setSearchQuery] = useState('')
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingChannelId, setEditingChannelId] = useState(null)
@@ -675,17 +679,94 @@ export default function ChannelConfiguration() {
     }
   }
 
-  const handleCheckChannel = async (channelId) => {
+  /**
+   * Health check pre-flight + execution.
+   *
+   * Uses automation_periods_count already on the channel object
+   * (populated by ChannelService._enrich_channels server-side) to avoid
+   * unnecessary API calls for the 0-period and 1-period cases.
+   *
+   * Decision tree:
+   *   0 periods -> toast (no profile), stop
+   *   1 period  -> proceed directly (unambiguous)
+   *   >1 periods -> fetch enriched list, deduplicate by profile_id
+   *               -> all share one profile: proceed
+   *               -> different profiles: open ProfilePickerDialog
+   *
+   * @param {number} channelId
+   * @param {string|null} resolvedProfileId - set when called back from ProfilePickerDialog
+   */
+  const handleCheckChannel = async (channelId, resolvedProfileId = null) => {
+    // Pre-flight: profile resolution
+    if (!resolvedProfileId) {
+      const channel = channels.find(ch => ch.id === channelId)
+      const periodCount = Number(channel?.automation_periods_count ?? 0)
+
+      // Case 1: No periods assigned - hard block, actionable message
+      if (periodCount === 0) {
+        toast({
+          title: 'No Automation Profile',
+          description:
+            'This channel has no automation profile assigned. ' +
+            'Assign an automation period with a profile before running a health check.',
+          variant: 'destructive',
+        })
+        return
+      }
+
+      // Case 2: Exactly one period - unambiguous, proceed immediately
+      // (falls through to the actual check below)
+
+      // Case 3: Multiple periods - check for profile ambiguity
+      if (periodCount > 1) {
+        try {
+          setCheckingChannel(channelId) // Show spinner during fetch
+          const response = await automationAPI.getChannelPeriods(channelId)
+          const periods = response.data || []
+
+          // Deduplicate by profile_id - multiple periods may share one profile
+          const uniqueProfileIds = [...new Set(
+            periods.map(p => p.profile_id).filter(Boolean)
+          )]
+
+          if (uniqueProfileIds.length <= 1) {
+            // All periods resolve to the same profile - no ambiguity, proceed
+            setCheckingChannel(null)
+            // Falls through to actual check; backend resolves active period
+          } else {
+            // Genuine ambiguity - open picker for user to select
+            setCheckingChannel(null)
+            setProfilePickerData({
+              channelId,
+              channelName: channel?.name ?? `Channel ${channelId}`,
+              periods,
+            })
+            setProfilePickerOpen(true)
+            return // Picker's onSelect calls handleCheckChannel with resolvedProfileId
+          }
+        } catch (err) {
+          setCheckingChannel(null)
+          console.error('Error fetching channel periods for health check pre-flight:', err)
+          toast({
+            title: 'Error',
+            description: 'Could not load automation periods for this channel.',
+            variant: 'destructive',
+          })
+          return
+        }
+      }
+    }
+
+    // Actual check
     try {
       setCheckingChannel(channelId)
 
-      // Show starting notification
       toast({
         title: "Channel Check Started",
         description: "Checking channel streams... This may take a few minutes.",
       })
 
-      const response = await streamCheckerAPI.checkSingleChannel(channelId)
+      const response = await streamCheckerAPI.checkSingleChannel(channelId, resolvedProfileId)
 
       if (response.data.success) {
         const stats = response.data.stats
@@ -693,8 +774,17 @@ export default function ChannelConfiguration() {
           title: "Channel Check Complete",
           description: `Checked ${stats.total_streams} streams. Dead: ${stats.dead_streams}. Avg Resolution: ${stats.avg_resolution}, Avg Bitrate: ${stats.avg_bitrate}`,
         })
-        // Reload the channel data to show updated stats
         loadData()
+      } else if (response.data.error === 'no_profile') {
+        // Backend safety-net fired (e.g. periods exist but none active at execution time)
+        toast({
+          title: 'No Active Profile',
+          description:
+            response.data.message ||
+            'This channel has no active automation profile. ' +
+            'Check that your automation period schedule is currently active.',
+          variant: 'destructive',
+        })
       } else {
         toast({
           title: "Check Failed",
@@ -704,7 +794,19 @@ export default function ChannelConfiguration() {
       }
     } catch (err) {
       console.error('Error checking channel:', err)
-      // Check if it's a timeout error
+
+      // 400 with no_profile = backend guard fired, surface it cleanly
+      if (err.response?.status === 400 && err.response?.data?.error === 'no_profile') {
+        toast({
+          title: 'No Active Profile',
+          description:
+            err.response.data.message ||
+            'This channel has no active automation profile.',
+          variant: 'destructive',
+        })
+        return
+      }
+
       if (err.code === 'ECONNABORTED' || err.message?.includes('timeout')) {
         toast({
           title: "Check Taking Longer Than Expected",
@@ -3713,6 +3815,20 @@ export default function ChannelConfiguration() {
           }}
         />
 
+        {profilePickerData && (
+          <ProfilePickerDialog
+            open={profilePickerOpen}
+            onOpenChange={(open) => {
+              setProfilePickerOpen(open)
+              if (!open) setProfilePickerData(null)
+            }}
+            channelName={profilePickerData.channelName}
+            periods={profilePickerData.periods}
+            onSelect={(profileId) =>
+              handleCheckChannel(profilePickerData.channelId, profileId)
+            }
+          />
+        )}
         <MatchPreviewDialog
           open={previewResultsOpen}
           onOpenChange={setPreviewResultsOpen}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -184,7 +184,10 @@ export const streamCheckerAPI = {
   getProgress: () => api.get('/stream-checker/progress'),
   checkChannel: (channelId) => api.post('/stream-checker/check-channel', { channel_id: channelId }),
   // Use longer timeout for single channel check as it can take time
-  checkSingleChannel: (channelId) => api.post('/stream-checker/check-single-channel', { channel_id: channelId }, { timeout: 120000 }),
+  checkSingleChannel: (channelId, profileId = null) => api.post('/stream-checker/check-single-channel', {
+    channel_id: channelId,
+    ...(profileId ? { profile_id: profileId } : {}),
+  }, { timeout: 120000 }),
   markUpdated: (data) => api.post('/stream-checker/mark-updated', data),
   queueAllChannels: () => api.post('/stream-checker/queue-all'),
   triggerGlobalAction: () => api.post('/stream-checker/global-action'),


### PR DESCRIPTION
Enforces the automation opt-in model when a user manually triggers a health check on a single channel from the Channel Configuration page.

Previously, clicking Health Check on a channel with no automation profile assigned would silently run using system-wide global defaults, ignoring per-channel configuration entirely. This produced checks with wrong scoring weights, matching flags, stream limits, and loop detection settings.

The check now behaves according to how many automation periods the channel has assigned. With no periods, the check is blocked immediately with a clear error directing the user to assign an automation period — no API call is made. With one period, the check proceeds immediately with no added friction. With multiple periods sharing the same profile, the check also proceeds silently. With multiple periods across different profiles, a picker dialog appears asking the user to choose which profile should govern this specific check — the selection is one-time and not persisted.

The selected profile is honoured end-to-end: matching flags, checking flags, scoring weights, stream limits, M3U priority, loop detection, dead stream handling, and revive settings all reflect the chosen profile rather than whichever period happens to be schedule-active at execution time.

The backend also enforces this independently as a safety net, returning a structured error if no profile resolves at execution time rather than falling through to global automation controls.