### PR TITLE
Prevent targeted checks clearing channels

### DIFF
--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -612,6 +612,40 @@ class StreamCheckerService:
         except Exception as e:
             logger.debug(f"Could not fetch M3U account for stream {stream_id}: {e}")
             return None
+
+    def _skip_empty_targeted_check(
+        self,
+        channel_id: int,
+        channel_name: str,
+        streams: List[Dict[str, Any]],
+        current_stream_ids: List[int],
+    ) -> Dict[str, Any]:
+        """Complete a targeted check that has no matching streams without reordering."""
+        logger.info(
+            f"Targeted stream check for channel {channel_name} has no matching "
+            "target streams; skipping reorder/update"
+        )
+        self.check_queue.mark_completed(channel_id)
+        self.update_tracker.mark_channel_checked(
+            channel_id,
+            stream_count=len(streams),
+            checked_stream_ids=current_stream_ids,
+        )
+        return {
+            'dead_streams_count': 0,
+            'revived_streams_count': 0,
+            'dead_streams': [],
+            'revived_streams': [],
+            'skipped': True,
+            'skip_reason': 'no_matching_target_streams',
+            'skipped_streams_count': len(streams),
+            'skipped_streams': [
+                {'id': s['id'], 'name': s.get('name', f"Stream {s['id']}")}
+                for s in streams
+            ],
+            'checked_streams': [],
+            'analyzed_streams': [],
+        }
     
     
     def _update_stream_stats(self, stream_data: Dict) -> bool:
@@ -1195,9 +1229,17 @@ class StreamCheckerService:
             
             if target_stream_ids is not None:
                 # Targeted check mode: Evaluates newly assigned streams ONLY
-                streams_to_check = [s for s in streams if str(s['id']) in [str(ts) for ts in target_stream_ids]]
-                streams_already_checked = [s for s in streams if str(s['id']) not in [str(ts) for ts in target_stream_ids]]
+                target_stream_id_set = {str(ts) for ts in target_stream_ids}
+                streams_to_check = [s for s in streams if str(s['id']) in target_stream_id_set]
+                streams_already_checked = [s for s in streams if str(s['id']) not in target_stream_id_set]
                 logger.info(f"Targeted stream check: evaluating {len(streams_to_check)} specific newly assigned streams")
+                if not streams_to_check:
+                    return self._skip_empty_targeted_check(
+                        channel_id,
+                        channel_name,
+                        streams,
+                        current_stream_ids,
+                    )
                 
             elif force_check or (grace_period and immunity_expired) or (not grace_period and not force_check):
                 # If grace period is DISABLED, we check everything every time unless it's a "needs_check" trigger?
@@ -1996,9 +2038,17 @@ class StreamCheckerService:
             
             if target_stream_ids is not None:
                 # Targeted check mode: Evaluates newly assigned streams ONLY
-                streams_to_check = [s for s in streams if str(s['id']) in [str(ts) for ts in target_stream_ids]]
-                streams_already_checked = [s for s in streams if str(s['id']) not in [str(ts) for ts in target_stream_ids]]
+                target_stream_id_set = {str(ts) for ts in target_stream_ids}
+                streams_to_check = [s for s in streams if str(s['id']) in target_stream_id_set]
+                streams_already_checked = [s for s in streams if str(s['id']) not in target_stream_id_set]
                 logger.info(f"Targeted stream check: evaluating {len(streams_to_check)} specific newly assigned streams")
+                if not streams_to_check:
+                    return self._skip_empty_targeted_check(
+                        channel_id,
+                        channel_name,
+                        streams,
+                        current_stream_ids,
+                    )
                 
             elif force_check or (grace_period and immunity_expired) or (not grace_period and not force_check):
                 streams_to_check = streams

