### PR TITLE
fix: automation stream checking scoping, channel targeting, and profile persistence

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,14 @@
+# 1. Ignore everything by default
+*
+
+# 2. Allow directories so Claude can find files inside them
+!*/
+
+# 3. Whitelist specific file extensions
+!*.py
+!*.jsx
+
+# 4. Optional: Allow key documentation/instruction files
+!CLAUDE.md
+!README.md
+!AGENT.md

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -3073,11 +3073,16 @@ class AutomatedStreamManager:
                         for ch_id in channels_to_quality_check:
                             check_all_streams = channel_check_all_streams.get(ch_id, False)
                             if not check_all_streams:
-                                # Strict validation mapping: Evaluate newly assigned streams only.
-                                if str(ch_id) in assigned_stream_ids:
+                                # Only populate target_stream_ids for channels that actually
+                                # received new stream assignments (non-empty list). Channels
+                                # with no new assignments are omitted entirely, which causes
+                                # them to fall through to the normal incremental-check branch
+                                # in the checker rather than entering the targeted-zero-streams
+                                # path that would incorrectly trigger dead removal against
+                                # unchecked streams (see: Change Block H, spec v1.0).
+                                if assigned_stream_ids.get(str(ch_id)):
                                     _target_stream_ids[ch_id] = assigned_stream_ids[str(ch_id)]
-                                else:
-                                    _target_stream_ids[ch_id] = []
+                                # else: no entry → channel uses incremental/grace-period logic
                         
                         if _target_stream_ids:
                             target_stream_ids = _target_stream_ids

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -3082,18 +3082,26 @@ class AutomatedStreamManager:
                         _target_stream_ids = {}
 
                         for ch_id in channels_to_quality_check:
-                            check_all_streams = channel_check_all_streams.get(ch_id, False)
+                            # Normalise ch_id to int for all lookups. channels_to_quality_check
+                            # may contain mixed int/str entries if populated from multiple sources.
+                            _ch_id_int = int(ch_id)
+                            check_all_streams = channel_check_all_streams.get(_ch_id_int, False)
+                            logger.debug(
+                                f"Quality check loop: ch_id={ch_id!r}({type(ch_id).__name__}) "
+                                f"check_all={check_all_streams} "
+                                f"assigned={_assigned_by_int.get(_ch_id_int, None) is not None}"
+                            )
                             if check_all_streams:
                                 # check_all_streams=True: always include, no stream targeting
-                                channels_to_check_sync.append(ch_id)
-                            elif _assigned_by_int.get(ch_id):
+                                channels_to_check_sync.append(_ch_id_int)
+                            elif _assigned_by_int.get(_ch_id_int):
                                 # check_all_streams=False with new assignments: include, targeted to
                                 # newly assigned streams only. Channels with no new assignments are
                                 # omitted entirely — they fall through to the background worker's
                                 # normal incremental logic rather than entering a full re-check via
                                 # the grace_period=False branch in _check_channel_concurrent/sequential.
