### PR TITLE
StreamFlow Automation: Cache-First Pipeline & Profile Flag Enforcement

### DIFF
--- a/backend/apps/api/web_api.py
+++ b/backend/apps/api/web_api.py
@@ -425,6 +425,7 @@ def scheduled_event_processor():
         get_wake_event=lambda: scheduled_event_processor_wake,
         get_scheduling_service=get_scheduling_service,
         get_stream_checker_service=get_stream_checker_service,
+        get_udi_manager=get_udi_manager,
         logger=logger,
         check_interval=30,
     )

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -1368,11 +1368,6 @@ class AutomatedStreamManager:
             
             logger.info("Starting M3U playlist refresh...")
             
-            # Get streams before refresh
-            from apps.core.api_utils import get_streams
-            streams_before = get_streams(log_result=False) if self.config.get("enabled_features", {}).get("changelog_tracking", True) else []
-            before_stream_ids = {s.get('id'): s.get('name', '') for s in streams_before if isinstance(s, dict) and s.get('id')}
-            
             # Get all M3U accounts
             all_accounts = get_m3u_accounts()
             self._m3u_accounts_cache = all_accounts
@@ -1439,10 +1434,11 @@ class AutomatedStreamManager:
                 logger.error("Playlist refresh encountered one or more failed account refreshes")
                 return False, refreshed_accounts
             
-            # NOTE: UDI refresh is intentionally decoupled from playlist refresh.
-            # Automation cycles perform a single dedicated UDI refresh step to avoid
-            # duplicate refreshes when playlist updates are part of the cycle.
-            
+            # NOTE: UDI refresh, changelog write, and dead stream cleanup are
+            # intentionally NOT performed here. run_automation_cycle() owns all
+            # three after refresh_playlists() returns, using a UDI sync to ensure
+            # accurate data. Doing them here would use a stale pre-fetch cache.
+
             # Trigger EPG matching to pick up any EPG/tvg-id changes made in Dispatcharr
             # This ensures that if a channel's EPG assignment was changed in Dispatcharr,
             # the new program data will be available in StreamFlow
@@ -1456,50 +1452,14 @@ class AutomatedStreamManager:
             except Exception as e:
                 logger.error(f"Error triggering rule matching after playlist update: {e}")
                 # Continue even if EPG refresh fails
-            
-            # Get streams after refresh - log this one since it shows the final result
-            streams_after = get_streams(log_result=True) if self.config.get("enabled_features", {}).get("changelog_tracking", True) else []
-            after_stream_ids = {s.get('id'): s.get('name', '') for s in streams_after if isinstance(s, dict) and s.get('id')}
-            
+
             self.last_playlist_update = datetime.now()
-            
-            # Calculate differences
-            added_stream_ids = set(after_stream_ids.keys()) - set(before_stream_ids.keys())
-            removed_stream_ids = set(before_stream_ids.keys()) - set(after_stream_ids.keys())
-            
-            added_streams = [{"id": sid, "name": after_stream_ids[sid]} for sid in added_stream_ids]
-            removed_streams = [{"id": sid, "name": before_stream_ids[sid]} for sid in removed_stream_ids]
-            
-            
-            if not skip_changelog and self.config.get("enabled_features", {}).get("changelog_tracking", True):
-                self.changelog.add_entry("playlist_refresh", {
-                    "success": True,
-                    "timestamp": self.last_playlist_update.isoformat(),
-                    "total_streams": len(after_stream_ids),
-                    "added_streams": added_streams[:50],  # Limit to first 50 for changelog size
-                    "removed_streams": removed_streams[:50],  # Limit to first 50 for changelog size
-                    "added_count": len(added_streams),
-                    "removed_count": len(removed_streams)
-                })
-            
-            logger.info(f"M3U playlist refresh completed successfully. Added: {len(added_streams)}, Removed: {len(removed_streams)}")
-            
-            # Clean up dead streams that are no longer in the playlist
-            if self.dead_streams_tracker:
-                try:
-                    current_stream_urls = {s.get('url', '') for s in streams_after if isinstance(s, dict) and s.get('url')}
-                    # Remove empty URLs from the set
-                    current_stream_urls.discard('')
-                    cleaned_count = self.dead_streams_tracker.cleanup_removed_streams(current_stream_urls)
-                    if cleaned_count > 0:
-                        logger.info(f"Dead streams cleanup: removed {cleaned_count} stream(s) no longer in playlist")
-                except Exception as cleanup_error:
-                    logger.error(f"Error during dead streams cleanup: {cleanup_error}")
-            
+            logger.info("M3U playlist refresh completed successfully")
+
             # Note: Channel marking for stream quality checking is handled in discover_and_assign_streams()
             # after streams are actually assigned to specific channels. This prevents marking all channels
             # when we only know that *some* streams changed in the playlist, not which channels are affected.
-            
+
             return True, refreshed_accounts
             
         except Exception as e:
@@ -2925,6 +2885,23 @@ class AutomatedStreamManager:
                     logger.warning(f"Could not read pre-refresh stream pool size: {e}")
                     pre_refresh_stream_count = 0
 
+                # Capture stream list before provider fetch for changelog delta.
+                # Must be done here (in run_automation_cycle) not inside refresh_playlists()
+                # because refresh_playlists() no longer owns the changelog write.
+                changelog_tracking_pre = self.config.get("enabled_features", {}).get("changelog_tracking", True)
+                try:
+                    streams_before = get_streams(log_result=False) if changelog_tracking_pre else []
+                    before_stream_ids = {
+                        s.get('id'): s.get('name', '')
+                        for s in streams_before
+                        if isinstance(s, dict) and s.get('id')
+                    }
+                except Exception as _sb_err:
+                    logger.warning(f"Could not capture pre-refresh stream list: {_sb_err}")
+                    before_stream_ids = {}
+            else:
+                before_stream_ids = {}
+
             if update_all_playlists:
                 logger.info("Updating ALL playlists (requested by one or more profiles)")
                 refresh_success, refreshed_accounts = self.refresh_playlists(account_id=None, skip_changelog=True)
@@ -2951,17 +2928,88 @@ class AutomatedStreamManager:
             # Deduplicate while preserving order (channels may appear in multiple active period groups).
             channels_to_quality_check = list(dict.fromkeys(channels_to_quality_check))
 
-            # NOTE: No mid-cycle UDI refresh occurs here.
+            # When playlists were refreshed, sync the UDI cache from Dispatcharr's
+            # now-updated stream pool before running validation, assignment, or the
+            # safety gate. Without this sync:
+            #   - matching reads stale stream IDs → Invalid pk errors on write
+            #   - changelog delta is always zero (streams_after == streams_before)
+            #   - dead stream cleanup uses wrong URLs
+            #   - safety gate compares two reads of the same stale cache
             #
-            # The UDI cache is the contract for all reads during this cycle. When
-            # m3u_update.enabled = True the provider fetch above updated Dispatcharr's
-            # own data; the poll helper confirmed completion before returning. When
-            # m3u_update.enabled = False the existing cache is used as-is. All writes
-            # (assignments, scores, ordering) go to Dispatcharr in real time. A background
-            # UDI sync fires in the finally block after the cycle completes to pull those
-            # writes back into the cache for the next run.
+            # When no playlists were refreshed (m3u_update=False across all active
+            # profiles), the existing cache is used as-is. The background UDI sync
+            # in the finally block handles cache accuracy for the next cycle.
+            if playlists_refreshed and refresh_success:
+                logger.info(
+                    "Syncing UDI cache after provider refresh — "
+                    "matching and safety gate will use current stream IDs..."
+                )
+                try:
+                    _sync_udi = get_udi_manager()
+                    _sync_udi.refresh_streams()
+                    _sync_udi.refresh_channels()
+                    logger.info("✓ UDI cache synced after provider refresh")
+                except Exception as _sync_err:
+                    logger.warning(
+                        f"UDI sync after provider refresh failed: {_sync_err} — "
+                        "proceeding with potentially stale cache"
+                    )
 
-            if playlists_refreshed:
+                # Capture streams_after from the now-current cache for changelog and cleanup
+                changelog_tracking = self.config.get("enabled_features", {}).get("changelog_tracking", True)
+                try:
+                    streams_after = get_streams(log_result=True) if changelog_tracking else []
+                    after_stream_ids = {
+                        s.get('id'): s.get('name', '')
+                        for s in streams_after
+                        if isinstance(s, dict) and s.get('id')
+                    }
+                except Exception as _sa_err:
+                    logger.warning(f"Could not capture post-refresh stream list: {_sa_err}")
+                    streams_after = []
+                    after_stream_ids = {}
+
+                # Changelog entry with accurate delta
+                if changelog_tracking:
+                    try:
+                        added_stream_ids = set(after_stream_ids.keys()) - set(before_stream_ids.keys())
+                        removed_stream_ids = set(before_stream_ids.keys()) - set(after_stream_ids.keys())
+                        added_streams = [{"id": sid, "name": after_stream_ids[sid]} for sid in added_stream_ids]
+                        removed_streams = [{"id": sid, "name": before_stream_ids.get(sid, '')} for sid in removed_stream_ids]
+                        self.changelog.add_entry("playlist_refresh", {
+                            "success": True,
+                            "timestamp": self.last_playlist_update.isoformat(),
+                            "total_streams": len(after_stream_ids),
+                            "added_streams": added_streams[:50],
+                            "removed_streams": removed_streams[:50],
+                            "added_count": len(added_streams),
+                            "removed_count": len(removed_streams),
+                        })
+                        logger.info(
+                            f"Playlist changelog: {len(added_streams)} added, "
+                            f"{len(removed_streams)} removed"
+                        )
+                    except Exception as _cl_err:
+                        logger.warning(f"Could not write playlist changelog entry: {_cl_err}")
+
+                # Dead stream cleanup using accurate current URLs
+                if self.dead_streams_tracker and streams_after:
+                    try:
+                        current_stream_urls = {
+                            s.get('url', '') for s in streams_after
+                            if isinstance(s, dict) and s.get('url')
+                        }
+                        current_stream_urls.discard('')
+                        cleaned_count = self.dead_streams_tracker.cleanup_removed_streams(current_stream_urls)
+                        if cleaned_count > 0:
+                            logger.info(
+                                f"Dead streams cleanup: removed {cleaned_count} "
+                                "stream(s) no longer in playlist"
+                            )
+                    except Exception as _ds_err:
+                        logger.warning(f"Dead stream cleanup failed: {_ds_err}")
+
+                # Safety gate — now reads the updated cache, making it meaningful
                 try:
                     post_refresh_stream_count = len(get_streams(log_result=False) or [])
                 except Exception as e:

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -3247,31 +3247,33 @@ class AutomatedStreamManager:
                 self._save_state()
             
             logger.info("Automation cycle completed")
