### PR TITLE
Scheduled UDI Cache Refresh

### DIFF
--- a/backend/apps/api/scheduling_handlers.py
+++ b/backend/apps/api/scheduling_handlers.py
@@ -470,3 +470,134 @@ def trigger_epg_refresh_response(*, epg_refresh_wake: Any, epg_refresh_running: 
     except Exception as exc:
         logger.error(f"Error triggering EPG refresh: {exc}")
         return jsonify({"error": "Internal Server Error"}), 500
+
+
+# ── UDI Refresh Processor handlers ──────────────────────────────────────────
+# Mirror the EPG refresh handler pattern exactly.
+
+def get_udi_refresh_processor_status_response(*, udi_refresh_thread: Any, udi_refresh_running: bool):
+    """Handle retrieval of UDI refresh processor status."""
+    try:
+        thread_alive = (
+            udi_refresh_thread is not None
+            and hasattr(udi_refresh_thread, "is_alive")
+            and udi_refresh_thread.is_alive()
+        )
+        is_running = thread_alive and udi_refresh_running
+        return jsonify({"running": is_running, "thread_alive": thread_alive}), 200
+    except Exception as exc:
+        logger.error(f"Error getting UDI refresh processor status: {exc}")
+        return jsonify({"error": "Internal Server Error"}), 500
+
+
+def start_udi_refresh_processor_api_response(*, start_udi_refresh_processor: Callable[[], Any]):
+    """Handle start request for UDI refresh processor."""
+    try:
+        success = start_udi_refresh_processor()
+        if success:
+            return jsonify({"message": "UDI refresh processor started"}), 200
+        return jsonify({"message": "UDI refresh processor is already running"}), 200
+    except Exception as exc:
+        logger.error(f"Error starting UDI refresh processor: {exc}")
+        return jsonify({"error": "Internal Server Error"}), 500
+
+
+def stop_udi_refresh_processor_api_response(*, stop_udi_refresh_processor: Callable[[], Any]):
+    """Handle stop request for UDI refresh processor."""
+    try:
+        success = stop_udi_refresh_processor()
+        if success:
+            return jsonify({"message": "UDI refresh processor stopped"}), 200
+        return jsonify({"message": "UDI refresh processor is not running"}), 200
+    except Exception as exc:
+        logger.error(f"Error stopping UDI refresh processor: {exc}")
+        return jsonify({"error": "Internal Server Error"}), 500
+
+
+def trigger_udi_refresh_response(*, udi_refresh_wake: Any, udi_refresh_running: bool, udi_refresh_thread: Any):
+    """Handle manual UDI refresh trigger request."""
+    try:
+        if (
+            udi_refresh_wake is not None
+            and hasattr(udi_refresh_wake, "set")
+            and udi_refresh_running
+            and udi_refresh_thread is not None
+            and hasattr(udi_refresh_thread, "is_alive")
+            and udi_refresh_thread.is_alive()
+        ):
+            udi_refresh_wake.set()
+            return jsonify({"message": "UDI refresh triggered"}), 200
+
+        return jsonify({"error": "UDI refresh processor is not running"}), 400
+    except Exception as exc:
+        logger.error(f"Error triggering UDI refresh: {exc}")
+        return jsonify({"error": "Internal Server Error"}), 500
+
+
+def get_udi_refresh_schedule_response(*, get_scheduling_service: Callable[[], Any]):
+    """Handle retrieval of the UDI refresh schedule."""
+    try:
+        service = get_scheduling_service()
+        schedule = service.get_udi_refresh_schedule()
+        return jsonify({"udi_refresh_schedule": schedule}), 200
+    except Exception as exc:
+        logger.error(f"Error getting UDI refresh schedule: {exc}")
+        return jsonify({"error": "Internal Server Error"}), 500
+
+
+def update_udi_refresh_schedule_response(*, payload: Any, get_scheduling_service: Callable[[], Any]):
+    """Handle update of the UDI refresh schedule.
+
+    Payload: {"schedule": {"type": "interval", "value": 120}}
+             {"schedule": {"type": "cron", "value": "45 4,6,8,10 * * *"}}
+             {"schedule": null}  — clears the schedule (worker goes dormant)
+    """
+    try:
+        data = payload or {}
+        schedule = data.get("schedule")  # None = clear schedule
+
+        if schedule is not None:
+            # Validate structure
+            stype = schedule.get("type")
+            svalue = schedule.get("value")
+            if stype not in ("interval", "cron"):
+                return error_response(
+                    "schedule.type must be 'interval' or 'cron'",
+                    status_code=400, code="validation_error"
+                )
+            if stype == "interval":
+                try:
+                    if int(svalue) < 1:
+                        raise ValueError
+                except (TypeError, ValueError):
+                    return error_response(
+                        "schedule.value must be a positive integer (minutes) for interval type",
+                        status_code=400, code="validation_error"
+                    )
+            elif stype == "cron":
+                try:
+                    from croniter import croniter
+                    if not croniter.is_valid(str(svalue)):
+                        raise ValueError
+                except ImportError:
+                    return error_response(
+                        "croniter package not available — cron schedules are not supported",
+                        status_code=400, code="validation_error"
+                    )
+                except ValueError:
+                    return error_response(
+                        f"Invalid cron expression: {svalue!r}",
+                        status_code=400, code="validation_error"
+                    )
+
+        service = get_scheduling_service()
+        success = service.update_udi_refresh_schedule(schedule)
+        if success:
+            return jsonify({
+                "message": "UDI refresh schedule updated",
+                "udi_refresh_schedule": schedule,
+            }), 200
+        return error_response("Failed to save UDI refresh schedule", status_code=500, code="internal_error")
+    except Exception as exc:
+        logger.error(f"Error updating UDI refresh schedule: {exc}")
+        return error_response("Internal Server Error", status_code=500, code="internal_error")

--- a/backend/apps/api/web_api.py
+++ b/backend/apps/api/web_api.py
@@ -32,6 +32,7 @@ from apps.automation.scheduling_service import get_scheduling_service
 from apps.background.scheduling_workers import (
     epg_refresh_processor_loop,
     scheduled_event_processor_loop,
+    udi_refresh_processor_loop,
 )
 from apps.stream.udp_proxy import UDPProxyManager
 
@@ -152,16 +153,22 @@ from apps.api.scheduling_handlers import (
     get_scheduled_event_processor_status_response,
     get_scheduled_events_response,
     get_scheduling_config_response,
+    get_udi_refresh_processor_status_response,
+    get_udi_refresh_schedule_response,
     import_auto_create_rules_response,
     process_due_scheduled_events_response,
     start_epg_refresh_processor_api_response,
     start_scheduled_event_processor_api_response,
+    start_udi_refresh_processor_api_response,
     stop_epg_refresh_processor_api_response,
     stop_scheduled_event_processor_api_response,
+    stop_udi_refresh_processor_api_response,
     test_auto_create_rule_response,
     trigger_epg_refresh_response,
+    trigger_udi_refresh_response,
     update_auto_create_rule_response,
     update_scheduling_config_response,
+    update_udi_refresh_schedule_response,
 )
 from apps.api.acestream_handlers import (
     check_acestream_orchestrator_ready_response,
@@ -358,6 +365,9 @@ scheduled_event_processor_wake = None  # threading.Event to wake up the processo
 epg_refresh_thread = None
 epg_refresh_running = False
 epg_refresh_wake = None  # threading.Event to wake up the refresh early
+udi_refresh_thread = None
+udi_refresh_running = False
+udi_refresh_wake = None  # threading.Event to wake up the UDI refresh early
 
 
 def _set_epg_refresh_running(value: bool):
@@ -425,7 +435,6 @@ def scheduled_event_processor():
         get_wake_event=lambda: scheduled_event_processor_wake,
         get_scheduling_service=get_scheduling_service,
         get_stream_checker_service=get_stream_checker_service,
-        get_udi_manager=get_udi_manager,
         logger=logger,
         check_interval=30,
     )
@@ -542,6 +551,66 @@ def stop_epg_refresh_processor():
         return False
     
     logger.info("EPG refresh processor stopped")
+    return True
+
+
+def udi_refresh_processor():
+    """Background thread for scheduled UDI cache refreshes.
+
+    Fires refresh_all() on the UDI manager according to the schedule stored
+    in scheduling config (udi_refresh_schedule). Skips if automation is busy.
+    """
+    return udi_refresh_processor_loop(
+        is_running=lambda: udi_refresh_running,
+        get_wake_event=lambda: udi_refresh_wake,
+        get_scheduling_service=get_scheduling_service,
+        get_udi_manager=get_udi_manager,
+        logger=logger,
+        check_interval=60,
+    )
+
+
+def start_udi_refresh_processor():
+    """Start the background thread for scheduled UDI cache refreshes."""
+    global udi_refresh_thread, udi_refresh_running, udi_refresh_wake
+
+    if udi_refresh_thread is not None and udi_refresh_thread.is_alive():
+        logger.warning("UDI refresh processor is already running")
+        return False
+
+    udi_refresh_wake = threading.Event()
+    udi_refresh_running = True
+    udi_refresh_thread = threading.Thread(
+        target=udi_refresh_processor,
+        name="UDIRefreshProcessor",
+        daemon=True,
+    )
+    udi_refresh_thread.start()
+    logger.info("UDI refresh processor started")
+    return True
+
+
+def stop_udi_refresh_processor():
+    """Stop the background thread for scheduled UDI cache refreshes."""
+    global udi_refresh_thread, udi_refresh_running, udi_refresh_wake
+
+    if udi_refresh_thread is None or not udi_refresh_thread.is_alive():
+        logger.warning("UDI refresh processor is not running")
+        return False
+
+    logger.info("Stopping UDI refresh processor...")
+    udi_refresh_running = False
+
+    if udi_refresh_wake:
+        udi_refresh_wake.set()
+
+    udi_refresh_thread.join(timeout=THREAD_SHUTDOWN_TIMEOUT_SECONDS)
+
+    if udi_refresh_thread.is_alive():
+        logger.warning("UDI refresh processor thread did not stop gracefully")
+        return False
+
+    logger.info("UDI refresh processor stopped")
     return True
 
 
@@ -1424,7 +1493,63 @@ def trigger_epg_refresh():
         epg_refresh_thread=epg_refresh_thread,
     )
 