-                                channels_to_check_sync.append(ch_id)
-                                _target_stream_ids[ch_id] = _assigned_by_int[ch_id]
+                                channels_to_check_sync.append(_ch_id_int)
+                                _target_stream_ids[_ch_id_int] = _assigned_by_int[_ch_id_int]
                             # else: check_all_streams=False, no new assignments → skip this cycle
 
                         logger.info(

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -3065,14 +3065,18 @@ class AutomatedStreamManager:
                     try:
                         from apps.stream.stream_checker_service import get_stream_checker_service
                         stream_checker = get_stream_checker_service()
-                        logger.info(f"Running synchronous quality checks for {len(channels_to_quality_check)} channels...")
 
                         # Normalise assigned_stream_ids to integer keys. The dict returned by
                         # _discover_and_assign_streams_impl uses integer channel IDs (from
-                        # defaultdict keyed by channel_id integers), but previous code looked
-                        # up keys with str(ch_id) which never matched. Normalising here once
-                        # ensures the lookup never misses due to an int/str type mismatch.
+                        # defaultdict keyed by channel_id integers), but lookups with
+                        # str(ch_id) never matched. Normalising here ensures the lookup
+                        # never misses due to an int/str type mismatch.
                         _assigned_by_int = {int(k): v for k, v in assigned_stream_ids.items()}
+                        logger.info(
+                            f"Running synchronous quality checks for "
+                            f"{len(channels_to_quality_check)} eligible channels "
+                            f"({len(_assigned_by_int)} received new assignments this cycle)"
+                        )
 
                         channels_to_check_sync = []
                         _target_stream_ids = {}
@@ -3091,6 +3095,13 @@ class AutomatedStreamManager:
                                 channels_to_check_sync.append(ch_id)
                                 _target_stream_ids[ch_id] = _assigned_by_int[ch_id]
                             # else: check_all_streams=False, no new assignments → skip this cycle
+
+                        logger.info(
+                            f"Quality check dispatch: {len(channels_to_check_sync)} channels selected "
+                            f"({len(_target_stream_ids)} targeted, "
+                            f"{len(channels_to_check_sync) - len(_target_stream_ids)} full-check, "
+                            f"{len(channels_to_quality_check) - len(channels_to_check_sync)} skipped)"
+                        )
 
                         # Run checks synchronously and collect results
                         if channels_to_check_sync:

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -3067,33 +3067,36 @@ class AutomatedStreamManager:
                         stream_checker = get_stream_checker_service()
                         logger.info(f"Running synchronous quality checks for {len(channels_to_quality_check)} channels...")
                         
-                        target_stream_ids = None
+                        channels_to_check_sync = []
                         _target_stream_ids = {}
-                        
+
                         for ch_id in channels_to_quality_check:
                             check_all_streams = channel_check_all_streams.get(ch_id, False)
-                            if not check_all_streams:
-                                # Only populate target_stream_ids for channels that actually
-                                # received new stream assignments (non-empty list). Channels
-                                # with no new assignments are omitted entirely, which causes
-                                # them to fall through to the normal incremental-check branch
-                                # in the checker rather than entering the targeted-zero-streams
-                                # path that would incorrectly trigger dead removal against
-                                # unchecked streams (see: Change Block H, spec v1.0).
-                                if assigned_stream_ids.get(str(ch_id)):
-                                    _target_stream_ids[ch_id] = assigned_stream_ids[str(ch_id)]
-                                # else: no entry → channel uses incremental/grace-period logic
-                        
-                        if _target_stream_ids:
-                            target_stream_ids = _target_stream_ids
-                            
+                            if check_all_streams:
+                                # check_all_streams=True: always include, no stream targeting
+                                channels_to_check_sync.append(ch_id)
+                            elif assigned_stream_ids.get(str(ch_id)):
+                                # check_all_streams=False with new assignments: include, targeted to
+                                # newly assigned streams only. Channels with no new assignments are
+                                # omitted entirely — they fall through to the background worker's
+                                # normal incremental logic rather than entering a full re-check via
+                                # the grace_period=False branch in _check_channel_concurrent/sequential.
+                                channels_to_check_sync.append(ch_id)
+                                _target_stream_ids[ch_id] = assigned_stream_ids[str(ch_id)]
+                            # else: check_all_streams=False, no new assignments → skip this cycle
+
                         # Run checks synchronously and collect results
-                        check_results = stream_checker.check_channels_synchronously(
-                            channel_ids=channels_to_quality_check, 
-                            force_check=forced,
-                            target_stream_ids=target_stream_ids
-                        )
-                        logger.info(f"Synchronous quality checks completed for {len(check_results)} channels")
+                        if channels_to_check_sync:
+                            target_stream_ids = _target_stream_ids if _target_stream_ids else None
+                            check_results = stream_checker.check_channels_synchronously(
+                                channel_ids=channels_to_check_sync,
+                                force_check=forced,
+                                target_stream_ids=target_stream_ids
+                            )
+                            logger.info(f"Synchronous quality checks completed for {len(check_results)} channels")
+                        else:
+                            logger.info("No channels require synchronous quality checks this cycle (no new assignments)")
+                            check_results = {}
                     except Exception as e:
                         logger.error(f"✗ Failed to run quality checks: {e}")
                         check_results = {}

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -3066,7 +3066,14 @@ class AutomatedStreamManager:
                         from apps.stream.stream_checker_service import get_stream_checker_service
                         stream_checker = get_stream_checker_service()
                         logger.info(f"Running synchronous quality checks for {len(channels_to_quality_check)} channels...")
-                        
+
+                        # Normalise assigned_stream_ids to integer keys. The dict returned by
+                        # _discover_and_assign_streams_impl uses integer channel IDs (from
+                        # defaultdict keyed by channel_id integers), but previous code looked
+                        # up keys with str(ch_id) which never matched. Normalising here once
+                        # ensures the lookup never misses due to an int/str type mismatch.
+                        _assigned_by_int = {int(k): v for k, v in assigned_stream_ids.items()}
+
                         channels_to_check_sync = []
                         _target_stream_ids = {}
 
@@ -3075,14 +3082,14 @@ class AutomatedStreamManager:
                             if check_all_streams:
                                 # check_all_streams=True: always include, no stream targeting
                                 channels_to_check_sync.append(ch_id)
-                            elif assigned_stream_ids.get(str(ch_id)):
+                            elif _assigned_by_int.get(ch_id):
                                 # check_all_streams=False with new assignments: include, targeted to
                                 # newly assigned streams only. Channels with no new assignments are
                                 # omitted entirely — they fall through to the background worker's
                                 # normal incremental logic rather than entering a full re-check via
                                 # the grace_period=False branch in _check_channel_concurrent/sequential.
                                 channels_to_check_sync.append(ch_id)
-                                _target_stream_ids[ch_id] = assigned_stream_ids[str(ch_id)]
+                                _target_stream_ids[ch_id] = _assigned_by_int[ch_id]
                             # else: check_all_streams=False, no new assignments → skip this cycle
 
                         # Run checks synchronously and collect results

--- a/backend/apps/automation/automation_config_manager.py
+++ b/backend/apps/automation/automation_config_manager.py
@@ -234,6 +234,8 @@ class AutomationConfigManager:
                 if k not in ['name', 'description', 'enabled', 'parallel_checks', 'id']:
                     current_extra[k] = v
             p.extra_settings = current_extra
+            from sqlalchemy.orm.attributes import flag_modified
+            flag_modified(p, "extra_settings")
             session.commit()
             return True
         except Exception as e:

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -1289,6 +1289,12 @@ class StreamCheckerService:
                     else:
                         logger.info(f"Channel composition changed (prev: {previous_stream_count}, curr: {current_stream_count}) - will reorder")
             
+            # Streams that are actively analyzed in this pass. Used to gate
+            # dead_stream_ids mutations — only streams checked in THIS pass may
+            # be added to dead_stream_ids. Unchecked streams retain their tracker
+            # state unchanged until a future run evaluates them directly.
+            checked_stream_id_set = {s['id'] for s in streams_to_check}
+
             # Get configuration for analysis
             analysis_params = self.config.get('stream_analysis', {})
             global_limit = self.config.get('concurrent_streams.global_limit', 10)
@@ -1480,8 +1486,16 @@ class StreamCheckerService:
                             logger.info(f"Stream {stream_id} is alive but revival disabled by profile: {stream_name}")
                     elif is_dead and was_dead:
                         logger.debug(f"Stream {stream_id} remains dead (already marked)")
-                        # Add to dead_stream_ids so the stream removal logic (line 1455) will filter it out
-                        dead_stream_ids.add(stream_id)
+                        # Only act on stale dead state if this stream was part of the current
+                        # check pass. Unchecked streams must not be culled based on prior-run
+                        # tracker state — their status will be re-evaluated in the next full check.
+                        if stream_id in checked_stream_id_set:
+                            dead_stream_ids.add(stream_id)
+                        else:
+                            logger.debug(
+                                f"Stream {stream_id} skipped dead accumulation "
+                                f"(not in current check pass)"
+                            )
                     
                     # Calculate score using per-profile scoring weights
                     score = self._calculate_stream_score(analyzed, priority_m3u_ids, priority_mode, scoring_weights)
@@ -2042,9 +2056,15 @@ class StreamCheckerService:
                     else:
                         logger.info(f"Channel composition changed (prev: {previous_stream_count}, curr: {current_stream_count}) - will reorder")
             
+            # Streams that are actively analyzed in this pass. Used to gate
+            # dead_stream_ids mutations — only streams checked in THIS pass may
+            # be added to dead_stream_ids. Unchecked streams retain their tracker
+            # state unchanged until a future run evaluates them directly.
+            checked_stream_id_set = {s['id'] for s in streams_to_check}
+
             # Import stream analysis functions from stream_check_utils
             from apps.stream.stream_check_utils import analyze_stream
-            
+
             # Analyze new/unchecked streams
             analyzed_streams = []
             dead_stream_ids = set()  # Use set for O(1) lookups
@@ -2143,9 +2163,13 @@ class StreamCheckerService:
                         dead_stream_ids.add(stream['id'])
                         logger.info(f"Stream {stream['id']} is alive but revival disabled by profile: {stream_name}")
                 elif is_dead and was_dead:
-                    # Stream remains dead
-                    dead_stream_ids.add(stream['id'])
-                
+                    # Stream remains dead. Guard is redundant here — this loop
+                    # iterates streams_to_check by definition — but kept for
+                    # symmetry with the concurrent method and to make the scope
+                    # constraint explicit at review time.
+                    if stream['id'] in checked_stream_id_set:
+                        dead_stream_ids.add(stream['id'])
+
                 # Calculate score
                 score = self._calculate_stream_score(analyzed, priority_m3u_ids, priority_mode, scoring_weights)
                 analyzed['score'] = score
@@ -2203,34 +2227,46 @@ class StreamCheckerService:
                         'status': 'OK'  # Assume OK for previously checked streams
                     }
                     