-            
+            _cycle_did_work = True
+
         finally:
             self._m3u_accounts_cache = None
 
             # Background UDI sync — pull all writes from this cycle back into cache.
-            # Runs in a daemon thread so it does not block the next scheduled wakeup.
-            # The next automation cycle or single-channel check will benefit from
-            # this refreshed cache state without having paid for it during the cycle.
-            def _background_cycle_udi_sync():
-                try:
-                    _udi = get_udi_manager()
-                    _udi.refresh_m3u_accounts()
-                    _udi.refresh_streams()
-                    _udi.refresh_channels()
-                    _udi.refresh_channel_groups()
-                    _udi.refresh_channel_profiles()
-                    logger.debug("Background UDI sync completed after automation cycle")
-                except Exception as _e:
-                    logger.warning(f"Background UDI sync failed after automation cycle: {_e}")
+            # Only fires when the cycle actually completed matching/checking work.
+            # Skipped on early returns (disabled, no active periods, safety gate abort)
+            # and when UDI is not yet fully initialised (e.g. concurrent with startup).
+            if locals().get('_cycle_did_work') and get_udi_manager().is_initialized():
+                def _background_cycle_udi_sync():
+                    try:
+                        _udi = get_udi_manager()
+                        _udi.refresh_m3u_accounts()
+                        _udi.refresh_streams()
+                        _udi.refresh_channels()
+                        _udi.refresh_channel_groups()
+                        _udi.refresh_channel_profiles()
+                        logger.debug("Background UDI sync completed after automation cycle")
+                    except Exception as _e:
+                        logger.warning(f"Background UDI sync failed after automation cycle: {_e}")
 
-            threading.Thread(
-                target=_background_cycle_udi_sync,
-                daemon=True,
-                name="udi-sync-post-cycle",
-            ).start()
+                threading.Thread(
+                    target=_background_cycle_udi_sync,
+                    daemon=True,
+                    name="udi-sync-post-cycle",
+                ).start()
 
     def _filter_channels_by_profile(self, channels: List[Dict], operation: str = "") -> List[Dict]:
         """

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -2013,6 +2013,56 @@ class AutomatedStreamManager:
                 if profile and profile.get('stream_checking', {}).get('allow_revive', False):
                     channel_to_revive_enabled[str(channel_id)] = True
 
+            # Collect channels excluded from matching but eligible for quality checking.
+            #
+            # These are channels whose profile has stream_matching.enabled = False but
+            # stream_checking.enabled = True — "checking-only" profiles. Without this
+            # collection they would silently drop out of the cycle because
+            # mark_channels_updated() below only fires for channels that received new
+            # stream assignments through the matching pass.
+            #
+            # We collect them here (before all_channels is replaced) so we can mark
+            # them for the checker after the matching pass completes. They are NOT
+            # added to the matching pass — that would be incorrect.
+            checking_only_channel_ids = []
+            for _ch in all_channels:
+                _ch_id = _ch.get('id')
+                if _ch_id in matching_enabled_channel_ids:
+                    continue  # already handled by matching path
+
+                # Resolve effective profile for this channel (respects forced_period_id)
+                _group_id = (
+                    _ch.get('group_id')
+                    if _ch.get('group_id') is not None
+                    else _ch.get('channel_group_id')
+                )
+                _config = automation_config.get_effective_configuration(_ch_id, _group_id)
+                if not _config:
+                    continue
+
+                # Honour forced_period_id — only include channels that belong to that period
+                if forced_period_id:
+                    _periods = _config.get('periods', [])
+                    _selected = next(
+                        (p for p in _periods if p.get('id') == forced_period_id),
+                        None,
+                    )
+                    if not _selected:
+                        continue
+                    _period_profile = _selected.get('profile')
+                else:
+                    _period_profile = _config.get('profile')
+
+                if _period_profile and _period_profile.get('stream_checking', {}).get('enabled', False):
+                    checking_only_channel_ids.append(_ch_id)
+
+            if checking_only_channel_ids:
+                logger.info(
+                    f"Found {len(checking_only_channel_ids)} checking-only channel(s) "
+                    "(matching disabled, checking enabled) — will queue for checker "
+                    "after matching pass."
+                )
+
             # Filter channels to only those with matching enabled
             filtered_channels = [ch for ch in all_channels if ch.get('id') in matching_enabled_channel_ids]
             
@@ -2306,6 +2356,45 @@ class AutomatedStreamManager:
                             logger.debug(f"Stream checker not available or error marking channels: {sc_error}")
                 except Exception as mark_error:
                     logger.debug(f"Could not mark channels for stream checking after discovery: {mark_error}")
+            
+            # Mark checking-only channels for quality checking.
+            #
+            # These channels had stream_matching.enabled = False so they were excluded
+            # from the matching pass and never received a mark_channels_updated() call.
+            # Without this block they are silently skipped by the checker every cycle.
+            # The existing get_and_clear_channels_needing_check() already filters by
+            # stream_checking.enabled so no duplicate guard is needed here.
+            if checking_only_channel_ids:
+                try:
+                    from apps.stream.stream_checker_service import get_stream_checker_service
+                    _co_checker = get_stream_checker_service()
+                    _co_stream_counts = {}
+                    for _co_id in checking_only_channel_ids:
+                        _co_ch = udi.get_channel_by_id(_co_id)
+                        if _co_ch:
+                            _co_streams = _co_ch.get('streams', [])
+                            _co_stream_counts[_co_id] = (
+                                len(_co_streams) if isinstance(_co_streams, list) else 0
+                            )
+                    _co_checker.update_tracker.mark_channels_updated(
+                        checking_only_channel_ids,
+                        stream_counts=_co_stream_counts,
+                    )
+                    logger.info(
+                        f"Marked {len(checking_only_channel_ids)} checking-only "
+                        "channel(s) for quality checking"
+                    )
+                    if not skip_check_trigger:
+                        _co_checker.trigger_check_updated_channels()
+                    else:
+                        logger.debug(
+                            "Skipping check trigger for checking-only channels "
+                            "(will be handled by caller)"
+                        )
+                except Exception as _co_err:
+                    logger.debug(
+                        f"Could not mark checking-only channels for quality checking: {_co_err}"
+                    )
             
             return {
                 "assignment_count": assignment_count,

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -2718,11 +2718,17 @@ class AutomatedStreamManager:
         return False
 
     def _refresh_udi_cache_for_automation_cycle(self) -> bool:
-        """Refresh all UDI entities once per automation cycle.
+        """Refresh all UDI entities after an automation cycle completes.
 
-        This is intentionally separate from playlist refresh calls so that:
-        - Automation cycles always refresh UDI even without M3U updates.
-        - Cycles with M3U updates still perform only one UDI refresh.
+        Called in a background daemon thread from the finally block of
+        run_automation_cycle(). Pulls all writes made during the cycle
+        (stream assignments, quality scores, stream ordering) back into
+        the local cache so the next cycle or single-channel check starts
+        from an accurate baseline.
+
+        This is intentionally post-cycle rather than pre-cycle so that
+        the cycle itself operates entirely on the existing cache state —
+        fast and deterministic regardless of UDI sync timing.
         """
         try:
             logger.info("Refreshing UDI cache for automation cycle...")
@@ -2907,12 +2913,18 @@ class AutomatedStreamManager:
             
             start_time = datetime.now()
 
-            try:
-                pre_refresh_stream_count = len(get_streams(log_result=False) or [])
-            except Exception as e:
-                logger.warning(f"Could not read pre-refresh stream pool size: {e}")
-                pre_refresh_stream_count = 0
-            
+            # Determine whether a provider playlist refresh will occur this cycle.
+            # Pre/post stream counts and the safety gate are only meaningful when
+            # playlists are actually refreshed — skip all three when they are not.
+            playlists_refreshed = bool(update_all_playlists or playlists_to_update)
+
+            if playlists_refreshed:
+                try:
+                    pre_refresh_stream_count = len(get_streams(log_result=False) or [])
+                except Exception as e:
+                    logger.warning(f"Could not read pre-refresh stream pool size: {e}")
+                    pre_refresh_stream_count = 0
+
             if update_all_playlists:
                 logger.info("Updating ALL playlists (requested by one or more profiles)")
                 refresh_success, refreshed_accounts = self.refresh_playlists(account_id=None, skip_changelog=True)
@@ -2926,39 +2938,46 @@ class AutomatedStreamManager:
                     if accs:
                         refreshed_accounts.extend(accs)
             else:
-                logger.info("No playlists to update based on active profile settings.")
+                logger.info(
+                    "No playlists to update based on active profile settings. "
+                    "Cycle will operate on current UDI cache."
+                )
                 self.last_playlist_update = datetime.now()
                 refresh_success = True
-            
+
             validation_details = []
             assignment_details = []
 
             # Deduplicate while preserving order (channels may appear in multiple active period groups).
             channels_to_quality_check = list(dict.fromkeys(channels_to_quality_check))
 