--- a/backend/tests/test_targeted_stream_check_noop.py
+++ b/backend/tests/test_targeted_stream_check_noop.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Regression tests for targeted stream checks with no matching streams."""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+
+# Add backend to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from apps.stream import stream_checker_service as scs
+
+
+class _TestConfig:
+    def get(self, key, default=None):
+        if key == 'batch_operations':
+            return {'enabled': True, 'batch_size': 10, 'verify_updates': False}
+        return default
+
+
+class TestTargetedStreamCheckNoop(unittest.TestCase):
+    """Targeted checks should not clear channels when no target streams match."""
+
+    def _make_service(self):
+        service = scs.StreamCheckerService.__new__(scs.StreamCheckerService)
+        service.config = _TestConfig()
+        service.progress = Mock()
+        service.check_queue = Mock()
+        service.update_tracker = Mock()
+        service.update_tracker.updates = {'channels': {}}
+        service.update_tracker.should_force_check.return_value = False
+        service._check_channel_limits = Mock(return_value=None)
+        service.changelog = None
+        return service
+
+    def _run_targeted_check(self, target_stream_ids):
+        service = self._make_service()
+        streams = [
+            {'id': 101, 'name': 'BBC News HD', 'url': 'http://example.com/101'},
+            {'id': 102, 'name': 'BBC News FHD', 'url': 'http://example.com/102'},
+        ]
+
+        udi = MagicMock()
+        udi.get_channel_by_id.return_value = {'id': 73, 'name': 'BBC News'}
+
+        automation_config = MagicMock()
+        automation_config.get_effective_configuration.return_value = None
+
+        with patch.object(scs, 'get_udi_manager', return_value=udi), \
+                patch.object(scs, 'fetch_channel_streams', return_value=streams), \
+                patch.object(scs, '_get_base_url', return_value='http://dispatcharr:9191'), \
+                patch.object(scs, 'update_channel_streams') as update_channel_streams, \
+                patch(
+                    'apps.automation.automation_config_manager.get_automation_config_manager',
+                    return_value=automation_config,
+                ):
+            result = service._check_channel_concurrent(
+                73,
+                skip_batch_changelog=True,
+                target_stream_ids=target_stream_ids,
+            )
+
+        return service, result, update_channel_streams
+
+    def test_empty_targeted_check_does_not_update_channel_with_empty_streams(self):
+        service, result, update_channel_streams = self._run_targeted_check([])
+
+        update_channel_streams.assert_not_called()
+        service.check_queue.mark_completed.assert_called_once_with(73)
+        service.update_tracker.mark_channel_checked.assert_called_once_with(
+            73,
+            stream_count=2,
+            checked_stream_ids=[101, 102],
+        )
+        self.assertTrue(result['skipped'])
+        self.assertEqual(result['skip_reason'], 'no_matching_target_streams')
+
+    def test_nonmatching_targeted_check_does_not_update_channel_with_empty_streams(self):
+        service, result, update_channel_streams = self._run_targeted_check(['999'])
+
+        update_channel_streams.assert_not_called()
+        service.check_queue.mark_completed.assert_called_once_with(73)
+        service.update_tracker.mark_channel_checked.assert_called_once_with(
+            73,
+            stream_count=2,
+            checked_stream_ids=[101, 102],
+        )
+        self.assertTrue(result['skipped'])
+        self.assertEqual(result['skip_reason'], 'no_matching_target_streams')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR prevents targeted stream checks from accidentally clearing a channel when there are no matching target streams to
check.

The issue was observed during an automated quality-check run where a channel already had streams assigned, but Streamflow
entered targeted-check mode with zero target streams. It then continued into the reorder/update path and sent an empty
stream list to Dispatcharr, which removed all streams from the channel.

Example log sequence:

```text
Found 4 streams for channel BBC News
Targeted stream check: evaluating 0 specific newly assigned streams
Successfully updated channel 73 with 0 streams

## Why This Was Created

Targeted stream checks are meant to evaluate only newly assigned streams. If a targeted check is invoked with an empty or
nonmatching target list, that should be a no-op for channel stream assignment.

Before this change, the empty targeted-check path could leave analyzed_streams empty and still call the channel update
logic. That made Streamflow PATCH the channel with streams: [], clearing the existing channel streams even though the
channel was not actually empty.

## What Changed

- Added a guard for targeted stream checks where no current channel streams match target_stream_ids.
- In that case, Streamflow now:
    - logs that no matching target streams were found,
    - marks the channel check as completed,
    - records the current stream IDs as checked,
    - returns a skipped/no-op result,
    - skips the reorder/update call entirely.
- Applied the same behavior to both concurrent and sequential stream-check paths.
- Converted repeated target ID membership checks into a set lookup.
- Added regression coverage for:
    - empty targeted stream ID list,
    - nonmatching targeted stream ID list,
    - ensuring update_channel_streams is not called with an empty stream list.

## Expected Behavior After This Change

If targeted check mode has no matching target streams, existing channel streams remain untouched.

Streamflow should only update the channel stream list when it has actual candidates to reorder or remove according to the
configured stream-checking rules.

## Test Plan

- Added and ran regression tests for empty/nonmatching targeted stream checks.
- Verified the changed source and test file compile successfully.