-                    # Check if this cached stream is dead using pre-resolved threshold config
-                    stream_url = stream.get('url', '')
-                    stream_name = stream.get('name', 'Unknown')
-                    is_dead, dead_reason = self._is_stream_dead(analyzed, channel_id, threshold_config=_threshold_config)
-                    was_dead = self.dead_streams_tracker.is_dead(stream_url)
-                    
-                    # Handle dead/alive state transitions (same logic as newly-checked streams)
-                    if is_dead and not was_dead:
-                        # Newly detected as dead
-                        if self.dead_streams_tracker.mark_as_dead(stream_url, stream['id'], stream_name, channel_id, reason=dead_reason):
-                            dead_stream_ids.add(stream['id'])
-                            logger.warning(f"Cached stream {stream['id']} detected as DEAD: {stream_name} (reason={dead_reason})")
-                        else:
-                            logger.error(f"Failed to mark cached stream {stream['id']} as DEAD, will not remove from channel")
-                    elif not is_dead and was_dead:
-                        # Stream was revived!
-                        if allow_revive:
-                            if self.dead_streams_tracker.mark_as_alive(stream_url):
-                                revived_stream_ids.append(stream['id'])
-                                logger.info(f"Cached stream {stream['id']} REVIVED: {stream_name}")
-                        else:
-                            # Not allowed to revive, treat as still dead
-                            dead_stream_ids.add(stream['id'])
-                            logger.info(f"Cached stream {stream['id']} is alive but revival disabled by profile: {stream_name}")
-                    elif is_dead and was_dead:
-                        # Stream remains dead (already marked)
-                        logger.debug(f"Cached stream {stream['id']} remains dead (already marked)")
-                        dead_stream_ids.add(stream['id'])
+                    # TARGETED MODE GUARD: Dead-state transitions for streams in
+                    # streams_already_checked are intentionally suppressed. These streams
+                    # were NOT analyzed in this pass — their dead/alive determination is
+                    # based on reconstructed cached stats, which are not authoritative.
+                    # Acting on cached stats here causes every previously-flagged-dead
+                    # stream in the channel to be culled during targeted checks even when
+                    # zero new assignments were made (see: Change Block F, spec v1.0).
+                    #
+                    # All three state transitions are blocked:
+                    #   is_dead and not was_dead  → no mark_as_dead on cached stats
+                    #   not is_dead and was_dead  → no revival on cached stats
+                    #   is_dead and was_dead      → no dead_stream_ids accumulation
+                    #
+                    # Dead-state transitions require live ffmpeg analysis to be
+                    # authoritative. Leave all state changes for the next full check pass.
+                    #
+                    # NOTE: The variables below are commented out rather than deleted so
+                    # the original logic remains readable alongside the guard explanation.
+                    # stream_url = stream.get('url', '')
+                    # stream_name = stream.get('name', 'Unknown')
+                    # is_dead, dead_reason = self._is_stream_dead(analyzed, channel_id, threshold_config=_threshold_config)
+                    # was_dead = self.dead_streams_tracker.is_dead(stream_url)
+                    #
+                    # if is_dead and not was_dead:
+                    #     if self.dead_streams_tracker.mark_as_dead(stream_url, stream['id'], stream_name, channel_id, reason=dead_reason):
+                    #         dead_stream_ids.add(stream['id'])
+                    #         logger.warning(f"Cached stream {stream['id']} detected as DEAD: {stream_name} (reason={dead_reason})")
+                    #     else:
+                    #         logger.error(f"Failed to mark cached stream {stream['id']} as DEAD, will not remove from channel")
+                    # elif not is_dead and was_dead:
+                    #     if allow_revive:
+                    #         if self.dead_streams_tracker.mark_as_alive(stream_url):
+                    #             revived_stream_ids.append(stream['id'])
+                    #             logger.info(f"Cached stream {stream['id']} REVIVED: {stream_name}")
+                    #     else:
+                    #         dead_stream_ids.add(stream['id'])
+                    #         logger.info(f"Cached stream {stream['id']} is alive but revival disabled by profile: {stream_name}")
+                    # elif is_dead and was_dead:
+                    #     logger.debug(f"Cached stream {stream['id']} remains dead (already marked)")
+                    #     dead_stream_ids.add(stream['id'])
                     
                     # Calculate score using stored stats and CURRENT profile weights
                     score = self._calculate_stream_score(analyzed, priority_m3u_ids, priority_mode, scoring_weights)