-            # Refresh UDI once per cycle, independent of playlist refresh selection.
-            # This keeps channel/stream/group/profile state current without coupling
-            # cache sync to the M3U refresh call path.
-            self._refresh_udi_cache_for_automation_cycle()
+            # NOTE: No mid-cycle UDI refresh occurs here.
+            #
+            # The UDI cache is the contract for all reads during this cycle. When
+            # m3u_update.enabled = True the provider fetch above updated Dispatcharr's
+            # own data; the poll helper confirmed completion before returning. When
+            # m3u_update.enabled = False the existing cache is used as-is. All writes
+            # (assignments, scores, ordering) go to Dispatcharr in real time. A background
+            # UDI sync fires in the finally block after the cycle completes to pull those
+            # writes back into the cache for the next run.
 
-            try:
-                post_refresh_stream_count = len(get_streams(log_result=False) or [])
-            except Exception as e:
-                logger.warning(f"Could not read post-refresh stream pool size: {e}")
-                post_refresh_stream_count = 0
+            if playlists_refreshed:
+                try:
+                    post_refresh_stream_count = len(get_streams(log_result=False) or [])
+                except Exception as e:
+                    logger.warning(f"Could not read post-refresh stream pool size: {e}")
+                    post_refresh_stream_count = 0
 
-            playlists_refreshed = bool(update_all_playlists or playlists_to_update)
-
-            if refresh_success and self._should_abort_for_suspicious_stream_pool(
-                before_count=pre_refresh_stream_count,
-                after_count=post_refresh_stream_count,
-                playlists_refreshed=playlists_refreshed,
-            ):
-                logger.error(
-                    "Automation safety gate triggered. Skipping validation and assignment "
-                    "to preserve existing channel streams."
-                )
-                refresh_success = False
+                if refresh_success and self._should_abort_for_suspicious_stream_pool(
+                    before_count=pre_refresh_stream_count,
+                    after_count=post_refresh_stream_count,
+                    playlists_refreshed=playlists_refreshed,
+                ):
+                    logger.error(
+                        "Automation safety gate triggered. Skipping validation and assignment "
+                        "to preserve existing channel streams."
+                    )
+                    refresh_success = False
             
             if refresh_success:
                 # Optional post-refresh delay for environments where provider updates
@@ -3231,6 +3250,28 @@ class AutomatedStreamManager:
             
         finally:
             self._m3u_accounts_cache = None
+
+            # Background UDI sync — pull all writes from this cycle back into cache.
+            # Runs in a daemon thread so it does not block the next scheduled wakeup.
+            # The next automation cycle or single-channel check will benefit from
+            # this refreshed cache state without having paid for it during the cycle.
+            def _background_cycle_udi_sync():
+                try:
+                    _udi = get_udi_manager()
+                    _udi.refresh_m3u_accounts()
+                    _udi.refresh_streams()
+                    _udi.refresh_channels()
+                    _udi.refresh_channel_groups()
+                    _udi.refresh_channel_profiles()
+                    logger.debug("Background UDI sync completed after automation cycle")
+                except Exception as _e:
+                    logger.warning(f"Background UDI sync failed after automation cycle: {_e}")
+
+            threading.Thread(
+                target=_background_cycle_udi_sync,
+                daemon=True,
+                name="udi-sync-post-cycle",
+            ).start()
 
     def _filter_channels_by_profile(self, channels: List[Dict], operation: str = "") -> List[Dict]:
         """

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -3256,7 +3256,7 @@ class AutomatedStreamManager:
             # Only fires when the cycle actually completed matching/checking work.
             # Skipped on early returns (disabled, no active periods, safety gate abort)
             # and when UDI is not yet fully initialised (e.g. concurrent with startup).
-            if locals().get('_cycle_did_work') and get_udi_manager().is_initialized():
+            if locals().get('_cycle_did_work') and get_udi_manager().is_network_ready():
                 def _background_cycle_udi_sync():
                     try:
                         _udi = get_udi_manager()
@@ -3329,6 +3329,17 @@ class AutomatedStreamManager:
         logger.info("Automation background loop started")
         while self.automation_running:
             try:
+                # Do not run automation cycles before the startup network UDI refresh
+                # completes. is_initialized() alone is True from SQL storage load
+                # (potentially empty — zero streams, zero M3U accounts).
+                if not get_udi_manager().is_network_ready():
+                    logger.debug(
+                        "Automation loop waiting — UDI network refresh not yet complete"
+                    )
+                    self.automation_wake_event.wait(timeout=10)
+                    self.automation_wake_event.clear()
+                    continue
+
                 # Run automation cycle
                 # Pass forced period info to cycle
                 forced = self.force_next_run

--- a/backend/apps/background/scheduling_workers.py
+++ b/backend/apps/background/scheduling_workers.py
@@ -10,6 +10,7 @@ def scheduled_event_processor_loop(
     get_wake_event: Callable[[], Any],
     get_scheduling_service: Callable[[], Any],
     get_stream_checker_service: Callable[[], Any],
+    get_udi_manager: Callable[[], Any],
     logger: Any,
     check_interval: int = 30,
 ):
@@ -25,6 +26,14 @@ def scheduled_event_processor_loop(
             else:
                 wake_event.wait(timeout=check_interval)
                 wake_event.clear()
+
+            # Do not process scheduled events before the startup network UDI refresh
+            # completes. Firing against an empty/stale cache produces no-op checks.
+            if not get_udi_manager().is_network_ready():
+                logger.debug(
+                    "Scheduled event processor waiting — UDI network refresh not yet complete"
+                )
+                continue
 
             service = get_scheduling_service()
             stream_checker = get_stream_checker_service()

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -332,6 +332,12 @@ class StreamCheckerService:
         This respects automation_controls and queues channels only when
         automatic quality checking is enabled.
         """
+        # Do not queue channels before the startup network UDI refresh completes.
+        # is_initialized() alone is True from SQL storage load (potentially empty cache).
+        if not get_udi_manager().is_network_ready():
+            logger.debug("Skipping channel queueing — UDI network refresh not yet complete")
+            return
+
         # Check if auto quality checking is enabled (considers both pipeline mode and individual controls)
         if not self.config.is_auto_quality_checking_enabled():
             logger.info("Skipping channel queueing - automatic quality checking is disabled")
@@ -363,6 +369,12 @@ class StreamCheckerService:
         self._cancel_queueing = False
         try:
             udi = get_udi_manager()
+
+            # Do not queue channels before the startup network UDI refresh completes.
+            if not udi.is_network_ready():
+                logger.debug("Skipping global channel queue — UDI network refresh not yet complete")
+                return
+
             channels = udi.get_channels()
             
             if channels:
@@ -3656,8 +3668,9 @@ class StreamCheckerService:
 
             # Background UDI sync — pull all writes from this check back into cache.
             # Runs in a daemon thread so it does not block the response to the caller.
-            # Guarded on is_initialized() to avoid firing during or before startup init.
-            if udi.is_initialized():
+            # Guarded on is_network_ready() to avoid firing before startup network
+            # refresh completes (is_initialized() alone is True from SQL storage load).
+            if udi.is_network_ready():
                 def _background_udi_sync(ch_id: int, ch_name: str):
                     try:
                         _udi = get_udi_manager()

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -3341,16 +3341,15 @@ class StreamCheckerService:
             # IMPORTANT DISTINCTION:
             #   m3u_update.enabled = True  → tell Dispatcharr to re-pull from the M3U
             #                                 provider URL (two-hop: StreamFlow → Dispatcharr
-            #                                 → provider). The UDI sync in Step 2b then reads
-            #                                 the result of that provider fetch.
-            #   m3u_update.enabled = False → no provider fetch is triggered. Step 2b still
-            #                                 syncs the UDI cache from whatever Dispatcharr
-            #                                 currently has, so matching/checking see the most
-            #                                 recent known state without causing any provider churn.
+            #                                 → provider). The cache is confirmed current
+            #                                 before proceeding to subsequent steps.
+            #   m3u_update.enabled = False → no provider fetch is triggered. All steps
+            #                                 operate on the existing cache as-is, which
+            #                                 reflects the last completed cycle or refresh.
             #
             # Dispatcharr processes M3U refreshes asynchronously. After triggering the
             # refresh we poll the UDI stream count until it changes (confirming Dispatcharr
-            # has finished processing) before proceeding to Step 2b.
+            # has finished processing) before proceeding.
             if m3u_update_enabled and account_ids:
                 logger.info(
                     f"Step 2a/6: Refreshing playlists for {len(account_ids)} M3U account(s) "
@@ -3382,25 +3381,20 @@ class StreamCheckerService:
                     "Subsequent steps will use the current UDI cache state."
                 )
 
-            # Step 2b: UDI cache sync — runs whenever a subsequent step will use the data.
+            # NOTE: No mid-pipeline UDI sync occurs here.
             #
-            # This is always a one-hop read (StreamFlow → Dispatcharr) and does NOT
-            # cause Dispatcharr to contact any provider. It ensures matching and checking
-            # operate on the freshest Dispatcharr state available, even when the provider
-            # fetch was skipped.
-            if matching_enabled or checking_enabled:
-                logger.debug(
-                    "Step 2b/6: Syncing UDI cache from Dispatcharr current state..."
-                )
-                udi.refresh_m3u_accounts()
-                udi.refresh_streams()
-                udi.refresh_channels()
-                udi.refresh_channel_groups()
-                logger.info("✓ UDI cache synced")
-            else:
-                logger.info(
-                    "Step 2b/6: Skipping UDI sync (matching and checking both disabled)."
-                )
+            # The UDI cache is the contract for all reads during this check. Whatever
+            # state the cache held at the start of this invocation is what all steps
+            # operate against. This makes the pipeline fast and deterministic.
+            #
+            # When m3u_update.enabled = True (Step 2a above), the provider fetch
+            # completed and the cache was confirmed current before reaching this point.
+            # When m3u_update.enabled = False, the existing cache is used as-is —
+            # reflecting the last completed cycle, provider refresh, or startup init.
+            #
+            # All writes (assignments, quality scores, stream ordering) go to Dispatcharr
+            # in real time during Steps 4-6. A background UDI sync fires after this
+            # function returns to pull those writes back into the cache for the next run.
             
             # Step 3: Clear dead streams for this channel to give them a second chance
             logger.info(f"Step 3/6: Clearing dead streams for channel {channel_name} to give them a second chance...")