-# ==================== Automation Service API ====================
+
+@app.route('/api/scheduling/udi-refresh/status', methods=['GET'])
+@log_function_call
+def get_udi_refresh_processor_status():
+    """Get the status of the UDI refresh processor background thread."""
+    return get_udi_refresh_processor_status_response(
+        udi_refresh_thread=udi_refresh_thread,
+        udi_refresh_running=udi_refresh_running,
+    )
+
+
+@app.route('/api/scheduling/udi-refresh/start', methods=['POST'])
+@log_function_call
+def start_udi_refresh_processor_api():
+    """Start the UDI refresh processor background thread."""
+    return start_udi_refresh_processor_api_response(
+        start_udi_refresh_processor=start_udi_refresh_processor,
+    )
+
+
+@app.route('/api/scheduling/udi-refresh/stop', methods=['POST'])
+@log_function_call
+def stop_udi_refresh_processor_api():
+    """Stop the UDI refresh processor background thread."""
+    return stop_udi_refresh_processor_api_response(
+        stop_udi_refresh_processor=stop_udi_refresh_processor,
+    )
+
+
+@app.route('/api/scheduling/udi-refresh/trigger', methods=['POST'])
+@log_function_call
+def trigger_udi_refresh():
+    """Manually trigger an immediate UDI cache refresh."""
+    return trigger_udi_refresh_response(
+        udi_refresh_wake=udi_refresh_wake,
+        udi_refresh_running=udi_refresh_running,
+        udi_refresh_thread=udi_refresh_thread,
+    )
+
+
+@app.route('/api/scheduling/udi-refresh/schedule', methods=['GET'])
+@log_function_call
+def get_udi_refresh_schedule():
+    """Get the UDI refresh schedule configuration."""
+    return get_udi_refresh_schedule_response(
+        get_scheduling_service=get_scheduling_service,
+    )
+
+
+@app.route('/api/scheduling/udi-refresh/schedule', methods=['PUT'])
+@log_function_call
+def update_udi_refresh_schedule():
+    """Set or clear the UDI refresh schedule."""
+    return update_udi_refresh_schedule_response(
+        payload=request.get_json(silent=True),
+        get_scheduling_service=get_scheduling_service,
+    )
 
 @app.route('/api/automation/status', methods=['GET'])
 @log_function_call