--- a/frontend/src/pages/AutomationProfileEditor.jsx
+++ b/frontend/src/pages/AutomationProfileEditor.jsx
@@ -134,7 +134,7 @@ export default function AutomationProfileEditor() {
 
     const updateProfile = (field, value) => {
         setProfile(prev => {
-            const newData = { ...prev }
+            const newData = JSON.parse(JSON.stringify(prev))  // Deep clone — prevents nested object mutation via shared reference
             if (field.includes('.')) {
                 const parts = field.split('.')
                 let current = newData


### PR DESCRIPTION
Bug Fixes

* Dead stream removal scoping — streams were incorrectly culled during targeted automation runs. Dead-state transitions are now gated to streams actually analyzed in the current pass via checked_stream_id_set. Unchecked streams retain their tracker state until a future full-check evaluates them.
* Automation cycle over-checking — all channels with checking enabled were full-checked every cycle regardless of activity. Channels now only enter the sync check queue when they received new stream assignments; channels with no assignments are skipped entirely.
* int/str type mismatch in channel dispatch — assigned_stream_ids keys were integers but the dispatch loop looked them up as strings, causing all channels to fall through to full-check. All channel ID lookups are now normalized to int.
* Profile save not persisting — SQLAlchemy's JSON column dirty-tracking silently skipped UPDATE statements when nested dict contents changed. Added flag_modified(p, "extra_settings") to update_profile to force the write.
* Frontend state mutation on toggle — updateProfile used a shallow copy of React state, causing nested objects like stream_checking to share references with the previous render. Replaced with JSON.parse(JSON.stringify(prev)) deep clone, ensuring toggles correctly isolate state changes.

Observability

* Added per-cycle dispatch summary log: N channels selected (X targeted, Y full-check, Z skipped) — visible at INFO level every automation run.