@@ -3469,13 +3463,12 @@ class StreamCheckerService:
             else:
                 logger.info(f"Step 5/6: Skipping stream matching (matching is disabled for this channel)")
             
-            # Refresh UDI cache again to ensure the check in Step 6 sees the newly assigned streams
-            # This is critical because discover_and_assign_streams updates the DB but UDI cache might be stale
+            # After matching writes new assignments to Dispatcharr, refresh only this
+            # channel's cache entry so Step 6 sees the updated stream list.
+            # This is a targeted single-channel read — not a full stream pool fetch.
             if matching_enabled:
-                logger.debug("Refreshing UDI cache for streams and channel to reflect new assignments...")
-                udi.refresh_streams()
                 udi.refresh_channel_by_id(channel_id)
-                logger.info(f"✓ UDI cache refreshed with latest stream assignments")
+                logger.debug("✓ Channel cache entry updated with latest stream assignments")
             
             # Step 6: Mark channel for force check and perform the check (if checking is enabled)
             dead_count = 0
@@ -3507,11 +3500,13 @@ class StreamCheckerService:
                 logger.info(f"Step 6/6: Skipping stream checking (checking is disabled for this channel)")
                 analyzed_lookup = {}
             
-            # Gather statistics after check using centralized utility.
-            # Refresh UDI cache first so stream_stats reflect the post-probe
-            # database state — loop fields written by _update_stream_stats
-            # won't be visible otherwise.
-            udi.refresh_streams()
+            # Gather statistics after check using cached channel data.
+            #
+            # fetch_channel_streams reads from the UDI in-memory cache — no network call.
+            # For streams that were probed in this run, analyzed_lookup carries authoritative
+            # scores and loop results (written to Dispatcharr during Step 6 and held in
+            # memory). The background UDI sync that fires after this function returns will
+            # pull those written values back into the cache for the next invocation.
             streams = fetch_channel_streams(channel_id)
             total_streams = len(streams)
             
@@ -3658,6 +3653,31 @@ class StreamCheckerService:
 
             # Clear progress so the frontend stops showing the single channel check UI
             self.progress.clear()
+
+            # Background UDI sync — pull all writes from this check back into cache.
+            # Runs in a daemon thread so it does not block the response to the caller.
+            # The next invocation of check_single_channel or run_automation_cycle will
+            # benefit from this refreshed cache state.
+            def _background_udi_sync(ch_id: int, ch_name: str):
+                try:
+                    _udi = get_udi_manager()
+                    _udi.refresh_streams()
+                    _udi.refresh_channel_by_id(ch_id)
+                    logger.debug(
+                        f"Background UDI sync completed for {ch_name} "
+                        f"(channel {ch_id})"
+                    )
+                except Exception as _e:
+                    logger.warning(
+                        f"Background UDI sync failed for {ch_name}: {_e}"
+                    )
+
+            threading.Thread(
+                target=_background_udi_sync,
+                args=(channel_id, channel_name),
+                daemon=True,
+                name=f"udi-sync-ch{channel_id}",
+            ).start()
 
             return {
                 'success': True,

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -94,6 +94,57 @@ from apps.stream.stream_checker_components import (
     StreamCheckerProgress,
 )
 
+def _wait_for_udi_stream_count_stabilise(
+    udi,
+    pre_count: int,
+    timeout: int = 60,
+    poll_interval: int = 5,
+) -> bool:
+    """Poll UDI stream count after triggering a Dispatcharr playlist refresh.
+
+    Dispatcharr processes M3U playlists asynchronously. The refresh API call
+    returns as soon as the job is *enqueued*, not when it completes. Immediately
+    syncing the UDI cache after the call often returns pre-refresh data.
+
+    This helper polls the UDI stream count until it changes from pre_count
+    (indicating Dispatcharr has finished processing) or until timeout elapses.
+    It reuses the same poll-and-confirm pattern used in the startup sequence.
+
+    Args:
+        udi: Initialised UDI manager instance.
+        pre_count: Stream count captured before refresh_m3u_playlists() was called.
+        timeout: Maximum seconds to wait before giving up (default 60).
+        poll_interval: Seconds between each poll attempt (default 5).
+
+    Returns:
+        True  — stream count changed; refresh appears to have taken effect.
+        False — timed out with no change; downstream steps proceed on
+                potentially stale data (logged as a warning).
+    """
+    elapsed = 0
+    while elapsed < timeout:
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+        try:
+            current_count = len(udi.get_streams() or [])
+            if current_count != pre_count:
+                logger.info(
+                    f"UDI stream count changed after playlist refresh: "
+                    f"{pre_count} → {current_count} ({elapsed}s elapsed)"
+                )
+                return True
+        except Exception as _e:
+            logger.warning(
+                f"Error polling UDI stream count during post-refresh wait: {_e}"
+            )
+    logger.warning(
+        f"UDI stream count unchanged after {timeout}s (still {pre_count} streams). "
+        "Proceeding with potentially stale data. "
+        "Consider setting post_refresh_delay_seconds in config if this recurs."
+    )
+    return False
+
+
 class StreamCheckerService:
     """Main service for managing stream checking operations."""
     
@@ -3223,10 +3274,16 @@ class StreamCheckerService:
                     'channel_name': channel_name,
                 }
 
-            matching_enabled = profile.get('stream_matching', {}).get('enabled', False)
-            checking_enabled = profile.get('stream_checking', {}).get('enabled', False)
+            m3u_update_enabled = profile.get('m3u_update', {}).get('enabled', False)
+            matching_enabled   = profile.get('stream_matching', {}).get('enabled', False)
+            checking_enabled   = profile.get('stream_checking', {}).get('enabled', False)
 
-            logger.info(f"Channel {channel_name} settings: matching={matching_enabled}, checking={checking_enabled}")
+            logger.info(
+                f"Channel {channel_name} profile flags: "
+                f"m3u_update={m3u_update_enabled}, "
+                f"matching={matching_enabled}, "
+                f"checking={checking_enabled}"
+            )
 
             # Signal to the frontend that this is a single channel check so the
             # stale batch progress card from the previous automation run is suppressed.
@@ -3279,25 +3336,71 @@ class StreamCheckerService:
                             account_ids.add(m3u_account)
                             logger.info(f"Found M3U account {m3u_account} from dead stream {dead_info.get('stream_name', 'Unknown')}")
             
-            # Step 2: Refresh playlists for those accounts
-            if account_ids:
-                logger.info(f"Step 2/6: Refreshing playlists for {len(account_ids)} M3U account(s)...")
+            # Step 2a: Provider fetch — only if m3u_update is enabled in the profile.
+            #
+            # IMPORTANT DISTINCTION:
+            #   m3u_update.enabled = True  → tell Dispatcharr to re-pull from the M3U
+            #                                 provider URL (two-hop: StreamFlow → Dispatcharr
+            #                                 → provider). The UDI sync in Step 2b then reads
+            #                                 the result of that provider fetch.
+            #   m3u_update.enabled = False → no provider fetch is triggered. Step 2b still
+            #                                 syncs the UDI cache from whatever Dispatcharr
+            #                                 currently has, so matching/checking see the most
+            #                                 recent known state without causing any provider churn.
+            #
+            # Dispatcharr processes M3U refreshes asynchronously. After triggering the
+            # refresh we poll the UDI stream count until it changes (confirming Dispatcharr
+            # has finished processing) before proceeding to Step 2b.
+            if m3u_update_enabled and account_ids:
+                logger.info(
+                    f"Step 2a/6: Refreshing playlists for {len(account_ids)} M3U account(s) "
+                    f"(m3u_update enabled in profile)..."
+                )
+                # Capture stream count before triggering refresh so we can detect completion.
+                pre_refresh_stream_count = len(udi.get_streams() or [])
+
                 # Import here to allow better test mocking
                 from apps.core.api_utils import refresh_m3u_playlists
                 for account_id in account_ids:
                     logger.info(f"Refreshing M3U account {account_id}")
                     refresh_m3u_playlists(account_id=account_id)
-                
-                # Refresh UDI cache to get updated streams
-                # Also refresh M3U accounts to detect any new accounts
-                # And refresh channel groups to detect any group changes
-                udi.refresh_m3u_accounts()  # Check for new M3U accounts
+
+                logger.info(
+                    "✓ Playlist refresh triggered — waiting for Dispatcharr to process..."
+                )
+                _wait_for_udi_stream_count_stabilise(
+                    udi, pre_refresh_stream_count, timeout=60
+                )
+            elif m3u_update_enabled and not account_ids:
+                logger.info(
+                    "Step 2a/6: m3u_update enabled but no M3U accounts found for this "
+                    "channel — skipping provider fetch."
+                )
+            else:
+                logger.info(
+                    "Step 2a/6: Skipping provider fetch (m3u_update disabled in profile). "
+                    "Subsequent steps will use the current UDI cache state."
+                )
+
+            # Step 2b: UDI cache sync — runs whenever a subsequent step will use the data.
+            #
+            # This is always a one-hop read (StreamFlow → Dispatcharr) and does NOT
+            # cause Dispatcharr to contact any provider. It ensures matching and checking
+            # operate on the freshest Dispatcharr state available, even when the provider
+            # fetch was skipped.
+            if matching_enabled or checking_enabled:
+                logger.debug(
+                    "Step 2b/6: Syncing UDI cache from Dispatcharr current state..."
+                )
+                udi.refresh_m3u_accounts()
                 udi.refresh_streams()
                 udi.refresh_channels()
-                udi.refresh_channel_groups()  # Check for new/updated channel groups
-                logger.info("✓ Playlists refreshed and UDI cache updated")
+                udi.refresh_channel_groups()
+                logger.info("✓ UDI cache synced")
             else:
-                logger.info("Step 2/6: No M3U accounts found for this channel, skipping playlist refresh")
+                logger.info(
+                    "Step 2b/6: Skipping UDI sync (matching and checking both disabled)."
+                )
             
             # Step 3: Clear dead streams for this channel to give them a second chance
             logger.info(f"Step 3/6: Clearing dead streams for channel {channel_name} to give them a second chance...")

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -3656,28 +3656,28 @@ class StreamCheckerService:
 
             # Background UDI sync — pull all writes from this check back into cache.
             # Runs in a daemon thread so it does not block the response to the caller.
-            # The next invocation of check_single_channel or run_automation_cycle will
-            # benefit from this refreshed cache state.
-            def _background_udi_sync(ch_id: int, ch_name: str):
-                try:
-                    _udi = get_udi_manager()
-                    _udi.refresh_streams()
-                    _udi.refresh_channel_by_id(ch_id)
-                    logger.debug(
-                        f"Background UDI sync completed for {ch_name} "
-                        f"(channel {ch_id})"
-                    )
-                except Exception as _e:
-                    logger.warning(
-                        f"Background UDI sync failed for {ch_name}: {_e}"
-                    )
+            # Guarded on is_initialized() to avoid firing during or before startup init.
+            if udi.is_initialized():
+                def _background_udi_sync(ch_id: int, ch_name: str):
+                    try:
+                        _udi = get_udi_manager()
+                        _udi.refresh_streams()
+                        _udi.refresh_channel_by_id(ch_id)
+                        logger.debug(
+                            f"Background UDI sync completed for {ch_name} "
+                            f"(channel {ch_id})"
+                        )
+                    except Exception as _e:
+                        logger.warning(
+                            f"Background UDI sync failed for {ch_name}: {_e}"
+                        )
 
-            threading.Thread(
-                target=_background_udi_sync,
-                args=(channel_id, channel_name),
-                daemon=True,
-                name=f"udi-sync-ch{channel_id}",
-            ).start()
+                threading.Thread(
+                    target=_background_udi_sync,
+                    args=(channel_id, channel_name),
+                    daemon=True,
+                    name=f"udi-sync-ch{channel_id}",
+                ).start()
 
             return {
                 'success': True,

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -3382,6 +3382,20 @@ class StreamCheckerService:
                 _wait_for_udi_stream_count_stabilise(
                     udi, pre_refresh_stream_count, timeout=60
                 )
+
+                # Sync UDI cache from Dispatcharr's now-updated stream pool.
+                #
+                # The provider fetch above caused Dispatcharr to update its internal
+                # stream database — potentially replacing stream IDs if the provider
+                # rotated them. The UDI cache is now stale relative to Dispatcharr.
+                # Syncing here ensures Steps 3-6 operate on current stream IDs,
+                # preventing Invalid pk errors when matching writes assignments back.
+                logger.info(
+                    "Step 2a/6: Syncing UDI cache after provider refresh..."
+                )
+                udi.refresh_streams()
+                udi.refresh_channels()
+                logger.info("✓ UDI cache synced — Steps 3-6 will use current stream IDs")
             elif m3u_update_enabled and not account_ids:
                 logger.info(
                     "Step 2a/6: m3u_update enabled but no M3U accounts found for this "
@@ -3393,16 +3407,16 @@ class StreamCheckerService:
                     "Subsequent steps will use the current UDI cache state."
                 )
 
-            # NOTE: No mid-pipeline UDI sync occurs here.
+            # NOTE: No mid-pipeline UDI sync occurs here except when m3u_update=True.
             #
-            # The UDI cache is the contract for all reads during this check. Whatever
-            # state the cache held at the start of this invocation is what all steps
-            # operate against. This makes the pipeline fast and deterministic.
-            #
-            # When m3u_update.enabled = True (Step 2a above), the provider fetch
-            # completed and the cache was confirmed current before reaching this point.
-            # When m3u_update.enabled = False, the existing cache is used as-is —
+            # The UDI cache is the contract for all reads during this check. When
+            # m3u_update.enabled = False, the existing cache is used as-is —
             # reflecting the last completed cycle, provider refresh, or startup init.
+            #
+            # When m3u_update.enabled = True, Step 2a fired a provider fetch that
+            # caused Dispatcharr to update its stream database. The UDI cache was
+            # synced immediately after the poll helper confirmed completion (above),
+            # so all subsequent steps see current stream IDs.
             #
             # All writes (assignments, quality scores, stream ordering) go to Dispatcharr
             # in real time during Steps 4-6. A background UDI sync fires after this

--- a/backend/apps/udi/manager.py
+++ b/backend/apps/udi/manager.py
@@ -115,6 +115,7 @@ class UDIManager:
         self.cache = UDICache()
         
         self._initialized = False
+        self._network_ready = False  # True only after a successful refresh_all() from Dispatcharr network
         self._lock = threading.Lock()
         self._refresh_thread = None
         self._refresh_running = False
@@ -319,6 +320,22 @@ class UDIManager:
             True if initialized, False otherwise
         """
         return self._initialized
+
+    def is_network_ready(self) -> bool:
+        """Check if the UDI Manager has completed a successful live refresh from Dispatcharr.
+
+        Distinct from is_initialized() which returns True even when data was loaded
+        from SQL storage at startup (potentially stale — zero streams, zero M3U accounts).
+
+        Background workers, scheduled event processors, automation loops, and queue
+        workers must use this guard before operating against the stream pool to avoid
+        acting on empty or stale startup cache state.
+
+        Returns:
+            True only after refresh_all() completed successfully from the Dispatcharr
+            network. False during startup before the network refresh finishes.
+        """
+        return self._network_ready
     
     def get_channels(self) -> List[Dict[str, Any]]:
         """Get all channels.
@@ -756,6 +773,9 @@ class UDIManager:
                 current_step='done',
                 entity_counts=entity_counts,
             )
+            # Mark network as ready — distinguishes a live Dispatcharr fetch from
+            # a load from SQL storage at startup (which may have stale/empty data).
+            self._network_ready = True
             return True
             
         except Exception as e:

--- a/backend/tests/test_automation_checking_only_profiles.py
+++ b/backend/tests/test_automation_checking_only_profiles.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""
+Tests for checking-only channel queue gap fix in _discover_and_assign_streams_impl().
+
+Covers:
+  - Channels with matching=False, checking=True are queued for the checker
+    after the matching pass completes
+  - Those channels are NOT included in the matching/assignment pass itself
+  - Channels with both matching=False and checking=False are not queued
+  - forced_period_id filtering is respected for checking-only collection
+  - Mixed-profile cycles (some matching+checking, some checking-only) both complete
+"""
+
+import sys
+import os
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock, call
+
+# Add backend directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_profile(matching_enabled=True, checking_enabled=True):
+    return {
+        'name': 'Test Profile',
+        'm3u_update': {'enabled': False, 'playlists': []},
+        'stream_matching': {'enabled': matching_enabled},
+        'stream_checking': {'enabled': checking_enabled, 'grace_period': False, 'allow_revive': False},
+        'global_action': {'affected': False},
+    }
+
+
+def _make_channel(channel_id, name='Channel', group_id=None):
+    return {
+        'id': channel_id,
+        'name': name,
+        'channel_group_id': group_id,
+        'group_id': group_id,
+        'streams': [],
+        'tvg_id': f'ch.{channel_id}',
+    }
+
+
+class TestCheckingOnlyChannelQueueGap(unittest.TestCase):
+    """Channels with matching=False, checking=True must be queued after matching pass."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _build_manager(self):
+        from apps.automation.automated_stream_manager import AutomatedStreamManager
+        with patch('automated_stream_manager.CONFIG_DIR', Path(self.temp_dir)):
+            mgr = AutomatedStreamManager()
+        mgr.changelog = Mock()
+        mgr._lock = __import__('threading').Lock()
+        return mgr
+
+    @patch('automated_stream_manager.get_udi_manager')
+    @patch('automated_stream_manager.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_stream_checker_service')
+    def test_checking_only_channels_queued_after_matching_pass(
+        self, mock_get_scs, mock_get_acm, mock_get_udi,
+    ):
+        """Channels with matching=False, checking=True appear in mark_channels_updated."""
+        matching_profile = _make_profile(matching_enabled=True, checking_enabled=True)
+        checking_only_profile = _make_profile(matching_enabled=False, checking_enabled=True)
+
+        ch_matching = _make_channel(101, 'Matching Channel')
+        ch_checking = _make_channel(102, 'Checking Only Channel')
+
+        mock_udi = Mock()
+        mock_udi.get_channels.return_value = [ch_matching, ch_checking]
+        mock_udi.get_streams.return_value = []
+        mock_udi.get_m3u_accounts.return_value = []
+        mock_udi.get_channel_by_id.side_effect = lambda cid: (
+            ch_matching if cid == 101 else ch_checking
+        )
+        mock_get_udi.return_value = mock_udi
+
+        mock_acm = Mock()
+
+        def _effective_config(channel_id, group_id=None):
+            profile = matching_profile if channel_id == 101 else checking_only_profile
+            return {
+                'profile': profile,
+                'periods': [{'id': 'p1', 'profile': profile}],
+                'period_id': 'p1',
+            }
+
+        mock_acm.get_effective_configuration.side_effect = _effective_config
+        mock_get_acm.return_value = mock_acm
+
+        mock_tracker = Mock()
+        mock_scs = Mock()
+        mock_scs.update_tracker = mock_tracker
+        mock_get_scs.return_value = mock_scs
+
+        mgr = self._build_manager()
+        mgr.regex_matcher = Mock()
+        mgr.regex_matcher.get_patterns.return_value = {'patterns': {}, 'global_settings': {}}
+
+        with patch.object(mgr, 'validate_and_remove_non_matching_streams', return_value={'details': []}), \
+             patch('automated_stream_manager.get_streams', return_value=[]), \
+             patch('automated_stream_manager.add_streams_to_channel', return_value=True):
+
+            mgr._discover_and_assign_streams_impl(
+                force=True, skip_check_trigger=False, channel_id=None
+            )
+
+        # mark_channels_updated must have been called at some point for channel 102
+        all_calls = mock_tracker.mark_channels_updated.call_args_list
+        all_marked_ids = []
+        for c in all_calls:
+            args = c[0]
+            if args:
+                all_marked_ids.extend(args[0])
+
+        self.assertIn(102, all_marked_ids,
+                      "Checking-only channel 102 must be marked for quality checking")
+
+    @patch('automated_stream_manager.get_udi_manager')
+    @patch('automated_stream_manager.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_stream_checker_service')
+    def test_checking_only_channels_excluded_from_matching_pass(
+        self, mock_get_scs, mock_get_acm, mock_get_udi,
+    ):
+        """Channels with matching=False must NOT appear in stream assignment calls."""
+        matching_profile = _make_profile(matching_enabled=True, checking_enabled=True)
+        checking_only_profile = _make_profile(matching_enabled=False, checking_enabled=True)
+
+        ch_matching = _make_channel(201)
+        ch_checking = _make_channel(202)
+
+        mock_udi = Mock()
+        mock_udi.get_channels.return_value = [ch_matching, ch_checking]
+        mock_udi.get_streams.return_value = []
+        mock_udi.get_m3u_accounts.return_value = []
+        mock_udi.get_channel_by_id.side_effect = lambda cid: (
+            ch_matching if cid == 201 else ch_checking
+        )
+        mock_get_udi.return_value = mock_udi
+
+        mock_acm = Mock()
+        mock_acm.get_effective_configuration.side_effect = lambda cid, gid=None: {
+            'profile': matching_profile if cid == 201 else checking_only_profile,
+            'periods': [{'id': 'p1', 'profile': matching_profile if cid == 201 else checking_only_profile}],
+        }
+        mock_get_acm.return_value = mock_acm
+
+        mock_get_scs.return_value = Mock()
+        mock_get_scs.return_value.update_tracker = Mock()
+
+        assigned_channel_ids = []
+
+        def _mock_add_streams(channel_id, stream_ids, **kwargs):
+            assigned_channel_ids.append(channel_id)
+            return True
+
+        mgr = self._build_manager()
+        mgr.regex_matcher = Mock()
+        mgr.regex_matcher.get_patterns.return_value = {'patterns': {}, 'global_settings': {}}
+
+        with patch.object(mgr, 'validate_and_remove_non_matching_streams', return_value={'details': []}), \
+             patch('automated_stream_manager.get_streams', return_value=[]), \
+             patch('automated_stream_manager.add_streams_to_channel', side_effect=_mock_add_streams):
+
+            mgr._discover_and_assign_streams_impl(force=True, skip_check_trigger=True)
+
+        self.assertNotIn(202, assigned_channel_ids,
+                         "Checking-only channel 202 must not appear in stream assignment calls")
+
+    @patch('automated_stream_manager.get_udi_manager')
+    @patch('automated_stream_manager.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_stream_checker_service')
+    def test_matching_and_checking_false_not_queued(
+        self, mock_get_scs, mock_get_acm, mock_get_udi,
+    ):
+        """Channels with both matching=False and checking=False must not be queued."""
+        noop_profile = _make_profile(matching_enabled=False, checking_enabled=False)
+        ch = _make_channel(301)
+
+        mock_udi = Mock()
+        mock_udi.get_channels.return_value = [ch]
+        mock_udi.get_streams.return_value = []
+        mock_udi.get_m3u_accounts.return_value = []
+        mock_udi.get_channel_by_id.return_value = ch
+        mock_get_udi.return_value = mock_udi
+
+        mock_acm = Mock()
+        mock_acm.get_effective_configuration.return_value = {
+            'profile': noop_profile,
+            'periods': [{'id': 'p1', 'profile': noop_profile}],
+        }
+        mock_get_acm.return_value = mock_acm
+
+        mock_tracker = Mock()
+        mock_scs = Mock()
+        mock_scs.update_tracker = mock_tracker
+        mock_get_scs.return_value = mock_scs
+
+        mgr = self._build_manager()
+        mgr.regex_matcher = Mock()
+        mgr.regex_matcher.get_patterns.return_value = {'patterns': {}, 'global_settings': {}}
+
+        with patch.object(mgr, 'validate_and_remove_non_matching_streams', return_value={'details': []}), \
+             patch('automated_stream_manager.get_streams', return_value=[]), \
+             patch('automated_stream_manager.add_streams_to_channel', return_value=True):
+
+            mgr._discover_and_assign_streams_impl(force=True, skip_check_trigger=True)
+
+        # mark_channels_updated should not have been called with channel 301
+        all_calls = mock_tracker.mark_channels_updated.call_args_list
+        all_marked_ids = []
+        for c in all_calls:
+            args = c[0]
+            if args:
+                all_marked_ids.extend(args[0])
+
+        self.assertNotIn(301, all_marked_ids,
+                         "No-op channel 301 must not be queued for checking")
+
+    @patch('automated_stream_manager.get_udi_manager')
+    @patch('automated_stream_manager.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_stream_checker_service')
+    def test_forced_period_id_respected_for_checking_only_collection(
+        self, mock_get_scs, mock_get_acm, mock_get_udi,
+    ):
+        """forced_period_id must filter checking-only collection the same as matching pass."""
+        period_a = 'period-a'
+        period_b = 'period-b'
+
+        profile_a = _make_profile(matching_enabled=False, checking_enabled=True)
+        profile_b = _make_profile(matching_enabled=False, checking_enabled=True)
+
+        ch_a = _make_channel(401)  # belongs to period_a
+        ch_b = _make_channel(402)  # belongs to period_b
+
+        mock_udi = Mock()
+        mock_udi.get_channels.return_value = [ch_a, ch_b]
+        mock_udi.get_streams.return_value = []
+        mock_udi.get_m3u_accounts.return_value = []
+        mock_udi.get_channel_by_id.side_effect = lambda cid: (
+            ch_a if cid == 401 else ch_b
+        )
+        mock_get_udi.return_value = mock_udi
+
+        def _config(cid, gid=None):
+            if cid == 401:
+                return {
+                    'profile': profile_a,
+                    'periods': [{'id': period_a, 'profile': profile_a}],
+                }
+            return {
+                'profile': profile_b,
+                'periods': [{'id': period_b, 'profile': profile_b}],
+            }
+
+        mock_acm = Mock()
+        mock_acm.get_effective_configuration.side_effect = _config
+        mock_get_acm.return_value = mock_acm
+
+        mock_tracker = Mock()
+        mock_scs = Mock()
+        mock_scs.update_tracker = mock_tracker
+        mock_get_scs.return_value = mock_scs
+
+        mgr = self._build_manager()
+        mgr.regex_matcher = Mock()
+        mgr.regex_matcher.get_patterns.return_value = {'patterns': {}, 'global_settings': {}}
+
+        with patch.object(mgr, 'validate_and_remove_non_matching_streams', return_value={'details': []}), \
+             patch('automated_stream_manager.get_streams', return_value=[]), \
+             patch('automated_stream_manager.add_streams_to_channel', return_value=True):
+
+            # Force only period_a to run
+            mgr._discover_and_assign_streams_impl(
+                force=True,
+                skip_check_trigger=True,
+                forced_period_id=period_a,
+            )
+
+        all_calls = mock_tracker.mark_channels_updated.call_args_list
+        all_marked_ids = []
+        for c in all_calls:
+            args = c[0]
+            if args:
+                all_marked_ids.extend(args[0])
+
+        self.assertIn(401, all_marked_ids,
+                      "Channel 401 (period_a) must be queued when forced_period_id=period_a")
+        self.assertNotIn(402, all_marked_ids,
+                         "Channel 402 (period_b) must NOT be queued when forced_period_id=period_a")
+
+    @patch('automated_stream_manager.get_udi_manager')
+    @patch('automated_stream_manager.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_stream_checker_service')
+    def test_skip_check_trigger_respected_for_checking_only(
+        self, mock_get_scs, mock_get_acm, mock_get_udi,
+    ):
+        """When skip_check_trigger=True, trigger_check_updated_channels must not be called."""
+        checking_only_profile = _make_profile(matching_enabled=False, checking_enabled=True)
+        ch = _make_channel(501)
+
+        mock_udi = Mock()
+        mock_udi.get_channels.return_value = [ch]
+        mock_udi.get_streams.return_value = []
+        mock_udi.get_m3u_accounts.return_value = []
+        mock_udi.get_channel_by_id.return_value = ch
+        mock_get_udi.return_value = mock_udi
+
+        mock_acm = Mock()
+        mock_acm.get_effective_configuration.return_value = {
+            'profile': checking_only_profile,
+            'periods': [{'id': 'p1', 'profile': checking_only_profile}],
+        }
+        mock_get_acm.return_value = mock_acm
+
+        mock_tracker = Mock()
+        mock_scs = Mock()
+        mock_scs.update_tracker = mock_tracker
+        mock_scs.trigger_check_updated_channels = Mock()
+        mock_get_scs.return_value = mock_scs
+
+        mgr = self._build_manager()
+        mgr.regex_matcher = Mock()
+        mgr.regex_matcher.get_patterns.return_value = {'patterns': {}, 'global_settings': {}}
+
+        with patch.object(mgr, 'validate_and_remove_non_matching_streams', return_value={'details': []}), \
+             patch('automated_stream_manager.get_streams', return_value=[]), \
+             patch('automated_stream_manager.add_streams_to_channel', return_value=True):
+
+            mgr._discover_and_assign_streams_impl(
+                force=True, skip_check_trigger=True
+            )
+
+        mock_scs.trigger_check_updated_channels.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/backend/tests/test_stream_checker_single_channel_profile_flags.py
+++ b/backend/tests/test_stream_checker_single_channel_profile_flags.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""
+Tests for single-channel profile flag enforcement in check_single_channel().
+
+Covers:
+  - m3u_update.enabled = False skips the Dispatcharr provider fetch
+  - m3u_update.enabled = False still syncs UDI when matching or checking is enabled
+  - m3u_update.enabled = False with all flags off skips UDI sync entirely
+  - m3u_update.enabled = True calls provider fetch then UDI sync
+  - Step 3 (dead stream clearing) is unconditional regardless of flags
+  - _wait_for_udi_stream_count_stabilise returns correctly
+"""
+
+import sys
+import os
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock, call
+
+# Add backend directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers — mirrors the pattern used in test_stream_checker_profile_flags.py
+# ---------------------------------------------------------------------------
+
+def _make_profile(
+    m3u_update_enabled=False,
+    matching_enabled=False,
+    checking_enabled=False,
+):
+    return {
+        'name': 'Test Profile',
+        'm3u_update': {'enabled': m3u_update_enabled, 'playlists': []},
+        'stream_matching': {'enabled': matching_enabled},
+        'stream_checking': {
+            'enabled': checking_enabled,
+            'grace_period': False,
+            'allow_revive': False,
+            'check_all_streams': False,
+            'stream_limit': 0,
+            'm3u_priority': [],
+            'm3u_priority_mode': 'absolute',
+        },
+        'scoring_weights': {
+            'bitrate': 0.35, 'resolution': 0.30, 'fps': 0.15,
+            'codec': 0.10, 'hdr': 0.10, 'prefer_h265': True,
+        },
+    }
+
+
+def _make_mock_config():
+    cfg = Mock()
+    cfg.get = Mock(side_effect=lambda key, default=None: default)
+    cfg.is_auto_quality_checking_enabled = Mock(return_value=True)
+    return cfg
+
+
+def _make_mock_udi(channel_id, channel_name, streams):
+    udi = Mock()
+    udi.get_channel_by_id.return_value = {
+        'id': channel_id,
+        'name': channel_name,
+        'channel_group_id': None,
+        'logo_id': None,
+        'streams': [s['id'] for s in streams],
+    }
+    udi.get_streams.return_value = streams
+    udi.get_stream_by_id.return_value = None
+    udi.refresh_streams = Mock()
+    udi.refresh_channels = Mock()
+    udi.refresh_m3u_accounts = Mock()
+    udi.refresh_channel_groups = Mock()
+    udi.refresh_channel_by_id = Mock()
+    return udi
+
+
+def _make_mock_acm(profile):
+    acm = Mock()
+    acm.get_profile.return_value = None
+    acm.get_effective_epg_scheduled_profile.return_value = None
+    acm.get_effective_configuration.return_value = {'profile': profile, 'periods': []}
+    return acm
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSingleChannelM3uUpdateFlagDisabled(unittest.TestCase):
+    """m3u_update.enabled = False must skip the provider fetch."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    @patch('stream_checker_service.fetch_channel_streams')
+    def test_m3u_update_disabled_skips_playlist_refresh_api_call(
+        self, mock_fetch, mock_session_mgr, mock_acm_factory,
+        mock_config_class, mock_get_udi,
+    ):
+        """When m3u_update.enabled is False, refresh_m3u_playlists must NOT be called."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        profile = _make_profile(m3u_update_enabled=False, matching_enabled=False, checking_enabled=True)
+        channel_id = 42
+        streams = [{'id': 1, 'url': 'http://x/1', 'm3u_account': 5, 'stream_stats': {}}]
+
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'Test Channel', streams)
+        mock_session_mgr.return_value.get_channels_in_active_sessions.return_value = []
+        mock_acm_factory.return_value = _make_mock_acm(profile)
+        mock_fetch.return_value = streams
+
+        service = StreamCheckerService()
+        service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0, 'analyzed_streams': []})
+        # Stub dead streams tracker
+        service.dead_streams_tracker = Mock()
+        service.dead_streams_tracker.get_dead_streams_for_channel.return_value = {}
+        service.dead_streams_tracker.clear_dead_streams_for_channel = Mock()
+
+        with patch('apps.core.api_utils.refresh_m3u_playlists') as mock_refresh, \
+             patch('stream_checker_service._wait_for_udi_stream_count_stabilise') as mock_poll:
+            service.check_single_channel(channel_id=channel_id)
+
+        mock_refresh.assert_not_called(), "refresh_m3u_playlists must not be called when m3u_update.enabled=False"
+        mock_poll.assert_not_called(), "_wait_for_udi_stream_count_stabilise must not be called when update disabled"
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    @patch('stream_checker_service.fetch_channel_streams')
+    def test_m3u_update_disabled_still_syncs_udi_when_checking_enabled(
+        self, mock_fetch, mock_session_mgr, mock_acm_factory,
+        mock_config_class, mock_get_udi,
+    ):
+        """When m3u_update=False but checking=True, UDI sync calls must still happen."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        profile = _make_profile(m3u_update_enabled=False, matching_enabled=False, checking_enabled=True)
+        channel_id = 43
+        streams = [{'id': 2, 'url': 'http://x/2', 'm3u_account': 5, 'stream_stats': {}}]
+
+        mock_config_class.return_value = _make_mock_config()
+        mock_udi = _make_mock_udi(channel_id, 'Test Channel', streams)
+        mock_get_udi.return_value = mock_udi
+        mock_session_mgr.return_value.get_channels_in_active_sessions.return_value = []
+        mock_acm_factory.return_value = _make_mock_acm(profile)
+        mock_fetch.return_value = streams
+
+        service = StreamCheckerService()
+        service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0, 'analyzed_streams': []})
+        service.dead_streams_tracker = Mock()
+        service.dead_streams_tracker.get_dead_streams_for_channel.return_value = {}
+        service.dead_streams_tracker.clear_dead_streams_for_channel = Mock()
+
+        with patch('apps.core.api_utils.refresh_m3u_playlists'):
+            service.check_single_channel(channel_id=channel_id)
+
+        mock_udi.refresh_streams.assert_called(), "UDI refresh_streams must be called even when m3u_update=False"
+        mock_udi.refresh_channels.assert_called(), "UDI refresh_channels must be called"
+        mock_udi.refresh_m3u_accounts.assert_called(), "UDI refresh_m3u_accounts must be called"
+        mock_udi.refresh_channel_groups.assert_called(), "UDI refresh_channel_groups must be called"
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    @patch('stream_checker_service.fetch_channel_streams')
+    def test_m3u_update_disabled_still_syncs_udi_when_matching_enabled(
+        self, mock_fetch, mock_session_mgr, mock_acm_factory,
+        mock_config_class, mock_get_udi,
+    ):
+        """When m3u_update=False but matching=True, UDI sync must happen so matching sees fresh data."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        profile = _make_profile(m3u_update_enabled=False, matching_enabled=True, checking_enabled=False)
+        channel_id = 44
+        streams = [{'id': 3, 'url': 'http://x/3', 'm3u_account': 5, 'stream_stats': {}}]
+
+        mock_config_class.return_value = _make_mock_config()
+        mock_udi = _make_mock_udi(channel_id, 'Test Channel', streams)
+        mock_get_udi.return_value = mock_udi
+        mock_session_mgr.return_value.get_channels_in_active_sessions.return_value = []
+        mock_acm_factory.return_value = _make_mock_acm(profile)
+        mock_fetch.return_value = streams
+
+        service = StreamCheckerService()
+        service.dead_streams_tracker = Mock()
+        service.dead_streams_tracker.get_dead_streams_for_channel.return_value = {}
+        service.dead_streams_tracker.clear_dead_streams_for_channel = Mock()
+
+        with patch('apps.core.api_utils.refresh_m3u_playlists'), \
+             patch('automated_stream_manager.AutomatedStreamManager') as mock_asm:
+            mock_asm.return_value.discover_and_assign_streams = Mock(return_value={})
+            mock_asm.return_value.validate_and_remove_non_matching_streams = Mock(return_value={})
+            service.check_single_channel(channel_id=channel_id)
+
+        mock_udi.refresh_streams.assert_called()
+        mock_udi.refresh_channels.assert_called()
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    @patch('stream_checker_service.fetch_channel_streams')
+    def test_all_flags_false_skips_both_refresh_and_udi_sync(
+        self, mock_fetch, mock_session_mgr, mock_acm_factory,
+        mock_config_class, mock_get_udi,
+    ):
+        """When all three flags are False, no provider fetch and no UDI sync should occur."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        profile = _make_profile(m3u_update_enabled=False, matching_enabled=False, checking_enabled=False)
+        channel_id = 45
+        streams = [{'id': 4, 'url': 'http://x/4', 'm3u_account': 5, 'stream_stats': {}}]
+
+        mock_config_class.return_value = _make_mock_config()
+        mock_udi = _make_mock_udi(channel_id, 'Test Channel', streams)
+        mock_get_udi.return_value = mock_udi
+        mock_session_mgr.return_value.get_channels_in_active_sessions.return_value = []
+        mock_acm_factory.return_value = _make_mock_acm(profile)
+        mock_fetch.return_value = streams
+
+        service = StreamCheckerService()
+        service.dead_streams_tracker = Mock()
+        service.dead_streams_tracker.get_dead_streams_for_channel.return_value = {}
+        service.dead_streams_tracker.clear_dead_streams_for_channel = Mock()
+
+        with patch('apps.core.api_utils.refresh_m3u_playlists') as mock_refresh:
+            service.check_single_channel(channel_id=channel_id)
+
+        mock_refresh.assert_not_called()
+        mock_udi.refresh_streams.assert_not_called()
+        mock_udi.refresh_channels.assert_not_called()
+        mock_udi.refresh_m3u_accounts.assert_not_called()
+        mock_udi.refresh_channel_groups.assert_not_called()
+
+
+class TestSingleChannelM3uUpdateFlagEnabled(unittest.TestCase):
+    """m3u_update.enabled = True must call provider fetch then UDI sync."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    @patch('stream_checker_service.fetch_channel_streams')
+    def test_m3u_update_enabled_calls_refresh_then_syncs_udi(
+        self, mock_fetch, mock_session_mgr, mock_acm_factory,
+        mock_config_class, mock_get_udi,
+    ):
+        """When m3u_update=True: provider fetch fires, poll helper fires, then UDI sync fires."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        profile = _make_profile(m3u_update_enabled=True, matching_enabled=False, checking_enabled=True)
+        channel_id = 46
+        streams = [{'id': 5, 'url': 'http://x/5', 'm3u_account': 7, 'stream_stats': {}}]
+
+        mock_config_class.return_value = _make_mock_config()
+        mock_udi = _make_mock_udi(channel_id, 'Test Channel', streams)
+        mock_get_udi.return_value = mock_udi
+        mock_session_mgr.return_value.get_channels_in_active_sessions.return_value = []
+        mock_acm_factory.return_value = _make_mock_acm(profile)
+        mock_fetch.return_value = streams
+
+        service = StreamCheckerService()
+        service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0, 'analyzed_streams': []})
+        service.dead_streams_tracker = Mock()
+        service.dead_streams_tracker.get_dead_streams_for_channel.return_value = {}
+        service.dead_streams_tracker.clear_dead_streams_for_channel = Mock()
+
+        call_order = []
+
+        with patch('apps.core.api_utils.refresh_m3u_playlists',
+                   side_effect=lambda account_id=None: call_order.append('refresh')) as mock_refresh, \
+             patch('stream_checker_service._wait_for_udi_stream_count_stabilise',
+                   side_effect=lambda *a, **kw: call_order.append('poll') or True) as mock_poll:
+
+            # Patch UDI sync methods to record order
+            original_refresh_streams = mock_udi.refresh_streams
+            mock_udi.refresh_streams.side_effect = lambda: call_order.append('udi_sync')
+
+            service.check_single_channel(channel_id=channel_id)
+
+        mock_refresh.assert_called_once_with(account_id=7)
+        mock_poll.assert_called_once()
+
+        # Verify order: refresh → poll → udi_sync
+        refresh_idx = next((i for i, v in enumerate(call_order) if v == 'refresh'), -1)
+        poll_idx = next((i for i, v in enumerate(call_order) if v == 'poll'), -1)
+        udi_idx = next((i for i, v in enumerate(call_order) if v == 'udi_sync'), -1)
+
+        self.assertGreater(poll_idx, refresh_idx, "Poll must happen after provider refresh")
+        self.assertGreater(udi_idx, poll_idx, "UDI sync must happen after poll confirms completion")
+
+
+class TestStep3DeadStreamClearIsUnconditional(unittest.TestCase):
+    """Step 3 (dead stream clearing) must run regardless of flag state."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    @patch('stream_checker_service.fetch_channel_streams')
+    def test_dead_stream_clear_runs_with_all_flags_off(
+        self, mock_fetch, mock_session_mgr, mock_acm_factory,
+        mock_config_class, mock_get_udi,
+    ):
+        """Even with all three flags False, dead streams must be cleared (Step 3)."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        # All flags off — a no-op profile from the user's perspective, but
+        # Step 3 is unconditional and must still fire.
+        profile = _make_profile(m3u_update_enabled=False, matching_enabled=False, checking_enabled=False)
+        channel_id = 47
+        streams = [{'id': 6, 'url': 'http://x/6', 'm3u_account': 3, 'stream_stats': {}}]
+
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'Test Channel', streams)
+        mock_session_mgr.return_value.get_channels_in_active_sessions.return_value = []
+        mock_acm_factory.return_value = _make_mock_acm(profile)
+        mock_fetch.return_value = streams
+
+        service = StreamCheckerService()
+        mock_tracker = Mock()
+        mock_tracker.get_dead_streams_for_channel.return_value = {}
+        mock_tracker.clear_dead_streams_for_channel = Mock()
+        service.dead_streams_tracker = mock_tracker
+
+        with patch('apps.core.api_utils.refresh_m3u_playlists'):
+            service.check_single_channel(channel_id=channel_id)
+
+        mock_tracker.clear_dead_streams_for_channel.assert_called_with(channel_id)
+
+    @patch('stream_checker_service.get_udi_manager')
+    @patch('stream_checker_service.StreamCheckConfig')
+    @patch('apps.stream.stream_checker_service.get_automation_config_manager')
+    @patch('apps.stream.stream_checker_service.get_session_manager')
+    @patch('stream_checker_service.fetch_channel_streams')
+    def test_dead_stream_clear_runs_with_checking_only_profile(
+        self, mock_fetch, mock_session_mgr, mock_acm_factory,
+        mock_config_class, mock_get_udi,
+    ):
+        """Checking-only profile: dead streams cleared before check runs."""
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        profile = _make_profile(m3u_update_enabled=False, matching_enabled=False, checking_enabled=True)
+        channel_id = 48
+        streams = [{'id': 7, 'url': 'http://x/7', 'm3u_account': 3, 'stream_stats': {}}]
+
+        mock_config_class.return_value = _make_mock_config()
+        mock_get_udi.return_value = _make_mock_udi(channel_id, 'Test Channel', streams)
+        mock_session_mgr.return_value.get_channels_in_active_sessions.return_value = []
+        mock_acm_factory.return_value = _make_mock_acm(profile)
+        mock_fetch.return_value = streams
+
+        service = StreamCheckerService()
+        service._check_channel = Mock(return_value={'dead_streams_count': 0, 'revived_streams_count': 0, 'analyzed_streams': []})
+        mock_tracker = Mock()
+        mock_tracker.get_dead_streams_for_channel.return_value = {}
+        mock_tracker.clear_dead_streams_for_channel = Mock()
+        service.dead_streams_tracker = mock_tracker
+
+        with patch('apps.core.api_utils.refresh_m3u_playlists'):
+            service.check_single_channel(channel_id=channel_id)
+
+        mock_tracker.clear_dead_streams_for_channel.assert_called_with(channel_id)
+
+
+class TestWaitForUdiStreamCountStabilise(unittest.TestCase):
+    """Unit tests for _wait_for_udi_stream_count_stabilise helper."""
+
+    def test_returns_true_when_count_changes(self):
+        from apps.stream.stream_checker_service import _wait_for_udi_stream_count_stabilise
+        import time
+
+        mock_udi = Mock()
+        # First poll: unchanged. Second poll: changed.
+        mock_udi.get_streams.side_effect = [
+            [{'id': i} for i in range(100)],   # poll 1 — same as pre_count
+            [{'id': i} for i in range(105)],   # poll 2 — changed
+        ]
+
+        with patch('time.sleep'):
+            result = _wait_for_udi_stream_count_stabilise(
+                mock_udi, pre_count=100, timeout=30, poll_interval=5
+            )
+
+        self.assertTrue(result)
+
+    def test_returns_false_on_timeout_with_no_change(self):
+        from apps.stream.stream_checker_service import _wait_for_udi_stream_count_stabilise
+
+        mock_udi = Mock()
+        # Always returns same count
+        mock_udi.get_streams.return_value = [{'id': i} for i in range(100)]
+
+        with patch('time.sleep'):
+            result = _wait_for_udi_stream_count_stabilise(
+                mock_udi, pre_count=100, timeout=10, poll_interval=5
+            )
+
+        self.assertFalse(result)
+
+    def test_handles_udi_exception_gracefully(self):
+        from apps.stream.stream_checker_service import _wait_for_udi_stream_count_stabilise
+
+        mock_udi = Mock()
+        # First call raises, second returns changed count
+        mock_udi.get_streams.side_effect = [
+            Exception("UDI unavailable"),
+            [{'id': i} for i in range(105)],
+        ]
+
+        with patch('time.sleep'):
+            result = _wait_for_udi_stream_count_stabilise(
+                mock_udi, pre_count=100, timeout=30, poll_interval=5
+            )
+
+        # Should recover from the exception and detect the change on the second poll
+        self.assertTrue(result)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This PR establishes the UDI cache as the authoritative data source for all automation operations, enforces automation profile flags correctly across both the single-channel and batch automation paths, and ensures fresh provider data is available when the update playlist flag demands it.

