### PR TITLE
Tooltip enrichment for Channel Configuration regex table

### DIFF
--- a/backend/apps/api/active_profile_handlers.py
+++ b/backend/apps/api/active_profile_handlers.py
@@ -1,0 +1,83 @@
+"""
+Handler: GET /api/channels/<channel_id>/active-profile
+
+Returns the currently resolved automation profile and EPG scheduled profile
+for a single channel, using the same resolution logic the stream checker uses.
+
+Response shape:
+{
+  "automation": {
+    "profile_name": "HD Sports" | null,
+    "period_name":  "Every 2h"  | null,
+    "source":       "channel" | "group" | null
+  },
+  "epg_override": {
+    "profile_name": "EPG Triggered" | null,
+    "source":       "channel" | "group" | null
+  }
+}
+"""
+
+from typing import Any, Callable
+
+from flask import jsonify
+
+from apps.core.logging_config import setup_logging
+
+logger = setup_logging(__name__)
+
+
+def get_channel_active_profile_response(
+    *,
+    channel_id: int,
+    get_automation_config_manager: Callable[[], Any],
+    get_udi_manager: Callable[[], Any],
+):
+    """Resolve and return the active automation + EPG profile for a channel."""
+    try:
+        udi = get_udi_manager()
+        channel = udi.get_channel_by_id(channel_id)
+        group_id = None
+        if channel:
+            group_id = (
+                channel.get("group_id")
+                if channel.get("group_id") is not None
+                else channel.get("channel_group_id")
+            )
+
+        automation_config = get_automation_config_manager()
+
+        # --- Automation profile (period-based resolution) ---
+        # Mirrors check_single_channel Step 2: get_effective_configuration
+        automation_result = {"profile_name": None, "period_name": None, "source": None}
+        config = automation_config.get_effective_configuration(channel_id, group_id)
+        if config:
+            profile = config.get("profile")
+            automation_result["profile_name"] = profile.get("name") if profile else None
+            automation_result["period_name"] = config.get("period_name")
+
+            # Source: channel-level assignment beats group-level
+            channel_periods = automation_config.get_channel_periods(channel_id)
+            active_period_id = config.get("period_id")
+            if active_period_id and str(active_period_id) in channel_periods:
+                automation_result["source"] = "channel"
+            else:
+                automation_result["source"] = "group"
+
+        # --- EPG scheduled profile override ---
+        # Mirrors check_single_channel Step 1: get_effective_epg_scheduled_profile
+        epg_result = {"profile_name": None, "source": None}
+        epg_profile = automation_config.get_effective_epg_scheduled_profile(channel_id, group_id)
+        if epg_profile:
+            epg_result["profile_name"] = epg_profile.get("name")
+            channel_epg_id = automation_config.get_channel_epg_scheduled_assignment(channel_id)
+            epg_result["source"] = "channel" if channel_epg_id else "group"
+
+        return jsonify({
+            "automation": automation_result,
+            "epg_override": epg_result,
+        }), 200
+
+    except Exception as exc:
+        logger.error(f"Error resolving active profile for channel {channel_id}: {exc}")
+        return jsonify({"error": "Internal Server Error"}), 500

--- a/backend/apps/api/web_api.py
+++ b/backend/apps/api/web_api.py
@@ -48,6 +48,9 @@ from apps.api.channel_handlers import (
     get_channel_stats_response,
     get_channels_response,
 )
+# ── NEW: active profile resolution handler ──────────────────────────────────
+from apps.api.active_profile_handlers import get_channel_active_profile_response
+# ────────────────────────────────────────────────────────────────────────────
 from apps.api.regex_handlers import (
     add_bulk_regex_patterns_response,
     add_regex_pattern_response,
@@ -985,7 +988,23 @@ def get_m3u_accounts_endpoint():
     )
 
 
+@app.route('/api/m3u-accounts/<int:account_id>/priority', methods=['PATCH'])
+def update_m3u_account_priority(account_id):
+    """Update the priority of a specific M3U account."""
+    from apps.api.quick_action_handlers import update_m3u_account_priority_response
+    return update_m3u_account_priority_response(
+        account_id=account_id,
+        payload=request.get_json(silent=True),
+    )
 
+
+@app.route('/api/m3u-priority/global-mode', methods=['PUT'])
+def update_global_priority_mode():
+    """Update the global M3U priority mode."""
+    from apps.api.quick_action_handlers import update_global_priority_mode_response
+    return update_global_priority_mode_response(
+        payload=request.get_json(silent=True),
+    )
 
 
 @app.route('/api/setup-wizard', methods=['GET'])
@@ -1210,14 +1229,7 @@ def get_scheduling_config():
 @app.route('/api/scheduling/config', methods=['PUT'])
 @log_function_call
 def update_scheduling_config():