@@ -2476,6 +2601,15 @@ if __name__ == '__main__':
                 logger.info("EPG refresh processor auto-started")
         except Exception as e:
             logger.error(f"Failed to auto-start EPG refresh processor: {e}")
+
+        try:
+            if not check_wizard_complete():
+                logger.info("UDI refresh processor will not start - setup wizard has not been completed")
+            else:
+                start_udi_refresh_processor()
+                logger.info("UDI refresh processor auto-started")
+        except Exception as e:
+            logger.error(f"Failed to auto-start UDI refresh processor: {e}")
         
         try:
             monitoring_service = get_monitoring_service()

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -2783,6 +2783,10 @@ class AutomatedStreamManager:
         logger.debug("Starting automation cycle...")
         
         try:
+            # Mark automation as busy so the scheduled UDI refresh worker
+            # skips its slot rather than replacing the cache mid-pipeline.
+            get_udi_manager().set_automation_busy()
+
             # 2. Determine which playlists to update and group channels by period
             udi = get_udi_manager()
             channels = udi.get_channels()
@@ -3300,6 +3304,10 @@ class AutomatedStreamManager:
 
         finally:
             self._m3u_accounts_cache = None
+
+            # Clear automation busy flag before starting background sync so the
+            # scheduled UDI refresh worker can proceed on its next slot if due.
+            get_udi_manager().clear_automation_busy()
 
             # Background UDI sync — pull all writes from this cycle back into cache.
             # Only fires when the cycle actually completed matching/checking work.

--- a/backend/apps/automation/scheduling_service.py
+++ b/backend/apps/automation/scheduling_service.py
@@ -96,9 +96,15 @@ class SchedulingService:
         return self._regex_matcher
 
     def _load_config(self) -> Dict[str, Any]:
-        """Load scheduling configuration from SQL."""
+        """Load scheduling configuration from SQL.
+
+        Migrates legacy epg_refresh_interval_minutes integer to the unified
+        schedule structure {type, value} on first load. Transparent to users —
+        same behaviour, no data loss, cron option unlocked going forward.
+        """
         default_config = {
-            'epg_refresh_interval_minutes': 60,
+            'epg_schedule': {'type': 'interval', 'value': 60},
+            'udi_refresh_schedule': None,
             'enabled': True
         }
         from apps.database.connection import get_session
@@ -107,9 +113,35 @@ class SchedulingService:
         try:
             setting = session.query(SystemSetting).filter(SystemSetting.key == 'scheduling_config').first()
             if setting and setting.value:
-                return setting.value
+                config = dict(setting.value)
+                needs_save = False
+
+                # One-time migration: convert legacy integer key to schedule object
+                if 'epg_refresh_interval_minutes' in config and 'epg_schedule' not in config:
+                    legacy_minutes = config.pop('epg_refresh_interval_minutes', 60)
+                    config['epg_schedule'] = {'type': 'interval', 'value': int(legacy_minutes)}
+                    logger.info(
+                        f"Migrated EPG schedule: epg_refresh_interval_minutes={legacy_minutes} "
+                        f"→ epg_schedule={{type: interval, value: {legacy_minutes}}}"
+                    )
+                    needs_save = True
+
+                # Ensure udi_refresh_schedule key exists in older configs
+                if 'udi_refresh_schedule' not in config:
+                    config['udi_refresh_schedule'] = None
+                    needs_save = True
+
+                # Persist only when something actually changed
+                if needs_save:
+                    from sqlalchemy.orm.attributes import flag_modified
+                    setting.value = config
+                    flag_modified(setting, "value")
+                    session.commit()
+
+                return config
         except Exception as e:
             logger.error(f"Error loading scheduling config: {e}")
+            session.rollback()
         finally:
             session.close()
         return default_config
@@ -252,6 +284,40 @@ class SchedulingService:
             self._config.update(config)
             return self._save_config()
 
+    def get_epg_schedule(self) -> dict:
+        """Return the EPG refresh schedule as a {type, value} dict.
+
+        Falls back to a 60-minute interval if the config still carries the
+        legacy epg_refresh_interval_minutes key (belt-and-suspenders).
+        """
+        schedule = self._config.get('epg_schedule')
+        if schedule and isinstance(schedule, dict):
+            return schedule
+        # Legacy fallback
+        legacy_mins = self._config.get('epg_refresh_interval_minutes', 60)
+        return {'type': 'interval', 'value': int(legacy_mins)}
+
+    def get_udi_refresh_schedule(self):
+        """Return the UDI refresh schedule or None if not configured.
+
+        None means the UDI refresh worker is dormant — no scheduled refreshes.
+        """
+        return self._config.get('udi_refresh_schedule')
+
+    def update_udi_refresh_schedule(self, schedule) -> bool:
+        """Set or clear the UDI refresh schedule.
+
+        Args:
+            schedule: Dict {type, value} for interval or cron, or None to
+                      clear (worker goes dormant).
+
+        Returns:
+            True if saved successfully.
+        """
+        with self._lock:
+            self._config['udi_refresh_schedule'] = schedule
+            return self._save_config()
+
     def _get_base_url(self) -> Optional[str]:
         config = get_dispatcharr_config()
         return config.get_base_url()