UDI Cache as Primary Source of Truth

The UDI in-memory cache now serves as the contract for all reads during a cycle or health check. No mid-pipeline network calls to Dispatcharr occur unless a provider refresh was explicitly requested. After each cycle or check completes, a background daemon thread syncs all writes back into the cache for the next run — non-blocking, invisible to the caller.

Profile Flag Enforcement

All three automation profile flags — m3u_update, stream_matching, and stream_checking — are now correctly read and respected across both paths. Channels with checking enabled but matching disabled were previously silently dropped from the batch queue; they are now correctly collected and queued for quality checking. Single-channel health checks now honour the m3u_update flag rather than ignoring it entirely.

Update Playlist as the Gateway to Fresh Data

When m3u_update is enabled, the system tells Dispatcharr to re-fetch from the provider, waits for processing to complete, then immediately syncs the UDI cache before matching proceeds. This eliminates stale stream ID writes, makes the automation safety gate meaningful for the first time, and produces accurate playlist changelog deltas — previously always recorded as zero. When m3u_update is disabled, the existing cache is used as-is, making checking-only cycles dramatically faster.

Performance and Dispatcharr Stability

Previously, every single-channel health check triggered a full 35-45 second blocking fetch of the entire stream pool regardless of which flags were active. Automation cycles compounded this with additional mid-pipeline syncs that fired unconditionally. This created continuous, overlapping read pressure against Dispatcharr throughout every operation. Under the cache-first model, Dispatcharr is only contacted when work genuinely requires it — provider fetches when m3u_update is enabled, and a single post-cycle background sync to capture writes. In production testing, checking-only batch cycles dropped from over one hour to 22 minutes, and single-channel checking-only health checks became near-instantaneous. Dispatcharr now operates in stable bursts rather than under sustained polling load.

Startup Guards

All background workers — automation loop, scheduled event processor, channel queue workers — now gate on is_network_ready(), a new UDI manager method that distinguishes a live Dispatcharr network refresh from a cold SQL storage load, preventing premature execution against an empty cache.