-    """Update scheduling configuration.
-    
-    Expected JSON body:
-    {
-        "epg_refresh_interval_minutes": 60,
-        "enabled": true
-    }
-    """
+    """Update scheduling configuration."""
     return update_scheduling_config_response(
         payload=request.get_json(silent=True),
         get_scheduling_service=get_scheduling_service,
@@ -1226,11 +1238,7 @@ def update_scheduling_config():
 @app.route('/api/scheduling/epg/grid', methods=['GET'])
 @log_function_call
 def get_epg_grid():
-    """Get EPG grid data (all programs for next 24 hours).
-    
-    Query parameters:
-    - force_refresh: If true, bypass cache and fetch fresh data
-    """
+    """Get EPG grid data (all programs for next 24 hours)."""
     return get_epg_grid_response(
         force_refresh=request.args.get('force_refresh', 'false').lower() == 'true',
         get_scheduling_service=get_scheduling_service,
@@ -1239,14 +1247,7 @@ def get_epg_grid():
 @app.route('/api/scheduling/epg/channel/<int:channel_id>', methods=['GET'])
 @log_function_call
 def get_channel_programs(channel_id):
-    """Get programs for a specific channel.
-    
-    Args:
-        channel_id: Channel ID
-    
-    Returns:
-        List of programs for the channel
-    """
+    """Get programs for a specific channel."""
     return get_channel_programs_response(
         channel_id=channel_id,
         get_scheduling_service=get_scheduling_service,
@@ -1261,17 +1262,7 @@ def get_scheduled_events():
 @app.route('/api/scheduling/events', methods=['POST'])
 @log_function_call
 def create_scheduled_event():
-    """Create a new scheduled event.
-    
-    Expected JSON body:
-    {
-        "channel_id": 123,
-        "program_start_time": "2024-01-01T10:00:00Z",
-        "program_end_time": "2024-01-01T11:00:00Z",
-        "program_title": "Program Name",
-        "minutes_before": 5
-    }
-    """
+    """Create a new scheduled event."""
     return create_scheduled_event_response(
         payload=request.get_json(silent=True),
         get_scheduling_service=get_scheduling_service,
@@ -1281,11 +1272,7 @@ def create_scheduled_event():
 @app.route('/api/scheduling/events/<event_id>', methods=['DELETE'])
 @log_function_call
 def delete_scheduled_event(event_id):
-    """Delete a scheduled event.
-    
-    Args:
-        event_id: Event ID
-    """
+    """Delete a scheduled event."""
     return delete_scheduled_event_response(
         event_id=event_id,
         get_scheduling_service=get_scheduling_service,
@@ -1302,18 +1289,7 @@ def get_auto_create_rules():
 @app.route('/api/scheduling/auto-create-rules', methods=['POST'])
 @log_function_call
 def create_auto_create_rule():
-    """Create a new auto-create rule.
-    
-    Expected JSON body:
-    {
-        "name": "Rule Name",
-        "channel_ids": [123, 456],  // or "channel_id": 123 for backward compatibility
-        "regex_pattern": "^Breaking News",
-        "minutes_before": 5,
-        "enable_looping_detection": true,
-        "enable_logo_detection": true
-    }
-    """
+    """Create a new auto-create rule."""
     return create_auto_create_rule_response(
         payload=request.get_json(silent=True),
         get_scheduling_service=get_scheduling_service,
@@ -1324,11 +1300,7 @@ def create_auto_create_rule():
 @app.route('/api/scheduling/auto-create-rules/<rule_id>', methods=['DELETE'])
 @log_function_call
 def delete_auto_create_rule(rule_id):
-    """Delete an auto-create rule.
-    
-    Args:
-        rule_id: Rule ID
-    """
+    """Delete an auto-create rule."""
     return delete_auto_create_rule_response(
         rule_id=rule_id,
         get_scheduling_service=get_scheduling_service,
@@ -1338,21 +1310,7 @@ def delete_auto_create_rule(rule_id):
 @app.route('/api/scheduling/auto-create-rules/<rule_id>', methods=['PUT', 'PATCH'])
 @log_function_call
 def update_auto_create_rule(rule_id):
-    """Update an auto-create rule.
-    
-    Args:
-        rule_id: Rule ID
-        
-    Expected JSON body (all fields optional):
-    {
-        "name": "Updated Rule Name",
-        "channel_id": 123,
-        "regex_pattern": "^Updated Pattern",
-        "minutes_before": 10,
-        "enable_looping_detection": false,
-        "enable_logo_detection": false
-    }
-    """
+    """Update an auto-create rule."""
     return update_auto_create_rule_response(
         rule_id=rule_id,
         payload=request.get_json(silent=True),
@@ -1364,14 +1322,7 @@ def update_auto_create_rule(rule_id):
 @app.route('/api/scheduling/auto-create-rules/test', methods=['POST'])
 @log_function_call
 def test_auto_create_rule():
-    """Test a regex pattern against EPG programs for a channel.
-    
-    Expected JSON body:
-    {
-        "channel_id": 123,
-        "regex_pattern": "^Breaking News"
-    }
-    """
+    """Test a regex pattern against EPG programs for a channel."""
     return test_auto_create_rule_response(
         payload=request.get_json(silent=True),
         get_scheduling_service=get_scheduling_service,
@@ -1381,33 +1332,14 @@ def test_auto_create_rule():
 @app.route('/api/scheduling/auto-create-rules/export', methods=['GET'])
 @log_function_call
 def export_auto_create_rules():
-    """Export all auto-create rules as JSON.
-    
-    Returns:
-        JSON array of auto-create rules
-    """
+    """Export all auto-create rules as JSON."""
     return export_auto_create_rules_response(get_scheduling_service=get_scheduling_service)
 
 
 @app.route('/api/scheduling/auto-create-rules/import', methods=['POST'])
 @log_function_call
 def import_auto_create_rules():
-    """Import auto-create rules from JSON.
-    
-    Expected JSON body:
-    [
-        {
-            "name": "Rule Name",
-            "channel_ids": [123, 456],
-            "regex_pattern": "^Breaking News",
-            "minutes_before": 5
-        },
-        ...
-    ]
-    
-    Returns:
-        JSON with import results
-    """
+    """Import auto-create rules from JSON."""
     return import_auto_create_rules_response(
         payload=request.get_json(silent=True),
         get_scheduling_service=get_scheduling_service,
@@ -1418,14 +1350,7 @@ def import_auto_create_rules():
 @app.route('/api/scheduling/process-due-events', methods=['POST'])
 @log_function_call
 def process_due_scheduled_events():
-    """Process all scheduled events that are due for execution.
-    
-    This endpoint should be called periodically (e.g., by a cron job or scheduler)
-    to check for and execute any scheduled channel checks.
-    
-    Returns:
-        JSON with execution results
-    """
+    """Process all scheduled events that are due for execution."""
     return process_due_scheduled_events_response(
         get_scheduling_service=get_scheduling_service,
         get_stream_checker_service=get_stream_checker_service,
@@ -1435,11 +1360,7 @@ def process_due_scheduled_events():
 @app.route('/api/scheduling/processor/status', methods=['GET'])
 @log_function_call
 def get_scheduled_event_processor_status():
-    """Get the status of the scheduled event processor background thread.
-    
-    Returns:
-        JSON with processor status
-    """
+    """Get the status of the scheduled event processor background thread."""
     return get_scheduled_event_processor_status_response(
         scheduled_event_processor_thread=scheduled_event_processor_thread,
         scheduled_event_processor_running=scheduled_event_processor_running,
@@ -1449,11 +1370,7 @@ def get_scheduled_event_processor_status():
 @app.route('/api/scheduling/processor/start', methods=['POST'])
 @log_function_call
 def start_scheduled_event_processor_api():
-    """Start the scheduled event processor background thread.
-    
-    Returns:
-        JSON with result
-    """
+    """Start the scheduled event processor background thread."""
     return start_scheduled_event_processor_api_response(
         start_scheduled_event_processor=start_scheduled_event_processor,
     )
@@ -1462,11 +1379,7 @@ def start_scheduled_event_processor_api():
 @app.route('/api/scheduling/processor/stop', methods=['POST'])
 @log_function_call
 def stop_scheduled_event_processor_api():
-    """Stop the scheduled event processor background thread.
-    
-    Returns:
-        JSON with result
-    """
+    """Stop the scheduled event processor background thread."""
     return stop_scheduled_event_processor_api_response(
         stop_scheduled_event_processor=stop_scheduled_event_processor,
     )
@@ -1475,11 +1388,7 @@ def stop_scheduled_event_processor_api():
 @app.route('/api/scheduling/epg-refresh/status', methods=['GET'])
 @log_function_call
 def get_epg_refresh_processor_status():
-    """Get the status of the EPG refresh processor background thread.
-    
-    Returns:
-        JSON with processor status
-    """
+    """Get the status of the EPG refresh processor background thread."""
     return get_epg_refresh_processor_status_response(
         epg_refresh_thread=epg_refresh_thread,
         epg_refresh_running=epg_refresh_running,
@@ -1489,11 +1398,7 @@ def get_epg_refresh_processor_status():
 @app.route('/api/scheduling/epg-refresh/start', methods=['POST'])
 @log_function_call
 def start_epg_refresh_processor_api():
-    """Start the EPG refresh processor background thread.
-    
-    Returns:
-        JSON with result
-    """
+    """Start the EPG refresh processor background thread."""
     return start_epg_refresh_processor_api_response(
         start_epg_refresh_processor=start_epg_refresh_processor,
     )
@@ -1502,11 +1407,7 @@ def start_epg_refresh_processor_api():
 @app.route('/api/scheduling/epg-refresh/stop', methods=['POST'])
 @log_function_call
 def stop_epg_refresh_processor_api():
-    """Stop the EPG refresh processor background thread.
-    
-    Returns:
-        JSON with result
-    """
+    """Stop the EPG refresh processor background thread."""
     return stop_epg_refresh_processor_api_response(
         stop_epg_refresh_processor=stop_epg_refresh_processor,
     )
@@ -1515,11 +1416,7 @@ def stop_epg_refresh_processor_api():
 @app.route('/api/scheduling/epg-refresh/trigger', methods=['POST'])
 @log_function_call
 def trigger_epg_refresh():
-    """Manually trigger an immediate EPG refresh.
-    
-    Returns:
-        JSON with result
-    """
+    """Manually trigger an immediate EPG refresh."""
     return trigger_epg_refresh_response(
         epg_refresh_wake=epg_refresh_wake,
         epg_refresh_running=epg_refresh_running,
@@ -1531,11 +1428,7 @@ def trigger_epg_refresh():
 @app.route('/api/automation/status', methods=['GET'])
 @log_function_call
 def get_automation_status():
-    """Get the status of the automation background service.
-    
-    Returns:
-        JSON with service status
-    """
+    """Get the status of the automation background service."""
     return get_automation_status_response(
         get_automation_manager=get_automation_manager,
         get_automation_config_manager=get_automation_config_manager,
@@ -1545,22 +1438,14 @@ def get_automation_status():
 @app.route('/api/automation/start', methods=['POST'])
 @log_function_call
 def start_automation_service_api():
-    """Start the automation background service.
-    
-    Returns:
-        JSON with result
-    """
+    """Start the automation background service."""
     return start_automation_service_api_response(get_automation_manager=get_automation_manager)
 
 
 @app.route('/api/automation/stop', methods=['POST'])
 @log_function_call
 def stop_automation_service_api():
-    """Stop the automation background service.
-    
-    Returns:
-        JSON with result
-    """
+    """Stop the automation background service."""
     return stop_automation_service_api_response(get_automation_manager=get_automation_manager)
 
 
@@ -1590,13 +1475,7 @@ def handle_automation_global_config():
 @app.route('/api/automation/profiles', methods=['GET', 'POST'])
 @log_function_call
 def handle_automation_profiles():
-    """Get all profiles or create a new profile.
-
-    GET supports optional query parameters:
-      - search (str): filter profiles by name (case-insensitive).
-      - page (int): page number (1-based). If omitted, returns full list.
-      - per_page (int): items per page (default 50, max 200).
-    """
+    """Get all profiles or create a new profile."""
     return handle_automation_profiles_response(
         method=request.method,
         args=request.args,
@@ -1726,18 +1605,7 @@ def remove_period_from_groups(period_id):
 @app.route('/api/channels/groups/batch/assign-periods', methods=['POST'])
 @log_function_call
 def batch_assign_periods_to_groups():
-    """Batch assign automation periods to multiple groups with profiles.
-
-    Expects format:
-    {
-        "group_ids": [1, 2, 3],
-        "period_assignments": [
-            {"period_id": "period1", "profile_id": "profile1"},
-            {"period_id": "period2", "profile_id": "profile2"}
-        ],
-        "replace": false
-    }
-    """
+    """Batch assign automation periods to multiple groups with profiles."""
     return batch_assign_periods_to_groups_response(
         payload=request.get_json(silent=True),
         get_automation_config_manager=get_automation_config_manager,
@@ -1745,18 +1613,11 @@ def batch_assign_periods_to_groups():
 
 
 # ==================== Automation Periods API ====================
-# Manage automation periods - multiple scheduled automation configurations per channel
 
 @app.route('/api/automation/periods', methods=['GET', 'POST'])
 @log_function_call
 def handle_automation_periods():
-    """Get all automation periods or create a new period.
-
-    GET supports optional query parameters:
-      - search (str): filter periods by name (case-insensitive).
-      - page (int): page number (1-based). If omitted, returns full list.
-      - per_page (int): items per page (default 50, max 200).
-    """
+    """Get all automation periods or create a new period."""
     return handle_automation_periods_response(
         method=request.method,
         args=request.args,
@@ -1833,22 +1694,27 @@ def get_channel_automation_periods(channel_id):
         get_udi_manager=get_udi_manager,
     )
 
+# ── NEW: active profile resolution endpoint ─────────────────────────────────
+@app.route('/api/channels/<int:channel_id>/active-profile', methods=['GET'])
+@log_function_call
+def get_channel_active_profile(channel_id):
+    """Return the resolved active automation profile and EPG override for a channel.
+
+    Uses the same resolution hierarchy as check_single_channel:
+      1. EPG scheduled profile (channel-level then group-level)
+      2. Active period-based profile (channel-level overrides group-level)
+    """
+    return get_channel_active_profile_response(
+        channel_id=channel_id,
+        get_automation_config_manager=get_automation_config_manager,
+        get_udi_manager=get_udi_manager,
+    )
+# ────────────────────────────────────────────────────────────────────────────
 
 @app.route('/api/channels/batch/assign-periods', methods=['POST'])
 @log_function_call
 def batch_assign_periods_to_channels():
-    """Batch assign automation periods to multiple channels with profiles.
-    
-    Expects format:
-    {
-        "channel_ids": [1, 2, 3],
-        "period_assignments": [
-            {"period_id": "period1", "profile_id": "profile1"},
-            {"period_id": "period2", "profile_id": "profile2"}
-        ],
-        "replace": false
-    }
-    """
+    """Batch assign automation periods to multiple channels with profiles."""
     return batch_assign_periods_to_channels_response(
         payload=request.get_json(silent=True),
         get_automation_config_manager=get_automation_config_manager,
@@ -1856,20 +1722,11 @@ def batch_assign_periods_to_channels():
 
 
 # ==================== Automation Events API ====================
-# Calculate and retrieve upcoming automation events based on periods
-
 
 @app.route('/api/automation/events/upcoming', methods=['GET'])
 @log_function_call
 def get_upcoming_automation_events():
-    """Get upcoming automation events based on configured periods.
-    
-    Query parameters:
-    - hours: Number of hours ahead to calculate (default: 24, max: 168)
-    - max_events: Maximum number of events to return (default: 100, max: 500)
-    - period_id: Filter by specific period ID
-    - force_refresh: Force cache refresh (true/false)
-    """
+    """Get upcoming automation events based on configured periods."""
     return get_upcoming_automation_events_response(
         args=request.args,
         get_events_scheduler=get_events_scheduler,
@@ -1880,18 +1737,13 @@ def get_upcoming_automation_events():
 @app.route('/api/automation/events/invalidate-cache', methods=['POST'])
 @log_function_call
 def invalidate_automation_events_cache():
-    """Invalidate the automation events cache.
-    
-    This should be called whenever automation periods are modified.
-    """
+    """Invalidate the automation events cache."""
     return invalidate_automation_events_cache_response(
         get_events_scheduler=get_events_scheduler,
     )
 
 
 # ==================== Stream Monitoring Session API ====================
-# Advanced stream monitoring with live quality tracking, reliability scoring,
-# and screenshot capture for event-based stream management
 
 from apps.stream.stream_session_manager import get_session_manager, REVIEW_DURATION
 from apps.stream.stream_monitoring_service import get_monitoring_service
@@ -1935,11 +1787,7 @@ def _acestream_client_or_error():
 
 
 def _ping_orchestrator_ready(client=None):
-    """Ping the orchestrator /api/v1/version endpoint to verify it is running and reachable.
-
-    Returns (True, version_str) on success, (False, error_msg) on failure.
-    The response must be a JSON object with a 'title' field containing 'AceStream Orchestrator'.
-    """
+    """Ping the orchestrator /api/v1/version endpoint to verify it is running and reachable."""
     if client is None:
         client = _get_acestream_monitoring_client()
     if not client.is_configured():
@@ -1965,7 +1813,6 @@ def _ping_orchestrator_ready(client=None):
     except requests.exceptions.HTTPError as exc:
         return False, f"Orchestrator /api/v1/version returned HTTP {exc.response.status_code}"
     except Exception as exc:
-        # Log full exception details server-side, but return a generic message to the client
         logger.error("Unexpected error while pinging AceStream orchestrator", exc_info=True)
         return False, "Unexpected error while pinging orchestrator"
 
@@ -1996,7 +1843,6 @@ def _parse_m3u_acestream_entries(m3u_content: str):
             })
             pending_name = None
 
-    # Deduplicate by content_id keeping first non-empty name.
     merged = {}
     for item in items:
         key = item['content_id']
@@ -2419,7 +2265,6 @@ def get_stream_metrics(session_id, stream_id):
     )
 
 
-# Serve screenshots
 @app.route('/api/data/screenshots/<filename>')
 def serve_screenshot(filename):
     """Serve screenshot files."""
@@ -2436,9 +2281,6 @@ def get_alive_screenshots(session_id):
         session_id=session_id,
         get_session_manager=get_session_manager,
     )
-
-
-
 
 
 @app.route('/api/proxy/status', methods=['GET'])
@@ -2466,8 +2308,6 @@ def get_stream_viewer_url(stream_id):
     )
 
 
-
-
 @app.route('/api/stream/proxy/<int:stream_id>', methods=['GET'])
 def stream_proxy_url(stream_id):
     """Proxy the local UDP stream from FFmpeg out via HTTP using a shared listener."""
@@ -2484,10 +2324,6 @@ def create_session_from_event(event_id):
         event_id=event_id,
         get_scheduling_service=get_scheduling_service,
     )
-
-
-
-# Serve React app for all frontend routes (catch-all - must be last!)
 
 
 # ==================== Settings API ====================
@@ -2507,6 +2343,7 @@ def handle_session_settings():
 def serve_frontend(path):
     """Serve React frontend files or return index.html for client-side routing."""
     return serve_frontend_response(static_folder=static_folder, path=path)
+
 # --- Telemetry API ---
 from apps.telemetry.telemetry_api import telemetry_bp
 app.register_blueprint(telemetry_bp, url_prefix='/api/telemetry')
@@ -2533,21 +2370,16 @@ if __name__ == '__main__':
         logger.error(f"Failed to initialize database schema: {e}", exc_info=True)
         raise
     
-    # Only start background services in the reloader process (or if not using reloader)
-    # WERKZEUG_RUN_MAIN is set to 'true' in the child process spawned by the reloader
     if not args.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         logger.info("Starting background services (active process)...")
         
-        # Auto-start stream checker service if enabled and automation is configured AND wizard is complete
         try:
-            # Check if wizard has been completed
             if not check_wizard_complete():
                 logger.info("Stream checker service will not start - setup wizard has not been completed")
             else:
                 service = get_stream_checker_service()
                 automation_controls = service.config.get('automation_controls', {})
                 
-                # Check if any automation is enabled
                 any_automation_enabled = (
                     automation_controls.get('auto_m3u_updates', True) or
                     automation_controls.get('auto_stream_matching', True) or
@@ -2565,7 +2397,6 @@ if __name__ == '__main__':
         except Exception as e:
             logger.error(f"Failed to auto-start stream checker service: {e}")
             
-        # Register signal handlers for graceful shutdown (SIGTERM/SIGINT)
         try:
             import signal
             import sys
@@ -2606,9 +2437,7 @@ if __name__ == '__main__':
         except Exception as e:
             logger.error(f"Failed to register signal handlers: {e}")
         
-        # Auto-start automation service if automation is configured AND wizard is complete
         try:
-            # Check if wizard has been completed
             if not check_wizard_complete():
                 logger.info("Automation service will not start - setup wizard has not been completed")
             else:
@@ -2616,7 +2445,6 @@ if __name__ == '__main__':
                 service = get_stream_checker_service()
                 automation_controls = service.config.get('automation_controls', {})
                 
-                # Check the master switch for regular automation
                 from apps.automation.automation_config_manager import get_automation_config_manager
                 automation_config = get_automation_config_manager()
                 global_settings = automation_config.get_global_settings()
@@ -2625,13 +2453,11 @@ if __name__ == '__main__':
                 if not regular_automation_enabled:
                     logger.info("Automation service is disabled (regular_automation_enabled is False)")
                 else:
-                    # Auto-start automation
                     manager.start_automation()
                     logger.info(f"Automation service auto-started")
         except Exception as e:
             logger.error(f"Failed to auto-start automation service: {e}")
         
-        # Auto-start scheduled event processor if wizard is complete
         try:
             if not check_wizard_complete():
                 logger.info("Scheduled event processor will not start - setup wizard has not been completed")
@@ -2641,7 +2467,6 @@ if __name__ == '__main__':
         except Exception as e:
             logger.error(f"Failed to auto-start scheduled event processor: {e}")
         
-        # Auto-start EPG refresh processor if wizard is complete
         try:
             if not check_wizard_complete():
                 logger.info("EPG refresh processor will not start - setup wizard has not been completed")
@@ -2651,7 +2476,6 @@ if __name__ == '__main__':
         except Exception as e:
             logger.error(f"Failed to auto-start EPG refresh processor: {e}")
         
-        # Auto-start stream monitoring service (always starts, independent of wizard)
         try:
             monitoring_service = get_monitoring_service()
             monitoring_service.start()
@@ -2659,10 +2483,6 @@ if __name__ == '__main__':
         except Exception as e:
             logger.error(f"Failed to auto-start stream monitoring service: {e}")
             
-        # Force a full UDI Refresh on startup in the background if wizard is complete.
-        # Polls Dispatcharr readiness before attempting the refresh so that a
-        # simultaneous Docker stack startup does not silently fail while Dispatcharr
-        # is still booting.
         try:
             if check_wizard_complete():
                 def startup_udi_refresh():
@@ -2671,7 +2491,7 @@ if __name__ == '__main__':
                     from apps.udi.fetcher import UDIFetcher
 
                     POLL_INTERVAL_SECONDS = 10
-                    MAX_WAIT_SECONDS = 300  # 5-minute ceiling
+                    MAX_WAIT_SECONDS = 300
 
                     fetcher = UDIFetcher()
                     elapsed = 0

--- a/frontend/src/components/channel-configuration/RegexTableRow.jsx
+++ b/frontend/src/components/channel-configuration/RegexTableRow.jsx
@@ -10,7 +10,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useToast } from '@/hooks/use-toast.js'
 import { channelsAPI, automationAPI } from '@/services/api.js'
 import { getCachedChannelLogoUrl, setCachedChannelLogoUrl } from '@/services/channelCache.js'
-import { Plus, Trash2, Loader2, Eye, ChevronDown, Activity, Calendar, CalendarClock, Edit } from 'lucide-react'
+import { Plus, Trash2, Loader2, Eye, ChevronDown, Activity, Calendar, CalendarClock, Edit, Zap } from 'lucide-react'
 import {
   REGEX_TABLE_GRID_COLS,
   normalizePatternData,
@@ -33,82 +33,140 @@ function formatSchedule(schedule) {
 
 // ---------------------------------------------------------------------------
 // Tooltip: Channel Group column
-// Shows resolved automation profile source + EPG override source
+//
+// Lazy-fetches /api/channels/<id>/active-profile on first hover to resolve
+// the *currently active* automation profile and EPG override — the same
+// resolution the stream checker uses. Falls back to static badge text
+// before the fetch completes.
 // ---------------------------------------------------------------------------
-function ChannelGroupTooltip({ children, channel, group, groupsConfig, profiles }) {
+function ChannelGroupTooltip({ children, channel, group, groupsConfig }) {
+  const [open, setOpen] = useState(false)
+  const [activeProfile, setActiveProfile] = useState(null)  // null = not yet fetched
+  const [loading, setLoading] = useState(false)
+  const fetchedRef = useRef(false)
+
+  const handleOpenChange = useCallback(
+    async (nextOpen) => {
+      setOpen(nextOpen)
+      if (!nextOpen || fetchedRef.current) return
+      fetchedRef.current = true
+      setLoading(true)
+      try {
+        const res = await channelsAPI.getChannelActiveProfile(channel.id)
+        setActiveProfile(res.data)
+      } catch {
+        setActiveProfile({ error: true })
+      } finally {
+        setLoading(false)
+      }
+    },
+    [channel.id]
+  )
+
   const channelGroupId = channel?.group_id ?? channel?.channel_group_id
 
-  // --- Automation profile resolution ---
+  // Static fallback values (always available without fetch)
   const isPeriodChannelOverride =
-    channel?.automation_periods_source === 'channel' ||
-    Number(channel?.channel_periods_count || 0) > 0
+    channel?.automation_periods_source === 'channel' || Number(channel?.channel_periods_count || 0) > 0
   const isPeriodGroupBased =
     channel?.automation_periods_source === 'group' ||
     (!isPeriodChannelOverride && Number(channel?.group_periods_count || 0) > 0)
-
-  // --- EPG profile resolution ---
   const isEpgChannelOverride = Boolean(channel?.channel_epg_scheduled_profile_id)
-  const groupEpgProfileId = groupsConfig?.[channelGroupId]?.epg_profile_id
-  const isEpgGroupBased = !isEpgChannelOverride && Boolean(groupEpgProfileId)
+  const isEpgGroupBased = !isEpgChannelOverride && Boolean(groupsConfig?.[channelGroupId]?.epg_profile_id)
 
-  // Resolve EPG profile name
-  const epgProfileId = channel?.channel_epg_scheduled_profile_id || groupEpgProfileId
-  const epgProfile = epgProfileId ? profiles?.find(p => String(p.id) === String(epgProfileId)) : null
-
-  // Automation source label
-  let automationSource = 'None'
-  if (isPeriodChannelOverride) automationSource = 'Channel override'
-  else if (isPeriodGroupBased) automationSource = 'Inherited from group'
-
-  // EPG source label
-  let epgSource = 'None'
-  if (isEpgChannelOverride) epgSource = 'Channel override'
-  else if (isEpgGroupBased) epgSource = 'Inherited from group'
+  const automation = activeProfile?.automation
+  const epgOverride = activeProfile?.epg_override
 
   return (
-    <Tooltip>
+    <Tooltip open={open} onOpenChange={handleOpenChange}>
       <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipContent className="max-w-[260px] space-y-2 p-3">
-        {/* Group name */}
+      <TooltipContent className="max-w-[280px] p-3 space-y-2">
+
         <p className="font-semibold text-sm">{group?.name || 'Ungrouped'}</p>
 
         <Separator className="my-1" />
 
-        {/* Automation profile */}
+        {loading && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground py-1">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Resolving active profile…
+          </div>
+        )}
+
+        {/* Active Automation Profile */}
         <div className="space-y-0.5">
-          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-            Automation
+          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground flex items-center gap-1">
+            <Zap className="h-3 w-3" />
+            Active Automation Profile
           </p>
-          <p className="text-xs">{automationSource}</p>
+          {!loading && automation?.profile_name ? (
+            <div className="rounded-md bg-muted/50 px-2 py-1.5">
+              <p className="text-xs font-medium">{automation.profile_name}</p>
+              {automation.period_name && (
+                <p className="text-[11px] text-muted-foreground mt-0.5">
+                  via period: {automation.period_name}
+                </p>
+              )}
+              {automation.source && (
+                <Badge
+                  variant={automation.source === 'channel' ? 'default' : 'outline'}
+                  className="text-[10px] h-4 px-1 mt-1"
+                >
+                  {automation.source === 'channel' ? 'Channel override' : 'From group'}
+                </Badge>
+              )}
+            </div>
+          ) : !loading ? (
+            <p className="text-xs text-muted-foreground italic">
+              {activeProfile?.error
+                ? 'Could not resolve'
+                : isPeriodChannelOverride || isPeriodGroupBased
+                  ? 'Periods assigned — none active right now'
+                  : 'No automation configured'}
+            </p>
+          ) : null}
         </div>
 
-        {/* EPG profile */}
+        {/* EPG Override Profile */}
         <div className="space-y-0.5">
-          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-            EPG Profile
+          <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground flex items-center gap-1">
+            <CalendarClock className="h-3 w-3" />
+            EPG Override Profile
           </p>
-          {epgProfile ? (
-            <p className="text-xs flex items-center gap-1">
-              <CalendarClock className="h-3 w-3 shrink-0" />
-              <span>{epgProfile.name}</span>
-              <span className="text-muted-foreground">({epgSource})</span>
+          {!loading && epgOverride?.profile_name ? (
+            <div className="rounded-md bg-muted/50 px-2 py-1.5">
+              <p className="text-xs font-medium">{epgOverride.profile_name}</p>
+              {epgOverride.source && (
+                <Badge
+                  variant={epgOverride.source === 'channel' ? 'default' : 'outline'}
+                  className="text-[10px] h-4 px-1 mt-1"
+                >
+                  {epgOverride.source === 'channel' ? 'Channel override' : 'From group'}
+                </Badge>
+              )}
+            </div>
+          ) : !loading ? (
+            <p className="text-xs text-muted-foreground italic">
+              {activeProfile?.error
+                ? 'Could not resolve'
+                : isEpgChannelOverride || isEpgGroupBased
+                  ? 'Assigned (fetching…)'
+                  : 'None'}
             </p>
-          ) : (
-            <p className="text-xs text-muted-foreground">{epgSource}</p>
-          )}
+          ) : null}
         </div>
+
       </TooltipContent>
     </Tooltip>
   )
 }
 
 // ---------------------------------------------------------------------------
-// Tooltip: Nº of Periods column
-// Lazy-loads period details on first hover; caches result in a ref.
+// Tooltip: Nº of Periods column — lazy fetch on first hover
 // ---------------------------------------------------------------------------
 function PeriodsTooltip({ children, channel, profiles }) {
   const [open, setOpen] = useState(false)
-  const [periods, setPeriods] = useState(null)   // null = not yet fetched
+  const [periods, setPeriods] = useState(null)
   const [loading, setLoading] = useState(false)
   const fetchedRef = useRef(false)
 
@@ -156,20 +214,16 @@ function PeriodsTooltip({ children, channel, profiles }) {
             {periods.map((period) => {
               const profileName =
                 period.profile?.name ||
+                period.profile_name ||
                 (period.profile_id
                   ? profiles?.find(p => String(p.id) === String(period.profile_id))?.name
                   : null)
               return (
-                <div
-                  key={period.id}
-                  className="rounded-md bg-muted/50 px-2 py-1.5 space-y-0.5"
-                >
+                <div key={period.id} className="rounded-md bg-muted/50 px-2 py-1.5 space-y-0.5">
                   <p className="text-xs font-medium leading-tight">{period.name}</p>
                   <p className="text-[11px] text-muted-foreground leading-tight">
                     {formatSchedule(period.schedule)}
-                    {profileName && (
-                      <span className="ml-1">· {profileName}</span>
-                    )}
+                    {profileName && <span className="ml-1">· {profileName}</span>}
                   </p>
                 </div>
               )
@@ -182,8 +236,7 @@ function PeriodsTooltip({ children, channel, profiles }) {
 }
 
 // ---------------------------------------------------------------------------
-// Tooltip: Regex Patterns column
-// All data is already in props — zero fetching needed.
+// Tooltip: Regex Patterns column — zero fetching, pure props
 // ---------------------------------------------------------------------------
 function RegexPatternsTooltip({ children, channelPatterns, matchByTvgId, isTvgInherited, channel }) {
   const normalizedPatterns = normalizePatternData(channelPatterns)
@@ -194,7 +247,6 @@ function RegexPatternsTooltip({ children, channelPatterns, matchByTvgId, isTvgIn
       <TooltipContent className="max-w-[320px] p-3 space-y-2">
         <p className="font-semibold text-sm">Regex Patterns</p>
 
-        {/* TVG-ID matching */}
         {matchByTvgId && (
           <div className="rounded-md bg-muted/50 px-2 py-1.5">
             <p className="text-xs font-medium flex items-center gap-1">
@@ -213,7 +265,6 @@ function RegexPatternsTooltip({ children, channelPatterns, matchByTvgId, isTvgIn
           </div>
         )}
 
-        {/* Regex patterns list */}
         {normalizedPatterns.length > 0 ? (
           <div className="space-y-1.5">
             {normalizedPatterns.map((p, i) => (
@@ -289,7 +340,7 @@ export function RegexTableRow({
     ? groupMatchingConfig.regex_patterns.length
     : 0
 
-  // Logo loading (unchanged)
+  // Logo
   useEffect(() => {
     const cached = getCachedChannelLogoUrl(channel.id)
     if (cached) { setLogoUrl(cached); return }
@@ -303,7 +354,7 @@ export function RegexTableRow({
     }
   }, [channel.id, channel.logo_id])
 
-  // Period loading for the expanded row panel (unchanged behaviour)
+  // Expanded panel period fetch
   const loadChannelPeriods = useCallback(async () => {
     setLoadingPeriods(true)
     try {
@@ -331,14 +382,9 @@ export function RegexTableRow({
     }
   }
 
-  // Matching mode helpers
-  const effectiveMatchingEnabled = effectiveMatchingConfig?.enabled !== false
-  const effectiveCheckingMode =
-    channel?.checking_mode || groupsConfig?.[channelGroupId]?.checking_mode || 'enabled'
-
   return (
     <div className="border-b last:border-b-0">
-      {/* ── Collapsed row grid ── */}
+      {/* ── Collapsed row ── */}
       <div
         className="grid items-center gap-2 px-3 py-3 hover:bg-muted/30 transition-colors"
         style={{ gridTemplateColumns: REGEX_TABLE_GRID_COLS }}
@@ -379,13 +425,12 @@ export function RegexTableRow({
           <span className="font-medium truncate">{channel.name}</span>
         </div>
 
-        {/* ── Channel Group column (with tooltip) ── */}
+        {/* ── Channel Group — fetches active profile on hover ── */}
         <div className="flex items-center text-sm text-muted-foreground min-w-0">
           <ChannelGroupTooltip
             channel={channel}
             group={group}
             groupsConfig={groupsConfig}
-            profiles={profiles}
           >
             <div className="min-w-0 cursor-default">
               <div className="truncate">{group?.name || '-'}</div>
@@ -407,7 +452,7 @@ export function RegexTableRow({
           </ChannelGroupTooltip>
         </div>
 
-        {/* ── Nº of Periods column (with tooltip) ── */}
+        {/* ── Nº of Periods ── */}
         <div className="flex items-center">
           <PeriodsTooltip channel={channel} profiles={profiles}>
             <div className="cursor-default">
@@ -419,7 +464,7 @@ export function RegexTableRow({
           </PeriodsTooltip>
         </div>
 
-        {/* ── Regex Patterns column (with tooltip) ── */}
+        {/* ── Regex Patterns ── */}
         <div className="flex items-center gap-2 flex-wrap">
           <RegexPatternsTooltip
             channelPatterns={channelPatterns}
@@ -450,7 +495,7 @@ export function RegexTableRow({
             </div>
           </RegexPatternsTooltip>
 
-          {/* Stream match count tooltip (pre-existing, unchanged) */}
+          {/* Stream match count (pre-existing, unchanged) */}
           <Tooltip>
             <TooltipTrigger asChild>
               <span className="text-xs font-mono tabular-nums cursor-default select-none">
@@ -520,22 +565,17 @@ export function RegexTableRow({
       {/* ── Expanded panel (unchanged) ── */}
       {expanded && (
         <div className="px-4 pb-4 space-y-4 bg-muted/20 border-t">
-          {/* Regex patterns editor */}
           <div className="pt-4">
             <div className="flex items-center justify-between mb-3">
               <h4 className="font-medium text-sm flex items-center gap-2">
                 <Edit className="h-4 w-4" />
                 Regex Patterns
-                {hasChannelMatchingConfig ? null : channelGroupId && groupMatchingPatternCount > 0 ? (
+                {!hasChannelMatchingConfig && channelGroupId && groupMatchingPatternCount > 0 && (
                   <Badge variant="outline" className="text-[10px]">Inherited from group</Badge>
-                ) : null}
+                )}
               </h4>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 text-xs"
-                onClick={() => onEditRegex?.(channel.id, null)}
-              >
+              <Button size="sm" variant="outline" className="h-7 text-xs"
+                onClick={() => onEditRegex?.(channel.id, null)}>
                 <Plus className="h-3 w-3 mr-1" />
                 Add Pattern
               </Button>
@@ -544,10 +584,8 @@ export function RegexTableRow({
             {normalizePatternData(channelPatterns).length > 0 ? (
               <div className="space-y-2">
                 {normalizePatternData(channelPatterns).map((p, idx) => (
-                  <div
-                    key={idx}
-                    className="flex items-center justify-between gap-2 rounded-md border bg-background px-3 py-2"
-                  >
+                  <div key={idx}
+                    className="flex items-center justify-between gap-2 rounded-md border bg-background px-3 py-2">
                     <div className="flex-1 min-w-0">
                       <p className="text-xs font-mono break-all">{p.pattern}</p>
                       {p.m3u_accounts && p.m3u_accounts.length > 0 && (
@@ -557,20 +595,13 @@ export function RegexTableRow({
                       )}
                     </div>
                     <div className="flex gap-1 shrink-0">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="h-7 w-7 p-0"
-                        onClick={() => onEditRegex?.(channel.id, idx)}
-                      >
+                      <Button size="sm" variant="ghost" className="h-7 w-7 p-0"
+                        onClick={() => onEditRegex?.(channel.id, idx)}>
                         <Edit className="h-3 w-3" />
                       </Button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
+                      <Button size="sm" variant="ghost"
                         className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                        onClick={() => onDeletePattern?.(channel.id, idx)}
-                      >
+                        onClick={() => onDeletePattern?.(channel.id, idx)}>
                         <Trash2 className="h-3 w-3" />
                       </Button>
                     </div>
@@ -588,14 +619,11 @@ export function RegexTableRow({
 
           <Separator />
 
-          {/* TVG-ID matching toggle */}
           {onUpdateMatchSettings && (
             <div className="flex items-center justify-between">
               <div>
                 <Label className="text-sm font-medium">TVG-ID Matching</Label>
-                <p className="text-xs text-muted-foreground">
-                  Match streams using the channel's TVG-ID
-                </p>
+                <p className="text-xs text-muted-foreground">Match streams using the channel's TVG-ID</p>
               </div>
               <Switch
                 checked={matchByTvgId}
@@ -608,19 +636,14 @@ export function RegexTableRow({
 
           <Separator />
 
-          {/* Automation periods */}
           <div>
             <div className="flex items-center justify-between mb-3">
               <h4 className="font-medium text-sm flex items-center gap-2">
                 <Calendar className="h-4 w-4" />
                 Automation Periods
               </h4>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7 text-xs"
-                onClick={() => setAssignDialogOpen(true)}
-              >
+              <Button size="sm" variant="outline" className="h-7 text-xs"
+                onClick={() => setAssignDialogOpen(true)}>
                 <Plus className="h-3 w-3 mr-1" />
                 Assign Period
               </Button>
@@ -636,14 +659,13 @@ export function RegexTableRow({
                 {channelPeriods.map((period) => {
                   const profileName =
                     period.profile?.name ||
+                    period.profile_name ||
                     (period.profile_id
                       ? profiles?.find(p => String(p.id) === String(period.profile_id))?.name
                       : null)
                   return (
-                    <div
-                      key={period.id}
-                      className="flex items-center justify-between gap-2 rounded-md border bg-background px-3 py-2"
-                    >
+                    <div key={period.id}
+                      className="flex items-center justify-between gap-2 rounded-md border bg-background px-3 py-2">
                       <div className="flex-1 min-w-0">
                         <p className="text-xs font-medium">{period.name}</p>
                         <p className="text-[11px] text-muted-foreground mt-0.5">
@@ -651,12 +673,9 @@ export function RegexTableRow({
                           {profileName && <span className="ml-1">· {profileName}</span>}
                         </p>
                       </div>
-                      <Button
-                        size="sm"
-                        variant="ghost"
+                      <Button size="sm" variant="ghost"
                         onClick={() => handleRemovePeriod(period.id)}
-                        className="text-destructive hover:text-destructive hover:bg-destructive/10 h-7 w-7 p-0"
-                      >
+                        className="text-destructive hover:text-destructive hover:bg-destructive/10 h-7 w-7 p-0">
                         <Trash2 className="h-4 w-4" />
                       </Button>
                     </div>
@@ -683,7 +702,6 @@ export function RegexTableRow({
 
           <Separator />
 
-          {/* EPG Scheduled Profile override */}
           {onAssignEpgProfile && (
             <div>
               <h4 className="font-medium text-sm flex items-center gap-2 mb-2">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,3 @@
-
 import axios from 'axios';
 
 // Create axios instance with default config
@@ -121,6 +120,16 @@ export const channelsAPI = {
   getChannelStats: (channelId) => api.get(`/channels/${channelId}/stats`),
   getLogo: (logoId) => api.get(`/channels/logos/${logoId}`),
   getLogoCached: (logoId) => `/api/channels/logos/${logoId}/cache`,
+
+  // Alias used by RegexTableRow logo loading
+  getChannelLogo: (logoId) => api.get(`/channels/logos/${logoId}`),
+
+  /**
+   * Resolve the currently active automation profile and EPG override for a channel.
+   * Uses the same resolution hierarchy the stream checker uses.
+   * Lazy — intended for on-demand tooltip fetches.
+   */
+  getChannelActiveProfile: (channelId) => api.get(`/channels/${channelId}/active-profile`),
 };
 
 export const channelOrderAPI = {
@@ -201,8 +210,6 @@ export const deadStreamsAPI = {
   /**
    * Fetch dead streams with SQL-native pagination, sorting, and optional search.
    *
-   * @param {number} [page=1]         - Page number (1-based).
-   * @param {number} [per_page=20]    - Items per page.
    * @param {Object} [options]
    * @param {number} [options.page=1]
    * @param {number} [options.per_page=20]
@@ -274,4 +281,28 @@ export const versionAPI = {
 
 export const environmentAPI = {
   getEnvironment: () => api.get('/environment'),
+};
+
+// ── These are imported by ChannelConfiguration.jsx but not captured in repomix.
+// ── Definitions inferred from usage patterns in ChannelConfiguration.jsx.
+// ── DO NOT REMOVE — removing these causes build errors.
+
+export const channelSettingsAPI = {
+  getAllSettings: () => api.get('/channel-settings'),
+  getSettings: (channelId) => api.get(`/channel-settings/${channelId}`),
+  updateSettings: (channelId, settings) => api.post(`/channel-settings/${channelId}`, settings),
+};
+
+export const groupSettingsAPI = {
+  getAllSettings: () => api.get('/group-settings'),
+  getSettings: (groupId) => api.get(`/group-settings/${groupId}`),
+  updateSettings: (groupId, settings) => api.post(`/group-settings/${groupId}`, settings),
+  bulkDisableMatching: () => api.post('/group-settings/bulk-disable-matching'),
+  bulkDisableChecking: () => api.post('/group-settings/bulk-disable-checking'),
+};
+
+export const profileAPI = {
+  getConfig: () => api.get('/profile-config'),
+  getProfileChannels: (profileId, includeSnapshot = false) =>
+    api.get(`/channels/profiles/${profileId}`, { params: { include_snapshot: includeSnapshot } }),
 };


### PR DESCRIPTION
Adds three hover tooltips to the Channel Configuration table — one each for the Channel Group, Nº of Periods, and Regex Patterns columns. The Channel Group tooltip lazily fetches the backend on first hover to resolve the channel's currently active automation profile and EPG override, following the same priority hierarchy the stream checker uses at runtime. The Periods tooltip loads assigned period names and schedules on demand. The Regex Patterns tooltip shows configured expressions inline with no extra network call. A new backend endpoint powers the profile resolution. The frontend service layer is also brought fully in sync with upstream API changes from the parallel development branch.