@@ -289,7 +355,7 @@ class SchedulingService:
             cached_data = self._epg_cache.get(tvg_id)
             if not force_refresh and cached_data:
                 cache_age = datetime.now() - cached_data['time']
-                refresh_interval = timedelta(minutes=self._config.get('epg_refresh_interval_minutes', 60))
+                refresh_interval = timedelta(minutes=self.get_epg_schedule().get('value', 60))
                 if cache_age < refresh_interval:
                     return cached_data['programs'].copy()
 

--- a/backend/apps/background/scheduling_workers.py
+++ b/backend/apps/background/scheduling_workers.py
@@ -1,7 +1,52 @@
 """Background worker loops for scheduled-event and EPG refresh processing."""
 
 import time
-from typing import Any, Callable
+from datetime import datetime, timedelta
+from typing import Any, Callable, Optional
+
+
+def _is_schedule_due(schedule: Optional[dict], last_run: Optional[datetime]) -> bool:
+    """Determine whether a schedule is due to fire.
+
+    Mirrors the _is_period_due() logic in automated_stream_manager.py.
+    Supports the same {type, value} structure used by automation periods.
+
+    Args:
+        schedule: Dict with 'type' ('interval' or 'cron') and 'value'.
+                  None means no schedule configured — never due.
+        last_run: Timestamp of last successful run. None means never run —
+                  treat as due immediately for interval, due on first cron match
+                  for cron.
+
+    Returns:
+        True if the schedule should fire now.
+    """
+    if not schedule:
+        return False
+
+    stype = schedule.get("type", "interval")
+    svalue = schedule.get("value")
+
+    if stype == "interval":
+        try:
+            interval_mins = max(1, int(svalue))
+        except (TypeError, ValueError):
+            return False
+        if last_run is None:
+            return True
+        return datetime.now() - last_run >= timedelta(minutes=interval_mins)
+
+    elif stype == "cron":
+        try:
+            from croniter import croniter
+            base = last_run if last_run is not None else datetime.now() - timedelta(seconds=1)
+            cron = croniter(str(svalue), base)
+            next_run = cron.get_next(datetime)
+            return datetime.now() >= next_run
+        except Exception:
+            return False
+
+    return False
 
 
 def scheduled_event_processor_loop(
@@ -10,7 +55,6 @@ def scheduled_event_processor_loop(
     get_wake_event: Callable[[], Any],
     get_scheduling_service: Callable[[], Any],
     get_stream_checker_service: Callable[[], Any],
-    get_udi_manager: Callable[[], Any],
     logger: Any,
     check_interval: int = 30,
 ):
@@ -26,14 +70,6 @@ def scheduled_event_processor_loop(
             else:
                 wake_event.wait(timeout=check_interval)
                 wake_event.clear()
-
-            # Do not process scheduled events before the startup network UDI refresh
-            # completes. Firing against an empty/stale cache produces no-op checks.
-            if not get_udi_manager().is_network_ready():
-                logger.debug(
-                    "Scheduled event processor waiting — UDI network refresh not yet complete"
-                )
-                continue
 
             service = get_scheduling_service()
             stream_checker = get_stream_checker_service()
@@ -77,21 +113,35 @@ def epg_refresh_processor_loop(
     initial_delay_seconds: int,
     error_retry_seconds: int,
 ):
-    """Run periodic EPG refresh loop until is_running() becomes False."""
+    """Run periodic EPG refresh loop until is_running() becomes False.
+
+    Uses the same {type, value} schedule structure as automation periods.
+    Reads the schedule on every iteration so config changes take effect
+    without restart.
+    """
     logger.info("EPG refresh processor thread started")
 
     time.sleep(initial_delay_seconds)
+
+    epg_last_run: Optional[datetime] = None
 
     while is_running():
         try:
             service = get_scheduling_service()
             config = service.get_config()
-            refresh_interval_minutes = max(config.get("epg_refresh_interval_minutes", 60), 5)
-            refresh_interval_seconds = refresh_interval_minutes * 60
 
-            logger.info("Fetching EPG data and matching programs to auto-create rules...")
-            result = service.match_programs_to_rules()
-            logger.info(f"EPG refresh complete. Created {result.get('created', 0)} events.")
+            # Support both legacy integer key and new schedule object.
+            # _load_config() migrates on first load but guard here for safety.
+            epg_schedule = config.get("epg_schedule")
+            if epg_schedule is None:
+                legacy_mins = config.get("epg_refresh_interval_minutes", 60)
+                epg_schedule = {"type": "interval", "value": int(legacy_mins)}
+
+            if _is_schedule_due(epg_schedule, epg_last_run):
+                logger.info("Fetching EPG data and matching programs to auto-create rules...")
+                result = service.match_programs_to_rules()
+                logger.info(f"EPG refresh complete. Created {result.get('created', 0)} events.")
+                epg_last_run = datetime.now()
 
             wake_event = get_wake_event()
             if wake_event is None:
@@ -99,8 +149,8 @@ def epg_refresh_processor_loop(
                 clear_running()
                 break
 
-            logger.debug(f"EPG refresh will occur again in {refresh_interval_minutes} minutes")
-            wake_event.wait(timeout=refresh_interval_seconds)
+            # Sleep for the minimum of: 60s poll interval or remaining time to next due
+            wake_event.wait(timeout=60)
             wake_event.clear()
 
         except Exception as exc:
@@ -113,3 +163,100 @@ def epg_refresh_processor_loop(
                 break
 
     logger.info("EPG refresh processor thread stopped")
+
+
+def udi_refresh_processor_loop(
+    *,
+    is_running: Callable[[], bool],
+    get_wake_event: Callable[[], Any],
+    get_scheduling_service: Callable[[], Any],
+    get_udi_manager: Callable[[], Any],
+    logger: Any,
+    check_interval: int = 60,
+):
+    """Run periodic UDI cache refresh loop until is_running() becomes False.
+
+    Fires refresh_all() on the UDI manager according to the schedule stored in
+    the scheduling config (udi_refresh_schedule). Supports both interval and
+    cron schedule types, identical to automation periods.
+
+    Guards:
+    - is_network_ready(): skips until startup network refresh completes.
+    - is_automation_busy(): skips the slot if a cycle or single-channel check
+      is running. Does not queue — waits for the next scheduled slot.
+    - Schedule null/not configured: worker is dormant, logs nothing.
+    """
+    logger.info("UDI refresh processor thread started")
+
+    while is_running():
+        try:
+            wake_event = get_wake_event()
+            if wake_event is None:
+                logger.error("UDI refresh wake event is None; using fallback sleep.")
+                time.sleep(check_interval)
+            else:
+                wake_event.wait(timeout=check_interval)
+                wake_event.clear()
+
+            udi = get_udi_manager()
+
+            # Guard: startup network refresh must be complete
+            if not udi.is_network_ready():
+                logger.debug(
+                    "UDI refresh processor waiting — network refresh not yet complete"
+                )
+                continue
+
+            # Read schedule on every iteration so config changes take effect
+            # without restart.
+            service = get_scheduling_service()
+            schedule = service.get_udi_refresh_schedule()
+
+            if not schedule:
+                # No schedule configured — worker is dormant
+                continue
+
+            last_run = udi.get_udi_refresh_last_run()
+
+            if not _is_schedule_due(schedule, last_run):
+                continue
+
+            # Guard: skip if a cycle or single-channel check is running
+            if udi.is_automation_busy():
+                logger.info(
+                    "UDI refresh skipping slot — automation is currently busy. "
+                    "Will retry at next scheduled time."
+                )
+                continue
+
+            # Guard: skip if queue-based stream checking is active.
+            # The _worker_loop processes queued channels outside check_single_channel
+            # so is_automation_busy() does not cover it. stream_checking_mode
+            # reflects queue activity, in-progress checks, and sync batch state.
+            try:
+                from apps.stream.stream_checker_service import get_stream_checker_service
+                checker_status = get_stream_checker_service().get_status()
+                if checker_status.get('stream_checking_mode', False):
+                    logger.info(
+                        "UDI refresh skipping slot — stream checking is active. "
+                        "Will retry at next scheduled time."
+                    )
+                    continue
+            except Exception as _sc_err:
+                logger.debug(f"Could not check stream checking mode: {_sc_err}")
+
+            logger.info(
+                f"Scheduled UDI refresh firing "
+                f"(schedule: {schedule.get('type')} {schedule.get('value')})..."
+            )
+            success = udi.refresh_all()
+            if success:
+                udi.set_udi_refresh_last_run()
+                logger.info("✓ Scheduled UDI refresh completed")
+            else:
+                logger.warning("Scheduled UDI refresh failed — will retry at next scheduled time")
+
+        except Exception as exc:
+            logger.error(f"Error in UDI refresh processor: {exc}", exc_info=True)
+
+    logger.info("UDI refresh processor thread stopped")

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -3182,13 +3182,16 @@ class StreamCheckerService:
         """
         import time as time_module
         start_time = time_module.time()
-        
+
+        # Mark automation as busy before entering try/finally so the flag
+        # is guaranteed to be cleared on every exit path including early returns.
+        get_udi_manager().set_automation_busy()
+
         try:
             logger.info(f"Starting single channel check for channel {channel_id}")
-            
+
             # Get channel info from UDI
             udi = get_udi_manager()
-            channel = udi.get_channel_by_id(channel_id)
             if not channel:
                 error_msg = f"Channel {channel_id} not found"
                 logger.error(error_msg)
@@ -3723,11 +3726,20 @@ class StreamCheckerService:
                 'channel_name': channel_name,
                 'stats': check_stats
             }
-            
+
         except Exception as e:
             logger.error(f"Error checking single channel {channel_id}: {e}", exc_info=True)
             self.progress.clear()
             return {'success': False, 'error': str(e)}
+
+        finally:
+            # Guarantee the busy flag is cleared on every exit path —
+            # normal completion, early returns (no channel, no profile,
+            # monitoring session, limits), and exceptions.
+            try:
+                get_udi_manager().clear_automation_busy()
+            except Exception:
+                pass
     
     def clear_queue(self):
         """Clear the checking queue."""

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -2890,16 +2890,29 @@ class StreamCheckerService:
 
     def _generate_stream_sort_key(self, stream_data: Dict, priority_m3u_ids: List[int] = None, priority_mode: str = 'absolute') -> Tuple:
         """Generate a lexicographical sort key for a stream based on priority tiers.
-        
+
         The sort key is a tuple used for ascending sort (lower is better).
-        
-        (AccountRank, ResolutionTier, QualityScore)
-        
-        Tiers (for 'same_resolution' mode):
-        (ResolutionTier, AccountRank, QualityScore)
+
+        Priority modes and their sort order:
+
+          'absolute'        → (0, playlist_rank, res_tier, quality_score)  [listed accounts]
+                            → (1, res_tier, quality_score)                  [unlisted — neutral fallback]
+
+          'same_resolution' → (res_tier, 0, playlist_rank, quality_score)  [listed accounts]
+                            → (res_tier, 1, quality_score)                  [unlisted — neutral fallback]
+
+          'equal'           → (res_tier, quality_score)                     [all streams, no account influence]
+
+          'quality'         → (quality_score,)                              [pure composite score, no bucketing]
+
+        The two-bucket approach (listed=0 / unlisted=1) for absolute and same_resolution modes
+        ensures streams from accounts NOT in the priority list are treated as neutral rather than
+        being penalised with an arbitrary worst-case rank. If all listed-account streams are dead
+        or filtered, the channel gracefully falls back to the best unlisted stream by quality.
         """
-        # 1. Account Rank (0 = highest)
-        account_rank = 100
+        # Resolve whether this stream's account is in the priority list
+        is_listed = False
+        playlist_rank = None
         stream_id = stream_data.get('stream_id')
         if priority_m3u_ids and stream_id:
             udi = get_udi_manager()
@@ -2907,22 +2920,39 @@ class StreamCheckerService:
             if stream:
                 m3u_id = stream.get('m3u_account')
                 if m3u_id in priority_m3u_ids:
-                    account_rank = priority_m3u_ids.index(m3u_id)
-        
-        # 2. Resolution Tier (0 = highest)
+                    is_listed = True
+                    playlist_rank = priority_m3u_ids.index(m3u_id)
+
+        # Resolution tier: 0=4K, 1=1080p, 2=720p, 3=576p, 4=low, 5=unknown
         res_tier = self._get_resolution_tier(stream_data.get('resolution'))
-        
-        
-        # 4. Quality Score (lower is better, so negate the 0-1 scale)
+
+        # Quality score: negated so lower tuple value = better stream
         quality_score = -stream_data.get('score', 0.0)
-        
-        if priority_mode == 'same_resolution':
-            return (res_tier, account_rank, quality_score)
+
+        if priority_mode == 'quality':
+            # Pure composite score — no resolution bucketing, no account influence.
+            return (quality_score,)
+
         elif priority_mode == 'equal':
-            # In 'equal' mode, resolution and quality matter, but not M3U account priority
+            # Resolution first, then quality. Playlist priority ignored entirely.
             return (res_tier, quality_score)
-        else: # 'absolute' mode
-            return (account_rank, res_tier, quality_score)
+
+        elif priority_mode == 'same_resolution':
+            # Resolution leads. Within the same resolution tier, listed accounts
+            # sort before unlisted (bucket 0 vs 1). Quality is the final tiebreaker.
+            if is_listed:
+                return (res_tier, 0, playlist_rank, quality_score)
+            else:
+                return (res_tier, 1, quality_score)
+
+        else:
+            # 'absolute' mode (default): playlist priority leads.
+            # Listed accounts always sort before unlisted regardless of quality.
+            # Unlisted accounts fall back gracefully sorted by res + quality.
+            if is_listed:
+                return (0, playlist_rank, res_tier, quality_score)
+            else:
+                return (1, res_tier, quality_score)
     
     def get_status(self) -> Dict:
         """Get current service status."""

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -3192,6 +3192,7 @@ class StreamCheckerService:
 
             # Get channel info from UDI
             udi = get_udi_manager()
+            channel = udi.get_channel_by_id(channel_id)
             if not channel:
                 error_msg = f"Channel {channel_id} not found"
                 logger.error(error_msg)

--- a/backend/apps/udi/manager.py
+++ b/backend/apps/udi/manager.py
@@ -886,6 +886,10 @@ class UDIManager:
             _refresh_end = datetime.now()
             self._last_refresh_duration_seconds = (_refresh_end - _refresh_start).total_seconds()
             self._last_refresh_time = _refresh_end
+            # Seed the scheduled UDI refresh last-run timestamp so the first
+            # scheduled slot waits the full interval from startup rather than
+            # firing immediately (startup refresh counts as the first run).
+            self._udi_refresh_last_run = _refresh_end
             # Mark network as ready — distinguishes a live Dispatcharr fetch from
             # a load from SQL storage at startup (which may have stale/empty data).
             self._network_ready = True

--- a/backend/apps/udi/manager.py
+++ b/backend/apps/udi/manager.py
@@ -118,6 +118,17 @@ class UDIManager:
         self._network_ready = False  # True only after a successful refresh_all() from Dispatcharr network
         self._last_refresh_duration_seconds: float = 0.0  # Duration of last successful refresh_all()
         self._last_refresh_time: Optional[datetime] = None  # Wall-clock time of last successful refresh_all()
+
+        # Automation busy flag — set while a cycle or single-channel check is running.
+        # The scheduled UDI refresh worker checks this before firing to avoid
+        # replacing the cache mid-pipeline. Cleared before any background sync fires.
+        self._automation_busy: bool = False
+        self._automation_busy_lock = threading.Lock()
+
+        # Last run timestamp for the scheduled UDI refresh worker.
+        # In-memory only — resets on restart, which is correct behaviour.
+        self._udi_refresh_last_run: Optional[datetime] = None
+
         self._lock = threading.Lock()
         self._refresh_thread = None
         self._refresh_running = False
@@ -376,6 +387,55 @@ class UDIManager:
         stream_count = len(self._streams_cache)
 
         return f"last synced {age_str} ({time_str}) — {stream_count:,} streams"
+
+    def set_automation_busy(self) -> None:
+        """Mark automation as busy — a cycle or single-channel check is running.
+
+        The scheduled UDI refresh worker checks this flag before firing.
+        If set, the worker skips the current slot and waits for the next
+        scheduled time rather than replacing the cache mid-pipeline.
+
+        Must be called at the start of run_automation_cycle() and
+        check_single_channel(). Clear with clear_automation_busy() before
+        any post-completion background sync fires.
+        """
+        with self._automation_busy_lock:
+            self._automation_busy = True
+
+    def clear_automation_busy(self) -> None:
+        """Clear the automation busy flag.
+
+        Call at the natural completion point of run_automation_cycle() and
+        check_single_channel() — before starting any background UDI sync
+        thread, so the sync does not hold the busy flag.
+        """
+        with self._automation_busy_lock:
+            self._automation_busy = False
+
+    def is_automation_busy(self) -> bool:
+        """Return True if a cycle or single-channel check is currently running.
+
+        Used by the scheduled UDI refresh worker to determine whether to
+        skip the current slot. Does not block — caller decides what to do.
+        """
+        with self._automation_busy_lock:
+            return self._automation_busy
+
+    def get_udi_refresh_last_run(self) -> Optional[datetime]:
+        """Return the timestamp of the last scheduled UDI refresh run.
+
+        In-memory only — resets to None on restart. Used by the UDI refresh
+        worker to determine if the schedule is due.
+        """
+        return self._udi_refresh_last_run
+
+    def set_udi_refresh_last_run(self, ts: Optional[datetime] = None) -> None:
+        """Record that the scheduled UDI refresh just ran.
+
+        Args:
+            ts: Timestamp to record. Defaults to datetime.now().
+        """
+        self._udi_refresh_last_run = ts if ts is not None else datetime.now()
 
     def get_channels(self) -> List[Dict[str, Any]]:
         """Get all channels.
@@ -665,6 +725,12 @@ class UDIManager:
             return False
         
         try:
+            # Set automation busy for the duration of this full refresh.
+            # Prevents the scheduled UDI refresh worker from firing a concurrent
+            # refresh_all() that would race with this one on the cache.
+            # Also prevents check_single_channel and run_automation_cycle from
+            # starting while a full cache rebuild is in progress.
+            self.set_automation_busy()
             _refresh_start = datetime.now()
 
             # Pre-fetch step: get authoritative counts from lightweight /ids/
@@ -829,6 +895,9 @@ class UDIManager:
             logger.error(f"Error refreshing UDI data: {e}")
             self._update_init_progress(status='failed', message=f'Refresh failed: {str(e)}')
             return False
+
+        finally:
+            self.clear_automation_busy()
     
     def refresh_channels(self) -> bool:
         """Refresh only channels data.

--- a/frontend/src/pages/AutomationProfileEditor.jsx
+++ b/frontend/src/pages/AutomationProfileEditor.jsx
@@ -563,7 +563,7 @@ export default function AutomationProfileEditor() {
                                                                             variant="ghost"
                                                                             size="icon"
                                                                             className="h-6 w-6"
-                                                                            disabled={idx === 0 || profile.stream_checking.m3u_priority_mode === 'equal' || profile.stream_checking.m3u_priority_mode === 'quality'}
+                                                                            disabled={idx === 0}
                                                                             onClick={() => {
                                                                                 const newOrder = [...sortedIds]
                                                                                 const temp = newOrder[idx]
@@ -578,7 +578,7 @@ export default function AutomationProfileEditor() {
                                                                             variant="ghost"
                                                                             size="icon"
                                                                             className="h-6 w-6"
-                                                                            disabled={idx === sortedIds.length - 1 || profile.stream_checking.m3u_priority_mode === 'equal' || profile.stream_checking.m3u_priority_mode === 'quality'}
+                                                                            disabled={idx === sortedIds.length - 1}
                                                                             onClick={() => {
                                                                                 const newOrder = [...sortedIds]
                                                                                 const temp = newOrder[idx]

--- a/frontend/src/pages/AutomationProfileEditor.jsx
+++ b/frontend/src/pages/AutomationProfileEditor.jsx
@@ -538,9 +538,10 @@ export default function AutomationProfileEditor() {
                                                 >
                                                     <SelectTrigger><SelectValue /></SelectTrigger>
                                                     <SelectContent>
-                                                        <SelectItem value="absolute">Absolute (Priority &gt; Quality)</SelectItem>
-                                                        <SelectItem value="same_resolution">Same Resolution (Quality &gt; Priority)</SelectItem>
-                                                        <SelectItem value="equal">Equal (Fallback Only)</SelectItem>
+                                                        <SelectItem value="absolute">Playlist Priority → Resolution → Score</SelectItem>
+                                                        <SelectItem value="same_resolution">Resolution → Playlist Priority → Score</SelectItem>
+                                                        <SelectItem value="equal">Resolution → Score</SelectItem>
+                                                        <SelectItem value="quality">Score Only</SelectItem>
                                                     </SelectContent>
                                                 </Select>
                                             </div>
@@ -562,7 +563,7 @@ export default function AutomationProfileEditor() {
                                                                             variant="ghost"
                                                                             size="icon"
                                                                             className="h-6 w-6"
-                                                                            disabled={idx === 0 || profile.stream_checking.m3u_priority_mode === 'equal'}
+                                                                            disabled={idx === 0 || profile.stream_checking.m3u_priority_mode === 'equal' || profile.stream_checking.m3u_priority_mode === 'quality'}
                                                                             onClick={() => {
                                                                                 const newOrder = [...sortedIds]
                                                                                 const temp = newOrder[idx]
@@ -577,7 +578,7 @@ export default function AutomationProfileEditor() {
                                                                             variant="ghost"
                                                                             size="icon"
                                                                             className="h-6 w-6"
-                                                                            disabled={idx === sortedIds.length - 1 || profile.stream_checking.m3u_priority_mode === 'equal'}
+                                                                            disabled={idx === sortedIds.length - 1 || profile.stream_checking.m3u_priority_mode === 'equal' || profile.stream_checking.m3u_priority_mode === 'quality'}
                                                                             onClick={() => {
                                                                                 const newOrder = [...sortedIds]
                                                                                 const temp = newOrder[idx]

--- a/frontend/src/pages/AutomationSettings.jsx
+++ b/frontend/src/pages/AutomationSettings.jsx
@@ -17,7 +17,7 @@ export default function AutomationSettings() {
   const [streamCheckerConfig, setStreamCheckerConfig] = useState(null)
   const [dispatcharrConfig, setDispatcharrConfig] = useState(null)
   const [sessionConfig, setSessionConfig] = useState({ review_duration: 60 })
-  const [schedulingConfig, setSchedulingConfig] = useState({ epg_refresh_interval_minutes: 60 })
+  const [schedulingConfig, setSchedulingConfig] = useState({ epg_schedule: { type: 'interval', value: 60 }, udi_refresh_schedule: null, enabled: true })
   const [orchestratorConfig, setOrchestratorConfig] = useState({ host: '', port: 8000, has_api_key: false, api_key: '' })
   const [testingConnection, setTestingConnection] = useState(false)
   const [connectionTestResult, setConnectionTestResult] = useState(null)
@@ -148,12 +148,6 @@ export default function AutomationSettings() {
     }))
   }
 
-  const handleSchedulingConfigChange = (field, value) => {
-    setSchedulingConfig(prev => ({
-      ...prev,
-      [field]: value
-    }))
-  }
 
   const handleOrchestratorConfigChange = (field, value) => {
     setOrchestratorConfig(prev => ({
@@ -241,23 +235,57 @@ export default function AutomationSettings() {
             <CardHeader>
               <CardTitle>Event Scheduling</CardTitle>
               <CardDescription>
-                Configure how often to refresh EPG data from Dispatcharr
+                Configure how often to refresh EPG and UDI data from Dispatcharr
               </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="refresh-interval">EPG Refresh Interval (minutes)</Label>
-                <div className="flex items-center gap-2">
-                  <Input
-                    id="refresh-interval"
-                    type="number"
-                    min="1"
-                    max="1440"
-                    className="max-w-[120px]"
-                    value={schedulingConfig?.epg_refresh_interval_minutes || 60}
-                    onChange={(e) => handleSchedulingConfigChange('epg_refresh_interval_minutes', parseInt(e.target.value))}
-                  />
-                  <span className="text-sm text-muted-foreground">minutes</span>
+            <CardContent>
+              <div className="grid grid-cols-2 gap-8">
+                {/* EPG Refresh — left column */}
+                <div className="space-y-2">
+                  <Label htmlFor="refresh-interval">EPG Refresh Interval (minutes)</Label>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      id="refresh-interval"
+                      type="number"
+                      min="1"
+                      max="1440"
+                      className="max-w-[120px]"
+                      value={schedulingConfig?.epg_schedule?.value || 60}
+                      onChange={(e) => setSchedulingConfig(prev => ({
+                        ...prev,
+                        epg_schedule: { type: 'interval', value: parseInt(e.target.value) || 60 }
+                      }))}
+                    />
+                    <span className="text-sm text-muted-foreground">minutes</span>
+                  </div>
+                </div>
+
+                {/* UDI Cache Refresh — right column */}
+                <div className="space-y-2">
+                  <Label htmlFor="udi-refresh-interval">UDI Refresh Interval (minutes)</Label>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      id="udi-refresh-interval"
+                      type="number"
+                      min="0"
+                      max="720"
+                      step="15"
+                      className="max-w-[120px]"
+                      value={schedulingConfig?.udi_refresh_schedule?.value || 0}
+                      onChange={(e) => {
+                        const raw = parseInt(e.target.value) || 0
+                        const snapped = Math.floor(Math.min(Math.max(raw, 0), 720) / 15) * 15
+                        setSchedulingConfig(prev => ({
+                          ...prev,
+                          udi_refresh_schedule: snapped === 0 ? null : { type: 'interval', value: snapped }
+                        }))
+                      }}
+                    />
+                    <span className="text-sm text-muted-foreground">minutes</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    A zero interval disables automatic UDI cache refresh
+                  </p>
                 </div>
               </div>
             </CardContent>

--- a/frontend/src/pages/AutomationSettings.jsx
+++ b/frontend/src/pages/AutomationSettings.jsx
@@ -288,6 +288,12 @@ export default function AutomationSettings() {
                   </p>
                 </div>
               </div>
+              <div className="flex justify-end pt-4">
+                <Button onClick={handleSave} disabled={saving}>
+                  {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Save Settings
+                </Button>
+              </div>
             </CardContent>
           </Card>
         </TabsContent>


### PR DESCRIPTION
This PR adds a scheduled background refresh of the UDI (Universal Data Index) stream cache, along with the supporting infrastructure to coordinate it safely with existing automation activity.

Backend

The UDI manager gains a simple mutex — a busy flag that is set whenever a batch automation cycle or single-channel health check is running, and cleared when it completes. The scheduled UDI refresh worker checks this flag before firing, skipping its slot rather than replacing the cache mid-pipeline if automation is active.

The refresh worker runs as a new background thread alongside the existing EPG and scheduled event processors. It reads its schedule from the same configuration store used by automation periods, supporting both fixed interval and cron expression formats. The startup refresh_all() seeds the last-run timestamp so the first scheduled slot correctly waits the full configured interval rather than firing immediately after boot.

The EPG refresh configuration is migrated from a plain integer (epg_refresh_interval_minutes) to the same structured schedule object used everywhere else, enabling cron support for EPG in a future pass.
New API endpoints mirror the EPG refresh pattern, providing status, start, stop, trigger, and schedule management routes.

Frontend

The Scheduling tab is updated to show both EPG and UDI refresh intervals side by side in a two-column layout. The UDI interval uses 15-minute steps with zero meaning disabled. A Save Settings button is added to the card, consistent with other tabs.

Guards

The mutex protects against concurrent cache replacement during automation cycles, single-channel checks, and the startup full refresh.