### PR TITLE
Add quality-check blank detection

### DIFF
--- a/backend/apps/api/schemas.py
+++ b/backend/apps/api/schemas.py
@@ -40,10 +40,16 @@ def _normalize_profile_payload(data: Dict[str, Any]) -> Dict[str, Any]:
     normalized = dict(data)
     normalized_stream_checking = dict(stream_checking)
 
-    if "remove_dead_streams" in normalized_stream_checking:
-        normalized_stream_checking["remove_dead_streams"] = _parse_bool(
-            normalized_stream_checking["remove_dead_streams"],
-            field_name="stream_checking.remove_dead_streams",
+    for bool_field in (
+        "remove_dead_streams",
+        "blank_check_enabled",
+        "treat_blank_as_dead",
+    ):
+        if bool_field not in normalized_stream_checking:
+            continue
+        normalized_stream_checking[bool_field] = _parse_bool(
+            normalized_stream_checking[bool_field],
+            field_name=f"stream_checking.{bool_field}",
         )
 
     normalized["stream_checking"] = normalized_stream_checking

--- a/backend/apps/core/config_migrator.py
+++ b/backend/apps/core/config_migrator.py
@@ -197,6 +197,7 @@ def convert_to_new_format(
                     "grace_period": False,
                     "check_all_streams": False,
                     "loop_check_enabled": False,
+                    "blank_check_enabled": False,
                     "m3u_priority": m3u_priority,
                     "m3u_priority_mode": m3u_priority_mode,
                     "min_resolution": "any",

--- a/backend/apps/core/config_migrator.py
+++ b/backend/apps/core/config_migrator.py
@@ -198,7 +198,6 @@ def convert_to_new_format(
                     "check_all_streams": False,
                     "loop_check_enabled": False,
                     "blank_check_enabled": False,
-                    "treat_blank_as_dead": True,
                     "m3u_priority": m3u_priority,
                     "m3u_priority_mode": m3u_priority_mode,
                     "min_resolution": "any",

--- a/backend/apps/core/config_migrator.py
+++ b/backend/apps/core/config_migrator.py
@@ -198,6 +198,7 @@ def convert_to_new_format(
                     "check_all_streams": False,
                     "loop_check_enabled": False,
                     "blank_check_enabled": False,
+                    "treat_blank_as_dead": True,
                     "m3u_priority": m3u_priority,
                     "m3u_priority_mode": m3u_priority_mode,
                     "min_resolution": "any",

--- a/backend/apps/core/stream_stats_utils.py
+++ b/backend/apps/core/stream_stats_utils.py
@@ -418,7 +418,8 @@ def is_stream_dead(stream_data: Dict[str, Any], config: Dict[str, Any] = None) -
     
     A stream is dead if:
     - It exited early on all attempts without completing the probe window (Reason: 'unstable')
-    - The quality probe identified a mostly blank video window (Reason: 'blank')
+    - The quality probe identified a mostly blank video window and blank-as-dead
+      handling is enabled (Reason: 'blank')
     - Resolution is '0x0' or contains 0 in width or height (Reason: 'offline')
     - Bitrate is 0 or None (Reason: 'offline')
     - Falls below configured minimum thresholds (Reason: 'low_quality')
@@ -430,6 +431,8 @@ def is_stream_dead(stream_data: Dict[str, Any], config: Dict[str, Any] = None) -
                 - min_resolution_height: Minimum height in pixels (default: 0 = no check)
                 - min_bitrate_kbps: Minimum bitrate in kbps (default: 0 = no check)
                 - min_score: Minimum score 0-100 (default: 0 = no check)
+                - treat_blank_as_dead: Whether detected blank screens count as dead
+                  (default: True for backwards compatibility)
         
     Returns:
         Tuple of (bool, str): (is_dead, reason)
@@ -469,7 +472,8 @@ def is_stream_dead(stream_data: Dict[str, Any], config: Dict[str, Any] = None) -
 
     blank_probe_ran = stream_data.get('blank_probe_ran', stream_stats.get('blank_probe_ran'))
     blank_detected = stream_data.get('blank_detected', stream_stats.get('blank_detected'))
-    if _coerce_bool(blank_probe_ran) and _coerce_bool(blank_detected):
+    treat_blank_as_dead = True if config is None else config.get('treat_blank_as_dead', True)
+    if _coerce_bool(treat_blank_as_dead) and _coerce_bool(blank_probe_ran) and _coerce_bool(blank_detected):
         return True, 'blank'
 
     # Extract normalized stats

--- a/backend/apps/core/stream_stats_utils.py
+++ b/backend/apps/core/stream_stats_utils.py
@@ -147,6 +147,15 @@ def format_fps(fps: Optional[float]) -> str:
     return f"{fps:.1f} fps"
 
 
+def _coerce_bool(value: Any) -> bool:
+    """Interpret common stored boolean values without treating 'false' as truthy."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {'true', '1', 'yes', 'on'}
+    return bool(value)
+
+
 def normalize_resolution(resolution: Any) -> str:
     """Normalize resolution to standard format.
     
@@ -409,6 +418,7 @@ def is_stream_dead(stream_data: Dict[str, Any], config: Dict[str, Any] = None) -
     
     A stream is dead if:
     - It exited early on all attempts without completing the probe window (Reason: 'unstable')
+    - The quality probe identified a mostly blank video window (Reason: 'blank')
     - Resolution is '0x0' or contains 0 in width or height (Reason: 'offline')
     - Bitrate is 0 or None (Reason: 'offline')
     - Falls below configured minimum thresholds (Reason: 'low_quality')
@@ -423,8 +433,9 @@ def is_stream_dead(stream_data: Dict[str, Any], config: Dict[str, Any] = None) -
         
     Returns:
         Tuple of (bool, str): (is_dead, reason)
-        Reasons: 'unstable' (exited early), 'offline' (truly dead),
-                 'low_quality' (below thresholds), 'none' (not dead)
+        Reasons: 'unstable' (exited early), 'blank' (blank screen),
+                 'offline' (truly dead), 'low_quality' (below thresholds),
+                 'none' (not dead)
     """
     # ── Early-exit / instability check ───────────────────────────────────────
     # A stream that never completed the probe window on any attempt is
@@ -445,6 +456,21 @@ def is_stream_dead(stream_data: Dict[str, Any], config: Dict[str, Any] = None) -
         and elapsed < expected * EARLY_EXIT_THRESHOLD
     ):
         return True, 'unstable'
+
+    stream_stats = stream_data.get('stream_stats')
+    if isinstance(stream_stats, str):
+        try:
+            import json
+            stream_stats = json.loads(stream_stats) or {}
+        except Exception:
+            stream_stats = {}
+    if not isinstance(stream_stats, dict):
+        stream_stats = {}
+
+    blank_probe_ran = stream_data.get('blank_probe_ran', stream_stats.get('blank_probe_ran'))
+    blank_detected = stream_data.get('blank_detected', stream_stats.get('blank_detected'))
+    if _coerce_bool(blank_probe_ran) and _coerce_bool(blank_detected):
+        return True, 'blank'
 
     # Extract normalized stats
     stats = extract_stream_stats(stream_data)

--- a/backend/apps/database/manager.py
+++ b/backend/apps/database/manager.py
@@ -180,6 +180,27 @@ class DatabaseManager:
         finally:
             session.close()
 
+    def update_dead_stream_reason(self, url: str, reason: str, channel_id: Optional[int] = None) -> bool:
+        session = self._get_session()
+        try:
+            dead = session.query(DeadStream).filter(DeadStream.url == url).first()
+            if not dead:
+                return False
+
+            dead.reason = reason
+            if channel_id is not None:
+                dead.channel_id = channel_id
+            dead.marked_dead_at = datetime.utcnow()
+
+            session.commit()
+            return True
+        except Exception as e:
+            session.rollback()
+            logger.error(f"Error updating dead stream reason {url}: {e}")
+            return False
+        finally:
+            session.close()
+
     def remove_dead_stream(self, url: str) -> bool:
         session = self._get_session()
         try:

--- a/backend/apps/stream/dead_streams_tracker.py
+++ b/backend/apps/stream/dead_streams_tracker.py
@@ -50,6 +50,14 @@ class DeadStreamsTracker:
             logger.error(f"❌ Error marking stream as dead: {e}")
             return False
     
+    def update_dead_reason(self, stream_url: str, reason: str, channel_id: int = None) -> bool:
+        """Update the reason for an already-dead stream without logging sensitive stream details."""
+        try:
+            return self.db.update_dead_stream_reason(stream_url, reason, channel_id)
+        except Exception as e:
+            logger.error(f"Error updating dead stream reason: {e}")
+            return False
+
     def mark_as_alive(self, stream_url: str) -> bool:
         """Mark a stream as alive (remove from dead streams)."""
         try:

--- a/backend/apps/stream/stream_check_utils.py
+++ b/backend/apps/stream/stream_check_utils.py
@@ -1309,6 +1309,18 @@ def analyze_stream(
                     'blank_segments': result_data.get('blank_segments', []),
                 }
 
+                if result.get('blank_probe_ran'):
+                    blank_duration = float(result.get('blank_duration_secs') or 0.0)
+                    blank_ratio = float(result.get('blank_ratio') or 0.0)
+                    blank_segments_count = len(result.get('blank_segments') or [])
+                    logger.info(
+                        f"  [blank-detect] {stream_name} (ID: {stream_id}): "
+                        f"detected={bool(result.get('blank_detected'))}, "
+                        f"blank_duration={blank_duration:.1f}s, "
+                        f"ratio={blank_ratio:.3f}, "
+                        f"segments={blank_segments_count}"
+                    )
+
                 if logger.isEnabledFor(logging.DEBUG):
                     if result['video_codec'] != 'N/A' or result['resolution'] != '0x0':
                         logger.info(f"    Video: {result['video_codec']}, {result['resolution']}, {result['fps']} FPS")

--- a/backend/apps/stream/stream_check_utils.py
+++ b/backend/apps/stream/stream_check_utils.py
@@ -39,6 +39,7 @@ stats line is produced the stream is considered unanalyzable — a missing
 bitrate is a meaningful signal that the stream is dead or unresponsive.
 """
 
+import hashlib
 import io
 import json
 import logging
@@ -55,6 +56,13 @@ from PIL import Image
 from apps.core.logging_config import setup_logging
 
 logger = setup_logging(__name__)
+
+
+def _audit_ref(kind: str, value: Any) -> str:
+    if value is None:
+        return f"{kind}-unknown"
+    digest = hashlib.sha256(f"{kind}:{value}".encode("utf-8")).hexdigest()[:12]
+    return f"{kind}-{digest}"
 
 # ── Loop probe constants ──────────────────────────────────────────────────────
 # Hamming tolerance for one-shot probes is tighter than the live sidecar value
@@ -1313,8 +1321,9 @@ def analyze_stream(
                     blank_duration = float(result.get('blank_duration_secs') or 0.0)
                     blank_ratio = float(result.get('blank_ratio') or 0.0)
                     blank_segments_count = len(result.get('blank_segments') or [])
-                    logger.info(
-                        f"  [blank-detect] {stream_name} (ID: {stream_id}): "
+                    log_method = logger.warning if result.get('blank_detected') else logger.info
+                    log_method(
+                        f"  [blank-detect] stream_ref={_audit_ref('stream', stream_id)}: "
                         f"detected={bool(result.get('blank_detected'))}, "
                         f"blank_duration={blank_duration:.1f}s, "
                         f"ratio={blank_ratio:.3f}, "

--- a/backend/apps/stream/stream_check_utils.py
+++ b/backend/apps/stream/stream_check_utils.py
@@ -49,7 +49,7 @@ import subprocess
 import threading
 import time
 from datetime import datetime
-from typing import Dict, Optional, Tuple, Any
+from typing import Dict, Optional, Tuple, Any, List
 
 from PIL import Image
 from apps.core.logging_config import setup_logging
@@ -76,6 +76,11 @@ MAX_DEBUG_LINES_TO_LOG = 10  # Maximum number of debug lines to log from ffmpeg 
 # has flowed.  Values at or below this threshold are startup artifacts and
 # are ignored so they cannot be mistaken for a real (very low) bitrate.
 MIN_VALID_PROGRESS_BITRATE = 10.0  # kbps
+
+BLACK_START_RE = re.compile(r'black_start:(?P<start>-?[0-9]+(?:\.[0-9]+)?)')
+BLACK_END_RE = re.compile(r'black_end:(?P<end>-?[0-9]+(?:\.[0-9]+)?)')
+BLACK_DURATION_RE = re.compile(r'black_duration:(?P<duration>-?[0-9]+(?:\.[0-9]+)?)')
+FFMPEG_TIME_RE = re.compile(r'time=(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+(?:\.\d+)?)')
 
 # FourCC to common codec name mapping
 FOURCC_TO_CODEC = {
@@ -135,6 +140,106 @@ def _log_ffmpeg_errors(output: str, logger: logging.Logger, error_patterns: list
         for line in output.splitlines()[-MAX_DEBUG_LINES_TO_LOG:]:
             if line.strip():
                 logger.debug(f"     {line.strip()}")
+
+
+def _parse_ffmpeg_progress_time(line: str) -> Optional[float]:
+    """Parse ffmpeg progress time=HH:MM:SS.xx into seconds."""
+    match = FFMPEG_TIME_RE.search(line)
+    if not match:
+        return None
+
+    try:
+        return (
+            int(match.group('hours')) * 3600
+            + int(match.group('minutes')) * 60
+            + float(match.group('seconds'))
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_blank_detection(
+    output: str,
+    duration: int,
+    blank_ratio_threshold: float = 0.80,
+) -> Dict[str, Any]:
+    """Parse ffmpeg blackdetect output into blank-screen metrics."""
+    segments: List[Dict[str, float]] = []
+    pending_start: Optional[float] = None
+    last_media_time: float = 0.0
+
+    for line in output.splitlines():
+        progress_time = _parse_ffmpeg_progress_time(line)
+        if progress_time is not None:
+            last_media_time = max(last_media_time, progress_time)
+
+        start_match = BLACK_START_RE.search(line)
+        end_match = BLACK_END_RE.search(line)
+        duration_match = BLACK_DURATION_RE.search(line)
+
+        start = None
+        if start_match:
+            try:
+                start = max(0.0, float(start_match.group('start')))
+                pending_start = start
+            except (TypeError, ValueError):
+                start = None
+
+        if not end_match:
+            continue
+
+        try:
+            end = max(0.0, float(end_match.group('end')))
+        except (TypeError, ValueError):
+            pending_start = None
+            continue
+
+        segment_start = start if start is not None else pending_start
+        segment_duration = None
+        if duration_match:
+            try:
+                segment_duration = max(0.0, float(duration_match.group('duration')))
+            except (TypeError, ValueError):
+                segment_duration = None
+
+        if segment_start is None and segment_duration is not None:
+            segment_start = max(0.0, end - segment_duration)
+        elif segment_start is None:
+            segment_start = 0.0
+
+        if segment_duration is None:
+            segment_duration = max(0.0, end - segment_start)
+
+        segments.append({
+            'start': round(segment_start, 3),
+            'end': round(end, 3),
+            'duration': round(segment_duration, 3),
+        })
+        pending_start = None
+
+    if pending_start is not None:
+        observed_end = max(float(duration or 0), last_media_time, pending_start)
+        segments.append({
+            'start': round(pending_start, 3),
+            'end': round(observed_end, 3),
+            'duration': round(max(0.0, observed_end - pending_start), 3),
+        })
+
+    blank_duration = sum(segment.get('duration', 0.0) for segment in segments)
+    probe_duration = float(duration or 0)
+    if probe_duration > 0:
+        blank_duration = min(blank_duration, probe_duration)
+        blank_ratio = min(1.0, blank_duration / probe_duration)
+    else:
+        blank_ratio = 0.0
+
+    return {
+        'blank_probe_ran': True,
+        'blank_detected': blank_ratio >= blank_ratio_threshold,
+        'blank_duration_secs': round(blank_duration, 3),
+        'blank_ratio': round(blank_ratio, 4),
+        'blank_segments': segments,
+    }
 
 
 def _extract_codec_from_line(line: str, codec_type: str) -> Optional[str]:
@@ -406,7 +511,17 @@ def get_stream_info(url: str, timeout: int = 30, user_agent: str = 'VLC/3.0.14')
         return None, None
 
 
-def get_stream_info_and_bitrate(url: str, duration: int = 30, timeout: int = 30, user_agent: str = 'VLC/3.0.14', stream_startup_buffer: int = 10) -> Dict[str, Any]:
+def get_stream_info_and_bitrate(
+    url: str,
+    duration: int = 30,
+    timeout: int = 30,
+    user_agent: str = 'VLC/3.0.14',
+    stream_startup_buffer: int = 10,
+    blank_check_enabled: bool = False,
+    blank_check_min_duration: float = 2.0,
+    blank_check_pixel_threshold: float = 0.10,
+    blank_check_ratio_threshold: float = 0.80,
+) -> Dict[str, Any]:
     """
     Get complete stream information using ffmpeg in a single call.
 
@@ -424,12 +539,17 @@ def get_stream_info_and_bitrate(url: str, duration: int = 30, timeout: int = 30,
         timeout: Base timeout in seconds (actual timeout includes duration + overhead)
         user_agent: User agent string to use for HTTP requests
         stream_startup_buffer: Buffer in seconds for stream startup (default: 10s)
+        blank_check_enabled: Run ffmpeg blackdetect on the same input connection
+        blank_check_min_duration: Minimum continuous black duration in seconds
+        blank_check_pixel_threshold: blackdetect pixel threshold
+        blank_check_ratio_threshold: Probe-window ratio required to flag blank
 
     Returns:
         Dictionary containing:
         - video_codec, audio_codec, resolution, fps, bitrate_kbps
         - hdr_format, pixel_format, audio_sample_rate, audio_channels
         - channel_layout, audio_bitrate, status, elapsed_time
+        - blank_probe_ran, blank_detected, blank_duration_secs, blank_ratio
     """
     # Validate and sanitize URL to prevent command injection
     if not url or not isinstance(url, str):
@@ -439,7 +559,10 @@ def get_stream_info_and_bitrate(url: str, duration: int = 30, timeout: int = 30,
             'fps': 0, 'bitrate_kbps': None, 'hdr_format': None,
             'pixel_format': None, 'audio_sample_rate': None,
             'audio_channels': None, 'channel_layout': None,
-            'audio_bitrate': None, 'status': 'Error', 'elapsed_time': 0
+            'audio_bitrate': None, 'status': 'Error', 'elapsed_time': 0,
+            'blank_probe_ran': False, 'blank_detected': False,
+            'blank_duration_secs': None, 'blank_ratio': None,
+            'blank_segments': []
         }
 
     url_lower = url.lower()
@@ -451,7 +574,10 @@ def get_stream_info_and_bitrate(url: str, duration: int = 30, timeout: int = 30,
             'fps': 0, 'bitrate_kbps': None, 'hdr_format': None,
             'pixel_format': None, 'audio_sample_rate': None,
             'audio_channels': None, 'channel_layout': None,
-            'audio_bitrate': None, 'status': 'Error', 'elapsed_time': 0
+            'audio_bitrate': None, 'status': 'Error', 'elapsed_time': 0,
+            'blank_probe_ran': False, 'blank_detected': False,
+            'blank_duration_secs': None, 'blank_ratio': None,
+            'blank_segments': []
         }
 
     logger.debug(f"Analyzing stream with ffmpeg for {duration}s: {url[:50]}...")
@@ -484,12 +610,26 @@ def get_stream_info_and_bitrate(url: str, duration: int = 30, timeout: int = 30,
         '-c', 'copy', '-f', 'mpegts', 'pipe:1'
     ]
 
+    if blank_check_enabled:
+        command += [
+            '-map', '0:v:0?', '-t', str(duration),
+            '-an', '-sn',
+            '-vf', (
+                f'blackdetect=d={float(blank_check_min_duration):g}:'
+                f'pix_th={float(blank_check_pixel_threshold):g}'
+            ),
+            '-f', 'null', os.devnull,
+        ]
+
     result_data = {
         'video_codec': 'N/A', 'audio_codec': 'N/A', 'resolution': '0x0',
         'fps': 0, 'bitrate_kbps': None, 'hdr_format': None,
         'pixel_format': None, 'audio_sample_rate': None,
         'audio_channels': None, 'channel_layout': None,
-        'audio_bitrate': None, 'status': 'OK', 'elapsed_time': 0
+        'audio_bitrate': None, 'status': 'OK', 'elapsed_time': 0,
+        'blank_probe_ran': False, 'blank_detected': False,
+        'blank_duration_secs': None, 'blank_ratio': None,
+        'blank_segments': []
     }
 
     # Total subprocess timeout: analysis window + startup headroom
@@ -508,6 +648,18 @@ def get_stream_info_and_bitrate(url: str, duration: int = 30, timeout: int = 30,
         result_data['elapsed_time'] = elapsed
 
         output = result.stderr
+        if blank_check_enabled:
+            result_data.update(_parse_blank_detection(
+                output,
+                duration=duration,
+                blank_ratio_threshold=float(blank_check_ratio_threshold),
+            ))
+            if result_data.get('blank_detected'):
+                logger.warning(
+                    "  [blank-detect] Blank screen detected "
+                    f"({result_data['blank_duration_secs']:.1f}s/"
+                    f"{duration}s, ratio={result_data['blank_ratio']:.2f})"
+                )
         progress_bitrate = None
         last_stats_line = None  # keeps updating; final line is the most stable average
 
@@ -1038,7 +1190,11 @@ def analyze_stream(
     retries: int = 1,
     retry_delay: int = 10,
     user_agent: str = 'VLC/3.0.14',
-    stream_startup_buffer: int = 10
+    stream_startup_buffer: int = 10,
+    blank_check_enabled: bool = False,
+    blank_check_min_duration: float = 2.0,
+    blank_check_pixel_threshold: float = 0.10,
+    blank_check_ratio_threshold: float = 0.80,
 ) -> Dict[str, Any]:
     """
     Perform complete stream analysis including codec, resolution, FPS, bitrate, and audio.
@@ -1058,6 +1214,10 @@ def analyze_stream(
         retry_delay: Delay in seconds between retries
         user_agent: User agent string to use for HTTP requests
         stream_startup_buffer: Buffer in seconds for stream startup (default: 10s)
+        blank_check_enabled: Run blank-screen detection in the same ffmpeg process
+        blank_check_min_duration: Minimum continuous black duration in seconds
+        blank_check_pixel_threshold: blackdetect pixel threshold
+        blank_check_ratio_threshold: Probe-window ratio required to flag blank
 
     Returns:
         Dictionary containing analysis results with keys:
@@ -1090,6 +1250,11 @@ def analyze_stream(
         'status': 'Error',
         'elapsed_time': 0,
         'ffmpeg_duration': ffmpeg_duration,
+        'blank_probe_ran': False,
+        'blank_detected': False,
+        'blank_duration_secs': None,
+        'blank_ratio': None,
+        'blank_segments': [],
     }
 
     try:
@@ -1111,7 +1276,11 @@ def analyze_stream(
                     duration=ffmpeg_duration,
                     timeout=timeout,
                     user_agent=user_agent,
-                    stream_startup_buffer=stream_startup_buffer
+                    stream_startup_buffer=stream_startup_buffer,
+                    blank_check_enabled=blank_check_enabled,
+                    blank_check_min_duration=blank_check_min_duration,
+                    blank_check_pixel_threshold=blank_check_pixel_threshold,
+                    blank_check_ratio_threshold=blank_check_ratio_threshold
                 )
 
                 result = {
@@ -1133,6 +1302,11 @@ def analyze_stream(
                     'status': result_data['status'],
                     'elapsed_time': result_data.get('elapsed_time', 0),
                     'ffmpeg_duration': ffmpeg_duration,
+                    'blank_probe_ran': result_data.get('blank_probe_ran', False),
+                    'blank_detected': result_data.get('blank_detected', False),
+                    'blank_duration_secs': result_data.get('blank_duration_secs'),
+                    'blank_ratio': result_data.get('blank_ratio'),
+                    'blank_segments': result_data.get('blank_segments', []),
                 }
 
                 if logger.isEnabledFor(logging.DEBUG):

--- a/backend/apps/stream/stream_checker_components.py
+++ b/backend/apps/stream/stream_checker_components.py
@@ -40,6 +40,9 @@ class StreamCheckConfig:
             'retries': 1,               # retry attempts
             'retry_delay': 10,          # seconds between retries
             'max_loop_duration': 120,   # maximum loop period to detect (seconds); probe runs for 3× this value
+            'blank_check_min_duration': 2.0,  # seconds of continuous black before blackdetect logs a segment
+            'blank_check_pixel_threshold': 0.10,  # blackdetect pix_th threshold
+            'blank_check_ratio_threshold': 0.80,  # probe-window ratio that marks a stream blank
             'user_agent': 'VLC/3.0.14'  # user agent for ffmpeg/ffprobe
         },
         'scoring': {

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -483,7 +483,11 @@ class StreamCheckerService:
         if min_fps and min_fps > 0:
             config['min_fps'] = min_fps
 
-        config['treat_blank_as_dead'] = stream_checking.get('treat_blank_as_dead', True)
+        # A single profile switch controls blank handling: when blank checks run,
+        # detected blank streams are treated as dead. The legacy
+        # treat_blank_as_dead value is intentionally ignored so older profiles
+        # with it set to False do not silently keep blanks alive.
+        config['treat_blank_as_dead'] = stream_checking.get('blank_check_enabled') is True
 
         return config
 

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -19,6 +19,7 @@ updates and maintaining a queue of channels that need checking. It
 integrates with the stream_check_utils.py module for stream analysis.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -85,6 +86,13 @@ logger = setup_logging(__name__)
 
 # Configuration directory
 CONFIG_DIR = Path(os.environ.get('CONFIG_DIR', '/app/data'))
+
+
+def _audit_ref(kind: str, value: Any) -> str:
+    if value is None:
+        return f"{kind}-unknown"
+    digest = hashlib.sha256(f"{kind}:{value}".encode("utf-8")).hexdigest()[:12]
+    return f"{kind}-{digest}"
 
 
 from apps.stream.stream_checker_components import (
@@ -610,8 +618,10 @@ class StreamCheckerService:
     def _log_blank_detection_summary(
         self,
         channel_id: int,
-        channel_name: str,
+        _channel_name: str,
         analyzed_streams: List[Dict],
+        dead_stream_ids: Optional[Set[int]] = None,
+        dead_stream_removal_enabled: Optional[bool] = None,
     ) -> None:
         """Log a URL-free blank-detection summary for post-run audits."""
         probed_streams = [
@@ -631,22 +641,31 @@ class StreamCheckerService:
                 return 0.0
 
         max_ratio_stream = max(probed_streams, key=lambda stream: _metric(stream, 'blank_ratio'))
+        channel_ref = _audit_ref('channel', channel_id)
         logger.info(
-            f"[blank-detect] Channel {channel_name} (ID: {channel_id}): "
+            f"[blank-detect] Channel summary: channel_ref={channel_ref}, "
             f"probed={len(probed_streams)}, clean={clean_count}, "
             f"blank={len(blank_streams)}, "
             f"max_ratio={_metric(max_ratio_stream, 'blank_ratio'):.3f}, "
             f"max_blank_duration={_metric(max_ratio_stream, 'blank_duration_secs'):.1f}s"
         )
 
-        for stream in blank_streams[:10]:
+        dead_stream_ids = dead_stream_ids or set()
+        removal_enabled = bool(dead_stream_removal_enabled)
+
+        for stream in blank_streams:
+            stream_id = stream.get('stream_id')
+            marked_dead = stream_id in dead_stream_ids
+            dead_reason = stream.get('dead_reason') or ('blank' if marked_dead else 'none')
+            action = 'remove' if marked_dead and removal_enabled else 'retain'
             logger.warning(
-                f"[blank-detect] Blank candidate: channel_id={channel_id}, "
-                f"stream_id={stream.get('stream_id')}, "
-                f"name={stream.get('stream_name', 'Unknown')!r}, "
+                f"[blank-detect] Blank candidate: channel_ref={channel_ref}, "
+                f"stream_ref={_audit_ref('stream', stream_id)}, "
                 f"duration={_metric(stream, 'blank_duration_secs'):.1f}s, "
                 f"ratio={_metric(stream, 'blank_ratio'):.3f}, "
-                f"segments={len(stream.get('blank_segments') or [])}"
+                f"segments={len(stream.get('blank_segments') or [])}, "
+                f"marked_dead={marked_dead}, reason={dead_reason}, "
+                f"removal_enabled={removal_enabled}, action={action}"
             )
     
     def _get_m3u_account_name(self, stream_id: int, udi=None) -> Optional[str]:
@@ -1554,7 +1573,15 @@ class StreamCheckerService:
                     if is_dead and not was_dead:
                         if self.dead_streams_tracker.mark_as_dead(stream_url, stream_id, stream_name, channel_id, reason=dead_reason):
                             dead_stream_ids.add(stream_id)
-                            logger.warning(f"Stream {stream_id} detected as DEAD: {stream_name} (reason={dead_reason})")
+                            if analyzed.get('blank_detected'):
+                                logger.warning(
+                                    f"[blank-detect] Stream marked dead: "
+                                    f"channel_ref={_audit_ref('channel', channel_id)}, "
+                                    f"stream_ref={_audit_ref('stream', stream_id)}, "
+                                    f"reason={dead_reason}"
+                                )
+                            else:
+                                logger.warning(f"Stream {stream_id} detected as DEAD: {stream_name} (reason={dead_reason})")
                         else:
                             logger.error(f"Failed to mark stream {stream_id} as dead in tracker")
                     elif not is_dead and was_dead:
@@ -1639,7 +1666,13 @@ class StreamCheckerService:
 
                 logger.info(f"Completed smart parallel analysis of {len(results)} streams with account-aware limits")
 
-            self._log_blank_detection_summary(channel_id, channel_name, analyzed_streams)
+            self._log_blank_detection_summary(
+                channel_id,
+                channel_name,
+                analyzed_streams,
+                dead_stream_ids=dead_stream_ids,
+                dead_stream_removal_enabled=dead_stream_removal_enabled,
+            )
 
             # Run loop probes on eligible streams (top 25% scoring >= 0.5).
             # Called after all streams are scored and analyzed_streams is fully
@@ -2270,7 +2303,15 @@ class StreamCheckerService:
                     # Mark as dead in tracker
                     if self.dead_streams_tracker.mark_as_dead(stream_url, stream['id'], stream_name, channel_id, reason=dead_reason):
                         dead_stream_ids.add(stream['id'])
-                        logger.warning(f"Stream {stream['id']} detected as DEAD: {stream_name} (reason={dead_reason})")
+                        if analyzed.get('blank_detected'):
+                            logger.warning(
+                                f"[blank-detect] Stream marked dead: "
+                                f"channel_ref={_audit_ref('channel', channel_id)}, "
+                                f"stream_ref={_audit_ref('stream', stream['id'])}, "
+                                f"reason={dead_reason}"
+                            )
+                        else:
+                            logger.warning(f"Stream {stream['id']} detected as DEAD: {stream_name} (reason={dead_reason})")
                     else:
                         logger.error(f"Failed to mark stream {stream['id']} as DEAD, will not remove from channel")
                 elif not is_dead and was_dead:
@@ -2427,7 +2468,13 @@ class StreamCheckerService:
                     analyzed['score'] = score
                     analyzed_streams.append(analyzed)
 
-            self._log_blank_detection_summary(channel_id, channel_name, analyzed_streams)
+            self._log_blank_detection_summary(
+                channel_id,
+                channel_name,
+                analyzed_streams,
+                dead_stream_ids=dead_stream_ids,
+                dead_stream_removal_enabled=dead_stream_removal_enabled,
+            )
 
             # Run loop probes on eligible streams — all streams scored, full
             # distribution known for top-percentile calculation.

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -671,6 +671,43 @@ class StreamCheckerService:
                 f"marked_dead={marked_dead}, reason={dead_reason}, "
                 f"removal_enabled={removal_enabled}, action={action}"
             )
+
+    def _refresh_dead_stream_reason_if_needed(
+        self,
+        stream_url: str,
+        stream_id: int,
+        stream_name: str,
+        channel_id: int,
+        reason: str,
+        blank_detected: bool = False,
+    ) -> bool:
+        """Refresh stale dead-stream reasons after a checked stream gets a newer verdict."""
+        if not stream_url or not reason or reason == 'none':
+            return False
+
+        try:
+            current_reason = None
+            if hasattr(self.dead_streams_tracker, 'get_dead_reason'):
+                current_reason = self.dead_streams_tracker.get_dead_reason(stream_url)
+            if current_reason == reason:
+                return False
+
+            update_reason = getattr(self.dead_streams_tracker, 'update_dead_reason', None)
+            if not callable(update_reason):
+                return False
+            updated = update_reason(stream_url, reason, channel_id=channel_id)
+
+            if updated and blank_detected:
+                logger.warning(
+                    f"[blank-detect] Stream dead reason updated: "
+                    f"channel_ref={_audit_ref('channel', channel_id)}, "
+                    f"stream_ref={_audit_ref('stream', stream_id)}, "
+                    f"reason={reason}"
+                )
+            return bool(updated)
+        except Exception as exc:
+            logger.warning("Failed to refresh dead stream reason for stream %s: %s", stream_id, exc)
+            return False
     
     def _get_m3u_account_name(self, stream_id: int, udi=None) -> Optional[str]:
         """Get the M3U account name for a stream.
@@ -1603,6 +1640,14 @@ class StreamCheckerService:
                         # check pass. Unchecked streams must not be culled based on prior-run
                         # tracker state — their status will be re-evaluated in the next full check.
                         if stream_id in checked_stream_id_set:
+                            self._refresh_dead_stream_reason_if_needed(
+                                stream_url,
+                                stream_id,
+                                stream_name,
+                                channel_id,
+                                dead_reason,
+                                blank_detected=bool(analyzed.get('blank_detected')),
+                            )
                             dead_stream_ids.add(stream_id)
                         else:
                             logger.debug(
@@ -2333,6 +2378,14 @@ class StreamCheckerService:
                     # symmetry with the concurrent method and to make the scope
                     # constraint explicit at review time.
                     if stream['id'] in checked_stream_id_set:
+                        self._refresh_dead_stream_reason_if_needed(
+                            stream_url,
+                            stream['id'],
+                            stream_name,
+                            channel_id,
+                            dead_reason,
+                            blank_detected=bool(analyzed.get('blank_detected')),
+                        )
                         dead_stream_ids.add(stream['id'])
 
                 # Calculate score

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -681,12 +681,16 @@ class StreamCheckerService:
             "loop_detected": stream_data.get("loop_detected") if stream_data.get("loop_probe_ran") else False,
             "loop_duration_secs": stream_data.get("loop_duration_secs") if stream_data.get("loop_detected") else None,
             "loop_score_penalty": stream_data.get("loop_score_penalty"),
+            "blank_probe_ran": True if stream_data.get("blank_probe_ran") else False,
+            "blank_detected": stream_data.get("blank_detected") if stream_data.get("blank_probe_ran") else False,
+            "blank_duration_secs": stream_data.get("blank_duration_secs") if stream_data.get("blank_probe_ran") else None,
+            "blank_ratio": stream_data.get("blank_ratio") if stream_data.get("blank_probe_ran") else None,
         }
         
         # Clean up the payload, removing None and N/A values.
         # PRESERVE_FALSE: keep False values for boolean loop fields so they
         # explicitly clear stale True values in Dispatcharr on PATCH merge.
-        PRESERVE_FALSE = {"loop_probe_ran", "loop_detected"}
+        PRESERVE_FALSE = {"loop_probe_ran", "loop_detected", "blank_probe_ran", "blank_detected"}
         stream_stats_payload = {
             k: v for k, v in stream_stats_payload.items()
             if v not in [None, "N/A"] or (v is None and k not in PRESERVE_FALSE)
@@ -780,12 +784,16 @@ class StreamCheckerService:
             "loop_detected": stream_data.get("loop_detected") if stream_data.get("loop_probe_ran") else False,
             "loop_duration_secs": stream_data.get("loop_duration_secs") if stream_data.get("loop_detected") else None,
             "loop_score_penalty": stream_data.get("loop_score_penalty"),
+            "blank_probe_ran": True if stream_data.get("blank_probe_ran") else False,
+            "blank_detected": stream_data.get("blank_detected") if stream_data.get("blank_probe_ran") else False,
+            "blank_duration_secs": stream_data.get("blank_duration_secs") if stream_data.get("blank_probe_ran") else None,
+            "blank_ratio": stream_data.get("blank_ratio") if stream_data.get("blank_probe_ran") else None,
         }
         
         # Clean up the payload, removing None and N/A values.
         # PRESERVE_FALSE: keep False values for boolean loop fields so they
         # explicitly clear stale True values in Dispatcharr on PATCH merge.
-        PRESERVE_FALSE = {"loop_probe_ran", "loop_detected"}
+        PRESERVE_FALSE = {"loop_probe_ran", "loop_detected", "blank_probe_ran", "blank_detected"}
         stream_stats_payload = {
             k: v for k, v in stream_stats_payload.items()
             if v not in [None, "N/A"] or (v is None and k not in PRESERVE_FALSE)
@@ -1060,6 +1068,7 @@ class StreamCheckerService:
         allow_revive = True
         grace_period = False
         loop_check_enabled = False
+        blank_check_enabled = False
         loop_penalty = 0.0
         priority_m3u_ids = []
         priority_mode = 'absolute'
@@ -1102,6 +1111,7 @@ class StreamCheckerService:
                 priority_mode = profile_stream_checking.get('m3u_priority_mode', 'absolute')
                 grace_period = profile_stream_checking.get('grace_period', False)
                 loop_check_enabled = profile_stream_checking.get('loop_check_enabled', False)
+                blank_check_enabled = profile_stream_checking.get('blank_check_enabled', False)
                 profile_remove_dead_streams = profile_stream_checking.get('remove_dead_streams')
                 if isinstance(profile_remove_dead_streams, bool):
                     dead_stream_removal_enabled = profile_remove_dead_streams
@@ -1384,7 +1394,7 @@ class StreamCheckerService:
                         stream_statuses[stream_id]['status'] = 'error'
                         stream_statuses[stream_id]['score'] = 0.0
                     elif is_dead:
-                        stream_statuses[stream_id]['status'] = _dead_reason if _dead_reason == 'low_quality' else 'dead'
+                        stream_statuses[stream_id]['status'] = _dead_reason if _dead_reason in ('low_quality', 'blank') else 'dead'
                         stream_statuses[stream_id]['score'] = 0.0
                     else:
                         stream_statuses[stream_id]['status'] = 'completed'
@@ -1435,7 +1445,7 @@ class StreamCheckerService:
                             self.progress.update(
                                 channel_id=channel_id,
                                 channel_name=channel_name,
-                                current=sum(1 for s in stream_statuses.values() if s.get('status') in ('completed', 'dead', 'error', 'loop_detected')),
+                                current=sum(1 for s in stream_statuses.values() if s.get('status') in ('completed', 'dead', 'error', 'loop_detected', 'blank')),
                                 total=total_streams,
                                 status='analyzing',
                                 step='Analyzing streams with account limits',
@@ -1463,7 +1473,11 @@ class StreamCheckerService:
                         retries=analysis_params.get('retries', 1),
                         retry_delay=analysis_params.get('retry_delay', 10),
                         user_agent=analysis_params.get('user_agent', 'VLC/3.0.14'),
-                        stream_startup_buffer=analysis_params.get('stream_startup_buffer', 10)
+                        stream_startup_buffer=analysis_params.get('stream_startup_buffer', 10),
+                        blank_check_enabled=blank_check_enabled,
+                        blank_check_min_duration=analysis_params.get('blank_check_min_duration', 2.0),
+                        blank_check_pixel_threshold=analysis_params.get('blank_check_pixel_threshold', 0.10),
+                        blank_check_ratio_threshold=analysis_params.get('blank_check_ratio_threshold', 0.80)
                     )
                 finally:
                     _heartbeat_stop.set()
@@ -1490,6 +1504,8 @@ class StreamCheckerService:
                     stream_url = analyzed.get('stream_url', '')
                     stream_name = analyzed.get('stream_name', 'Unknown')
                     was_dead = self.dead_streams_tracker.is_dead(stream_url)
+                    if is_dead:
+                        analyzed['dead_reason'] = dead_reason
                     
                     if is_dead and not was_dead:
                         if self.dead_streams_tracker.mark_as_dead(stream_url, stream_id, stream_name, channel_id, reason=dead_reason):
@@ -1558,6 +1574,10 @@ class StreamCheckerService:
                             'video_codec': stream_stats.get('video_codec', 'N/A'),
                             'audio_codec': stream_stats.get('audio_codec', 'N/A'),
                             'hdr_format': stream_stats.get('hdr_format'),
+                            'blank_probe_ran': stream_stats.get('blank_probe_ran', False),
+                            'blank_detected': stream_stats.get('blank_detected', False),
+                            'blank_duration_secs': stream_stats.get('blank_duration_secs'),
+                            'blank_ratio': stream_stats.get('blank_ratio'),
                             'status': 'cached',
                             'channel_id': channel_id,
                             'channel_name': channel_name,
@@ -1744,7 +1764,7 @@ class StreamCheckerService:
                     
                     # Mark dead streams as "dead" instead of showing score:0
                     if is_dead:
-                        stream_stat['status'] = 'dead'
+                        stream_stat['status'] = analyzed.get('dead_reason') if analyzed.get('dead_reason') == 'blank' else 'dead'
                     elif is_revived:
                         stream_stat['status'] = 'revived'
                         stream_stat['score'] = round(analyzed.get('score', 0), 2)
@@ -1756,6 +1776,11 @@ class StreamCheckerService:
                         stream_stat['loop_probe_ran']      = True
                         stream_stat['loop_detected']       = analyzed.get('loop_detected')
                         stream_stat['loop_duration_secs']  = analyzed.get('loop_duration_secs')
+                    if analyzed.get('blank_probe_ran'):
+                        stream_stat['blank_probe_ran']     = True
+                        stream_stat['blank_detected']      = analyzed.get('blank_detected')
+                        stream_stat['blank_duration_secs'] = analyzed.get('blank_duration_secs')
+                        stream_stat['blank_ratio']         = analyzed.get('blank_ratio')
 
                     # Clean up N/A values for cleaner JSON
                     cleaned_stat = {k: v for k, v in stream_stat.items() if v not in [None]}
@@ -1901,6 +1926,7 @@ class StreamCheckerService:
         allow_revive = True
         grace_period = False
         loop_check_enabled = False
+        blank_check_enabled = False
         loop_penalty = 0.0
         priority_m3u_ids = []
         priority_mode = 'absolute'
@@ -1938,6 +1964,7 @@ class StreamCheckerService:
                 priority_mode = profile_stream_checking.get('m3u_priority_mode', 'absolute')
                 grace_period = profile_stream_checking.get('grace_period', False)
                 loop_check_enabled = profile_stream_checking.get('loop_check_enabled', False)
+                blank_check_enabled = profile_stream_checking.get('blank_check_enabled', False)
                 profile_remove_dead_streams = profile_stream_checking.get('remove_dead_streams')
                 if isinstance(profile_remove_dead_streams, bool):
                     dead_stream_removal_enabled = profile_remove_dead_streams
@@ -2175,7 +2202,11 @@ class StreamCheckerService:
                     retries=analysis_params.get('retries', 1),
                     retry_delay=analysis_params.get('retry_delay', 10),
                     user_agent=analysis_params.get('user_agent', 'VLC/3.0.14'),
-                    stream_startup_buffer=analysis_params.get('stream_startup_buffer', 10)
+                    stream_startup_buffer=analysis_params.get('stream_startup_buffer', 10),
+                    blank_check_enabled=blank_check_enabled,
+                    blank_check_min_duration=analysis_params.get('blank_check_min_duration', 2.0),
+                    blank_check_pixel_threshold=analysis_params.get('blank_check_pixel_threshold', 0.10),
+                    blank_check_ratio_threshold=analysis_params.get('blank_check_ratio_threshold', 0.80)
                 )
                 
                 # Update stream stats on dispatcharr with ffmpeg-extracted data
@@ -2186,6 +2217,8 @@ class StreamCheckerService:
                 stream_url = stream.get('url', '')
                 stream_name = stream.get('name', 'Unknown')
                 was_dead = self.dead_streams_tracker.is_dead(stream_url)
+                if is_dead:
+                    analyzed['dead_reason'] = dead_reason
                 
                 if is_dead and not was_dead:
                     # Mark as dead in tracker
@@ -2222,7 +2255,7 @@ class StreamCheckerService:
                         stream_statuses[stream['id']]['status'] = 'error'
                         stream_statuses[stream['id']]['score'] = 0.0
                     elif is_dead:
-                        stream_statuses[stream['id']]['status'] = dead_reason if dead_reason == 'low_quality' else 'dead'
+                        stream_statuses[stream['id']]['status'] = dead_reason if dead_reason in ('low_quality', 'blank') else 'dead'
                         stream_statuses[stream['id']]['score'] = 0.0
                     else:
                         stream_statuses[stream['id']]['status'] = 'completed'
@@ -2265,6 +2298,10 @@ class StreamCheckerService:
                         'audio_codec': stream_stats.get('audio_codec', 'N/A'),
                         'hdr_format': stream_stats.get('hdr_format'),
                         'bitrate_kbps': stream_stats.get('ffmpeg_output_bitrate', 0),
+                        'blank_probe_ran': stream_stats.get('blank_probe_ran', False),
+                        'blank_detected': stream_stats.get('blank_detected', False),
+                        'blank_duration_secs': stream_stats.get('blank_duration_secs'),
+                        'blank_ratio': stream_stats.get('blank_ratio'),
                         'status': 'OK'  # Assume OK for previously checked streams
                     }
                     
@@ -2333,7 +2370,11 @@ class StreamCheckerService:
                         retries=analysis_params.get('retries', 1),
                         retry_delay=analysis_params.get('retry_delay', 10),
                         user_agent=analysis_params.get('user_agent', 'VLC/3.0.14'),
-                        stream_startup_buffer=analysis_params.get('stream_startup_buffer', 10)
+                        stream_startup_buffer=analysis_params.get('stream_startup_buffer', 10),
+                        blank_check_enabled=blank_check_enabled,
+                        blank_check_min_duration=analysis_params.get('blank_check_min_duration', 2.0),
+                        blank_check_pixel_threshold=analysis_params.get('blank_check_pixel_threshold', 0.10),
+                        blank_check_ratio_threshold=analysis_params.get('blank_check_ratio_threshold', 0.80)
                     )
                     self._update_stream_stats(analyzed)
                     score = self._calculate_stream_score(analyzed, priority_m3u_ids, priority_mode)
@@ -2508,7 +2549,7 @@ class StreamCheckerService:
                     }
 
                     if is_dead:
-                        stream_stat['status'] = 'dead'
+                        stream_stat['status'] = analyzed.get('dead_reason') if analyzed.get('dead_reason') == 'blank' else 'dead'
                     elif is_revived:
                         stream_stat['status'] = 'revived'
                         stream_stat['score'] = round(analyzed.get('score', 0), 2)
@@ -2522,6 +2563,11 @@ class StreamCheckerService:
                         stream_stat['loop_probe_ran']     = True
                         stream_stat['loop_detected']      = analyzed.get('loop_detected')
                         stream_stat['loop_duration_secs'] = analyzed.get('loop_duration_secs')
+                    if analyzed.get('blank_probe_ran'):
+                        stream_stat['blank_probe_ran']     = True
+                        stream_stat['blank_detected']      = analyzed.get('blank_detected')
+                        stream_stat['blank_duration_secs'] = analyzed.get('blank_duration_secs')
+                        stream_stat['blank_ratio']         = analyzed.get('blank_ratio')
 
                     stream_stat = {k: v for k, v in stream_stat.items() if v not in [None, "N/A"]}
                     stream_stats.append(stream_stat)
@@ -3789,7 +3835,9 @@ class StreamCheckerService:
                     'resolution': stream_stats.get('resolution', '0x0'),
                     'fps': stream_stats.get('source_fps', 0),
                     'video_codec': stream_stats.get('video_codec', 'N/A'),
-                    'bitrate_kbps': stream_stats.get('ffmpeg_output_bitrate', 0)
+                    'bitrate_kbps': stream_stats.get('ffmpeg_output_bitrate', 0),
+                    'blank_probe_ran': stream_stats.get('blank_probe_ran', False),
+                    'blank_detected': stream_stats.get('blank_detected', False)
                 }
                 
                 # Calculate score — prefer the in-memory score from the check run
@@ -3836,6 +3884,16 @@ class StreamCheckerService:
                     stream_detail['loop_probe_ran']     = True
                     stream_detail['loop_detected']      = stream_stats.get('loop_detected')
                     stream_detail['loop_duration_secs'] = stream_stats.get('loop_duration_secs')
+                if analyzed and analyzed.get('blank_probe_ran'):
+                    stream_detail['blank_probe_ran']     = True
+                    stream_detail['blank_detected']      = analyzed.get('blank_detected')
+                    stream_detail['blank_duration_secs'] = analyzed.get('blank_duration_secs')
+                    stream_detail['blank_ratio']         = analyzed.get('blank_ratio')
+                elif stream_stats.get('blank_probe_ran'):
+                    stream_detail['blank_probe_ran']     = True
+                    stream_detail['blank_detected']      = stream_stats.get('blank_detected')
+                    stream_detail['blank_duration_secs'] = stream_stats.get('blank_duration_secs')
+                    stream_detail['blank_ratio']         = stream_stats.get('blank_ratio')
 
                 check_stats['stream_details'].append(stream_detail)
             

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -604,6 +604,48 @@ class StreamCheckerService:
             Dictionary with avg_resolution, avg_bitrate, and avg_fps
         """
         return calculate_channel_averages(analyzed_streams, dead_stream_ids)
+
+    def _log_blank_detection_summary(
+        self,
+        channel_id: int,
+        channel_name: str,
+        analyzed_streams: List[Dict],
+    ) -> None:
+        """Log a URL-free blank-detection summary for post-run audits."""
+        probed_streams = [
+            stream for stream in analyzed_streams
+            if stream.get('blank_probe_ran') and stream.get('status') != 'cached'
+        ]
+        if not probed_streams:
+            return
+
+        blank_streams = [stream for stream in probed_streams if stream.get('blank_detected')]
+        clean_count = len(probed_streams) - len(blank_streams)
+
+        def _metric(stream: Dict, key: str) -> float:
+            try:
+                return float(stream.get(key) or 0.0)
+            except (TypeError, ValueError):
+                return 0.0
+
+        max_ratio_stream = max(probed_streams, key=lambda stream: _metric(stream, 'blank_ratio'))
+        logger.info(
+            f"[blank-detect] Channel {channel_name} (ID: {channel_id}): "
+            f"probed={len(probed_streams)}, clean={clean_count}, "
+            f"blank={len(blank_streams)}, "
+            f"max_ratio={_metric(max_ratio_stream, 'blank_ratio'):.3f}, "
+            f"max_blank_duration={_metric(max_ratio_stream, 'blank_duration_secs'):.1f}s"
+        )
+
+        for stream in blank_streams[:10]:
+            logger.warning(
+                f"[blank-detect] Blank candidate: channel_id={channel_id}, "
+                f"stream_id={stream.get('stream_id')}, "
+                f"name={stream.get('stream_name', 'Unknown')!r}, "
+                f"duration={_metric(stream, 'blank_duration_secs'):.1f}s, "
+                f"ratio={_metric(stream, 'blank_ratio'):.3f}, "
+                f"segments={len(stream.get('blank_segments') or [])}"
+            )
     
     def _get_m3u_account_name(self, stream_id: int, udi=None) -> Optional[str]:
         """Get the M3U account name for a stream.
@@ -1595,6 +1637,8 @@ class StreamCheckerService:
 
                 logger.info(f"Completed smart parallel analysis of {len(results)} streams with account-aware limits")
 
+            self._log_blank_detection_summary(channel_id, channel_name, analyzed_streams)
+
             # Run loop probes on eligible streams (top 25% scoring >= 0.5).
             # Called after all streams are scored and analyzed_streams is fully
             # assembled so the complete score distribution is available.
@@ -2380,6 +2424,8 @@ class StreamCheckerService:
                     score = self._calculate_stream_score(analyzed, priority_m3u_ids, priority_mode)
                     analyzed['score'] = score
                     analyzed_streams.append(analyzed)
+
+            self._log_blank_detection_summary(channel_id, channel_name, analyzed_streams)
 
             # Run loop probes on eligible streams — all streams scored, full
             # distribution known for top-percentile calculation.

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -475,6 +475,8 @@ class StreamCheckerService:
         if min_fps and min_fps > 0:
             config['min_fps'] = min_fps
 
+        config['treat_blank_as_dead'] = stream_checking.get('treat_blank_as_dead', True)
+
         return config
 
     @staticmethod

--- a/backend/tests/test_api_schemas.py
+++ b/backend/tests/test_api_schemas.py
@@ -126,11 +126,15 @@ def test_automation_profile_schema_normalizes_remove_dead_streams_flag():
             "stream_checking": {
                 "enabled": True,
                 "remove_dead_streams": "false",
+                "blank_check_enabled": "true",
+                "treat_blank_as_dead": "false",
             },
         }
     )
 
     assert parsed.profile_data["stream_checking"]["remove_dead_streams"] is False
+    assert parsed.profile_data["stream_checking"]["blank_check_enabled"] is True
+    assert parsed.profile_data["stream_checking"]["treat_blank_as_dead"] is False
 
 
 def test_automation_profile_schema_rejects_invalid_remove_dead_streams_flag():
@@ -144,3 +148,16 @@ def test_automation_profile_schema_rejects_invalid_remove_dead_streams_flag():
         )
 
     assert "stream_checking.remove_dead_streams must be a boolean" in str(exc.value)
+
+
+def test_automation_profile_schema_rejects_invalid_treat_blank_as_dead_flag():
+    with pytest.raises(ValidationError) as exc:
+        AutomationProfileUpdateSchema.from_payload(
+            {
+                "stream_checking": {
+                    "treat_blank_as_dead": "maybe",
+                },
+            }
+        )
+
+    assert "stream_checking.treat_blank_as_dead must be a boolean" in str(exc.value)

--- a/backend/tests/test_blank_detection.py
+++ b/backend/tests/test_blank_detection.py
@@ -129,15 +129,16 @@ class TestBlankDetectionAnalysis(unittest.TestCase):
                 "blank_segments": [{"start": 0.0, "end": 30.0, "duration": 30.0}],
             }
 
-            result = analyze_stream(
-                stream_url="http://example.com/test.m3u8",
-                stream_id=42,
-                stream_name="Blank Test",
-                blank_check_enabled=True,
-                blank_check_min_duration=3.0,
-                blank_check_pixel_threshold=0.08,
-                blank_check_ratio_threshold=0.75,
-            )
+            with self.assertLogs(stream_check_utils.logger, level="INFO") as logs:
+                result = analyze_stream(
+                    stream_url="http://example.com/test.m3u8",
+                    stream_id=42,
+                    stream_name="Blank Test",
+                    blank_check_enabled=True,
+                    blank_check_min_duration=3.0,
+                    blank_check_pixel_threshold=0.08,
+                    blank_check_ratio_threshold=0.75,
+                )
 
         kwargs = mock_probe.call_args.kwargs
         self.assertTrue(kwargs["blank_check_enabled"])
@@ -148,6 +149,10 @@ class TestBlankDetectionAnalysis(unittest.TestCase):
         self.assertTrue(result["blank_detected"])
         self.assertEqual(result["blank_duration_secs"], 30.0)
         self.assertEqual(result["blank_ratio"], 1.0)
+        self.assertTrue(any(
+            "[blank-detect] Blank Test (ID: 42)" in message and "ratio=1.000" in message
+            for message in logs.output
+        ))
 
     def test_blank_detection_marks_stream_dead(self):
         stream_data = {

--- a/backend/tests/test_blank_detection.py
+++ b/backend/tests/test_blank_detection.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Tests for quality-check blank-screen detection."""
+
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from apps.core.stream_stats_utils import is_stream_dead
+from apps.stream import stream_check_utils
+from apps.stream.stream_check_utils import (
+    _parse_blank_detection,
+    analyze_stream,
+    get_stream_info_and_bitrate,
+)
+
+
+def _ffmpeg_output(extra: str = "") -> str:
+    return f"""
+Input #0, mpegts, from 'http://example.com/stream.m3u8':
+  Duration: N/A, start: 0.000000, bitrate: N/A
+    Stream #0:0: Video: h264, yuv420p, 1920x1080, 25 fps
+    Stream #0:1: Audio: aac, 48000 Hz, stereo
+frame=  750 fps=25 q=-1.0 size=12345kB time=00:00:30.00 bitrate=3333.3kbits/s speed=1.0x
+{extra}
+"""
+
+
+class TestBlankDetectionParsing(unittest.TestCase):
+    def test_blank_window_above_ratio_threshold_is_detected(self):
+        output = _ffmpeg_output(
+            "[blackdetect @ 000] black_start:0 black_end:25 black_duration:25"
+        )
+
+        result = _parse_blank_detection(output, duration=30, blank_ratio_threshold=0.80)
+
+        self.assertTrue(result["blank_detected"])
+        self.assertEqual(result["blank_duration_secs"], 25.0)
+        self.assertAlmostEqual(result["blank_ratio"], 0.8333)
+        self.assertEqual(result["blank_segments"][0]["start"], 0.0)
+
+    def test_short_blank_window_below_ratio_threshold_is_clean(self):
+        output = _ffmpeg_output(
+            "[blackdetect @ 000] black_start:10 black_end:12 black_duration:2"
+        )
+
+        result = _parse_blank_detection(output, duration=30, blank_ratio_threshold=0.80)
+
+        self.assertFalse(result["blank_detected"])
+        self.assertEqual(result["blank_duration_secs"], 2.0)
+        self.assertAlmostEqual(result["blank_ratio"], 0.0667)
+
+    def test_open_blank_segment_runs_until_probe_end(self):
+        output = _ffmpeg_output("[blackdetect @ 000] black_start:0")
+
+        result = _parse_blank_detection(output, duration=30, blank_ratio_threshold=0.80)
+
+        self.assertTrue(result["blank_detected"])
+        self.assertEqual(result["blank_duration_secs"], 30.0)
+        self.assertEqual(result["blank_ratio"], 1.0)
+
+
+class TestBlankDetectionFfmpegCommand(unittest.TestCase):
+    @patch.object(stream_check_utils.subprocess, "run")
+    def test_blank_detection_uses_one_input_connection(self, mock_run):
+        mock_run.return_value = Mock(
+            stderr=_ffmpeg_output(
+                "[blackdetect @ 000] black_start:0 black_end:30 black_duration:30"
+            ),
+            returncode=0,
+        )
+
+        result = get_stream_info_and_bitrate(
+            "http://example.com/test.m3u8",
+            duration=30,
+            timeout=30,
+            blank_check_enabled=True,
+        )
+
+        command = mock_run.call_args.args[0]
+        self.assertEqual(command[0], "ffmpeg")
+        self.assertEqual(command.count("-i"), 1)
+        self.assertNotIn("ffprobe", command)
+        self.assertIn("-vf", command)
+        self.assertTrue(any("blackdetect=d=2:pix_th=0.1" in arg for arg in command))
+        self.assertTrue(result["blank_probe_ran"])
+        self.assertTrue(result["blank_detected"])
+
+    @patch.object(stream_check_utils.subprocess, "run")
+    def test_blank_detection_disabled_preserves_plain_quality_command(self, mock_run):
+        mock_run.return_value = Mock(stderr=_ffmpeg_output(), returncode=0)
+
+        result = get_stream_info_and_bitrate(
+            "http://example.com/test.m3u8",
+            duration=30,
+            timeout=30,
+        )
+
+        command = mock_run.call_args.args[0]
+        self.assertEqual(command.count("-i"), 1)
+        self.assertFalse(any("blackdetect" in arg for arg in command))
+        self.assertFalse(result["blank_probe_ran"])
+        self.assertFalse(result["blank_detected"])
+
+
+class TestBlankDetectionAnalysis(unittest.TestCase):
+    def test_analyze_stream_passes_blank_options_and_returns_metrics(self):
+        with patch.object(stream_check_utils, "get_stream_info_and_bitrate") as mock_probe:
+            mock_probe.return_value = {
+                "video_codec": "h264",
+                "audio_codec": "aac",
+                "resolution": "1920x1080",
+                "fps": 25.0,
+                "bitrate_kbps": 3333.3,
+                "hdr_format": None,
+                "pixel_format": None,
+                "audio_sample_rate": None,
+                "audio_channels": None,
+                "channel_layout": None,
+                "audio_bitrate": None,
+                "status": "OK",
+                "elapsed_time": 30.0,
+                "blank_probe_ran": True,
+                "blank_detected": True,
+                "blank_duration_secs": 30.0,
+                "blank_ratio": 1.0,
+                "blank_segments": [{"start": 0.0, "end": 30.0, "duration": 30.0}],
+            }
+
+            result = analyze_stream(
+                stream_url="http://example.com/test.m3u8",
+                stream_id=42,
+                stream_name="Blank Test",
+                blank_check_enabled=True,
+                blank_check_min_duration=3.0,
+                blank_check_pixel_threshold=0.08,
+                blank_check_ratio_threshold=0.75,
+            )
+
+        kwargs = mock_probe.call_args.kwargs
+        self.assertTrue(kwargs["blank_check_enabled"])
+        self.assertEqual(kwargs["blank_check_min_duration"], 3.0)
+        self.assertEqual(kwargs["blank_check_pixel_threshold"], 0.08)
+        self.assertEqual(kwargs["blank_check_ratio_threshold"], 0.75)
+        self.assertTrue(result["blank_probe_ran"])
+        self.assertTrue(result["blank_detected"])
+        self.assertEqual(result["blank_duration_secs"], 30.0)
+        self.assertEqual(result["blank_ratio"], 1.0)
+
+    def test_blank_detection_marks_stream_dead(self):
+        stream_data = {
+            "resolution": "1920x1080",
+            "bitrate_kbps": 3333.3,
+            "blank_probe_ran": True,
+            "blank_detected": True,
+        }
+
+        self.assertEqual(is_stream_dead(stream_data), (True, "blank"))
+
+    def test_persisted_blank_detection_marks_stream_dead(self):
+        stream_data = {
+            "stream_stats": {
+                "resolution": "1920x1080",
+                "ffmpeg_output_bitrate": 3333,
+                "blank_probe_ran": True,
+                "blank_detected": True,
+            }
+        }
+
+        self.assertEqual(is_stream_dead(stream_data), (True, "blank"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_blank_detection.py
+++ b/backend/tests/test_blank_detection.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from apps.core.stream_stats_utils import is_stream_dead
 from apps.stream import stream_check_utils
+from apps.stream.stream_checker_service import StreamCheckerService
 from apps.stream.stream_check_utils import (
     _parse_blank_detection,
     analyze_stream,
@@ -149,10 +150,14 @@ class TestBlankDetectionAnalysis(unittest.TestCase):
         self.assertTrue(result["blank_detected"])
         self.assertEqual(result["blank_duration_secs"], 30.0)
         self.assertEqual(result["blank_ratio"], 1.0)
-        self.assertTrue(any(
-            "[blank-detect] Blank Test (ID: 42)" in message and "ratio=1.000" in message
-            for message in logs.output
-        ))
+        blank_log = "\n".join(
+            message for message in logs.output if "[blank-detect]" in message
+        )
+        self.assertIn("[blank-detect] stream_ref=", blank_log)
+        self.assertIn("detected=True", blank_log)
+        self.assertIn("ratio=1.000", blank_log)
+        self.assertNotIn("Blank Test", blank_log)
+        self.assertNotIn("ID: 42", blank_log)
 
     def test_blank_detection_marks_stream_dead(self):
         stream_data = {
@@ -188,6 +193,52 @@ class TestBlankDetectionAnalysis(unittest.TestCase):
         }
 
         self.assertEqual(is_stream_dead(stream_data), (True, "blank"))
+
+    def test_blank_detection_audit_logs_all_candidates_without_names(self):
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        streams = [
+            {
+                "stream_id": 1000 + index,
+                "stream_name": f"Sensitive Provider {index}",
+                "blank_probe_ran": True,
+                "blank_detected": True,
+                "blank_duration_secs": 30.0,
+                "blank_ratio": 1.0,
+                "blank_segments": [{"start": 0.0, "end": 30.0, "duration": 30.0}],
+                "dead_reason": "blank",
+            }
+            for index in range(12)
+        ]
+        streams.append({
+            "stream_id": 2000,
+            "stream_name": "Sensitive Clean Provider",
+            "blank_probe_ran": True,
+            "blank_detected": False,
+            "blank_duration_secs": 0.0,
+            "blank_ratio": 0.0,
+            "blank_segments": [],
+        })
+
+        with self.assertLogs("apps.stream.stream_checker_service", level="INFO") as logs:
+            service._log_blank_detection_summary(
+                777,
+                "Sensitive Channel",
+                streams,
+                dead_stream_ids={stream["stream_id"] for stream in streams[:12]},
+                dead_stream_removal_enabled=True,
+            )
+
+        audit_log = "\n".join(logs.output)
+        self.assertIn("blank=12", audit_log)
+        self.assertEqual(audit_log.count("Blank candidate"), 12)
+        self.assertIn("channel_ref=", audit_log)
+        self.assertIn("stream_ref=", audit_log)
+        self.assertIn("marked_dead=True", audit_log)
+        self.assertIn("reason=blank", audit_log)
+        self.assertIn("action=remove", audit_log)
+        self.assertNotIn("Sensitive", audit_log)
+        self.assertNotIn("stream_id=", audit_log)
+        self.assertNotIn("channel_id=", audit_log)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_blank_detection.py
+++ b/backend/tests/test_blank_detection.py
@@ -254,6 +254,69 @@ class TestBlankDetectionAnalysis(unittest.TestCase):
         self.assertNotIn("stream_id=", audit_log)
         self.assertNotIn("channel_id=", audit_log)
 
+    def test_blank_detection_refreshes_existing_dead_reason_without_sensitive_log(self):
+        class FakeDeadStreamsTracker:
+            def __init__(self):
+                self.updated = []
+
+            def get_dead_reason(self, stream_url):
+                return "low_quality"
+
+            def update_dead_reason(self, stream_url, reason, channel_id=None):
+                self.updated.append((stream_url, reason, channel_id))
+                return True
+
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        service.dead_streams_tracker = FakeDeadStreamsTracker()
+
+        with self.assertLogs("apps.stream.stream_checker_service", level="WARNING") as logs:
+            updated = service._refresh_dead_stream_reason_if_needed(
+                "http://sensitive.example/stream.m3u8",
+                12345,
+                "Sensitive Provider Stream",
+                777,
+                "blank",
+                blank_detected=True,
+            )
+
+        self.assertTrue(updated)
+        self.assertEqual(
+            service.dead_streams_tracker.updated,
+            [("http://sensitive.example/stream.m3u8", "blank", 777)],
+        )
+        audit_log = "\n".join(logs.output)
+        self.assertIn("[blank-detect] Stream dead reason updated", audit_log)
+        self.assertIn("reason=blank", audit_log)
+        self.assertNotIn("sensitive.example", audit_log)
+        self.assertNotIn("Sensitive Provider", audit_log)
+
+    def test_dead_reason_refresh_skips_when_reason_is_current(self):
+        class FakeDeadStreamsTracker:
+            def __init__(self):
+                self.updated = False
+
+            def get_dead_reason(self, stream_url):
+                return "blank"
+
+            def update_dead_reason(self, stream_url, reason, channel_id=None):
+                self.updated = True
+                return True
+
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        service.dead_streams_tracker = FakeDeadStreamsTracker()
+
+        updated = service._refresh_dead_stream_reason_if_needed(
+            "http://sensitive.example/stream.m3u8",
+            12345,
+            "Sensitive Provider Stream",
+            777,
+            "blank",
+            blank_detected=True,
+        )
+
+        self.assertFalse(updated)
+        self.assertFalse(service.dead_streams_tracker.updated)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_blank_detection.py
+++ b/backend/tests/test_blank_detection.py
@@ -182,6 +182,20 @@ class TestBlankDetectionAnalysis(unittest.TestCase):
             (False, "none"),
         )
 
+    def test_profile_blank_check_ignores_legacy_blank_as_dead_false(self):
+        stream_data = {
+            "resolution": "1920x1080",
+            "bitrate_kbps": 3333.3,
+            "blank_probe_ran": True,
+            "blank_detected": True,
+        }
+        threshold_config = StreamCheckerService._build_threshold_config_from_profile(
+            None,
+            {"blank_check_enabled": True, "treat_blank_as_dead": False},
+        )
+
+        self.assertEqual(is_stream_dead(stream_data, threshold_config), (True, "blank"))
+
     def test_persisted_blank_detection_marks_stream_dead(self):
         stream_data = {
             "stream_stats": {

--- a/backend/tests/test_blank_detection.py
+++ b/backend/tests/test_blank_detection.py
@@ -164,6 +164,19 @@ class TestBlankDetectionAnalysis(unittest.TestCase):
 
         self.assertEqual(is_stream_dead(stream_data), (True, "blank"))
 
+    def test_blank_detection_can_be_kept_out_of_dead_classification(self):
+        stream_data = {
+            "resolution": "1920x1080",
+            "bitrate_kbps": 3333.3,
+            "blank_probe_ran": True,
+            "blank_detected": True,
+        }
+
+        self.assertEqual(
+            is_stream_dead(stream_data, {"treat_blank_as_dead": False}),
+            (False, "none"),
+        )
+
     def test_persisted_blank_detection_marks_stream_dead(self):
         stream_data = {
             "stream_stats": {

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -54,6 +54,7 @@ Profiles live in `automation_config.json` under `profiles`. A profile has three 
   "min_fps": 0,
   "min_bitrate": 0,
   "require_hdr": "any",
+  "blank_check_enabled": false,
   "m3u_priority": [],
   "m3u_priority_mode": "absolute",
   "grace_period": false
@@ -69,6 +70,7 @@ Profiles live in `automation_config.json` under `profiles`. A profile has three 
 | `min_fps`           | Discard streams below this FPS                                        |
 | `min_bitrate`       | Discard streams below this bitrate (kbps)                             |
 | `require_hdr`       | `"any"` / `"hdr"` / `"sdr"`                                           |
+| `blank_check_enabled` | Run blank-screen detection during the quality probe                 |
 | `m3u_priority`      | Ordered list of M3U account IDs — higher index = lower priority       |
 | `m3u_priority_mode` | `"absolute"` (strict ordering) or `"equal"` (quality score only)      |
 | `grace_period`      | If `true`, skip recently-checked streams within the grace window      |

--- a/docs/stream-checking.md
+++ b/docs/stream-checking.md
@@ -15,6 +15,7 @@ Each stream is analyzed by spawning a short ffmpeg probe session. Extracted metr
 - FPS
 - Codec (H.264, H.265/HEVC, AV1, etc.)
 - HDR (detected from ffmpeg stderr: pixel format, color space, primaries, transfer function)
+- Blank-screen status (optional; parsed from ffmpeg `blackdetect` output)
 - Error presence (dropped frames, decode errors)
 
 ---
@@ -47,6 +48,12 @@ Before scoring, streams can be discarded based on minimum thresholds (set in `st
 | `min_resolution` | Skip streams below this resolution                          |
 | `min_fps`        | Skip streams below this FPS                                 |
 | `min_bitrate`    | Skip streams below this bitrate (kbps)                      |
+| `blank_check_enabled` | Mark streams dead when most of the probe window is blank |
+
+Blank detection is folded into the same ffmpeg process as the quality probe.
+It adds a second ffmpeg output from the already-open input instead of starting
+ffprobe or a second provider connection, so single-stream provider limits are
+respected.
 
 ---
 

--- a/frontend/src/pages/AutomationProfileEditor.jsx
+++ b/frontend/src/pages/AutomationProfileEditor.jsx
@@ -36,7 +36,6 @@ const DEFAULT_PROFILE = {
         check_all_streams: false,
         loop_check_enabled: false,
         blank_check_enabled: false,
-        treat_blank_as_dead: true,
         stream_limit: 0,
         min_resolution: 'any',
         min_fps: 0,
@@ -472,19 +471,7 @@ export default function AutomationProfileEditor() {
                                                 />
                                                 <div className="space-y-0.5">
                                                     <Label htmlFor="blank_check_enabled" className="cursor-pointer font-medium">Check streams for blank screens</Label>
-                                                    <p className="text-[10px] text-muted-foreground">Runs black-screen detection during the normal quality probe.</p>
-                                                </div>
-                                            </div>
-                                            <div className="flex items-center space-x-3 bg-muted/50 p-3 rounded-md">
-                                                <Switch
-                                                    id="treat_blank_as_dead"
-                                                    checked={profile.stream_checking.treat_blank_as_dead ?? true}
-                                                    disabled={!(profile.stream_checking.blank_check_enabled ?? false)}
-                                                    onCheckedChange={(checked) => updateProfile('stream_checking.treat_blank_as_dead', checked)}
-                                                />
-                                                <div className="space-y-0.5">
-                                                    <Label htmlFor="treat_blank_as_dead" className="cursor-pointer font-medium">Treat Blank Screens as Dead</Label>
-                                                    <p className="text-[10px] text-muted-foreground">When disabled, blank metrics are logged and saved without marking the stream dead.</p>
+                                                    <p className="text-[10px] text-muted-foreground">Detected blank streams are marked dead and follow this profile&apos;s dead stream removal setting.</p>
                                                 </div>
                                             </div>
 

--- a/frontend/src/pages/AutomationProfileEditor.jsx
+++ b/frontend/src/pages/AutomationProfileEditor.jsx
@@ -35,6 +35,8 @@ const DEFAULT_PROFILE = {
         remove_dead_streams: true,
         check_all_streams: false,
         loop_check_enabled: false,
+        blank_check_enabled: false,
+        treat_blank_as_dead: true,
         stream_limit: 0,
         min_resolution: 'any',
         min_fps: 0,
@@ -460,6 +462,29 @@ export default function AutomationProfileEditor() {
                                                 <div className="space-y-0.5">
                                                     <Label htmlFor="loop_check_enabled" className="cursor-pointer font-medium">Check scored streams for looping?</Label>
                                                     <p className="text-[10px] text-muted-foreground">Checks top 25% of streams with a score greater than 0.50</p>
+                                                </div>
+                                            </div>
+                                            <div className="flex items-center space-x-3 bg-muted/50 p-3 rounded-md">
+                                                <Switch
+                                                    id="blank_check_enabled"
+                                                    checked={profile.stream_checking.blank_check_enabled ?? false}
+                                                    onCheckedChange={(checked) => updateProfile('stream_checking.blank_check_enabled', checked)}
+                                                />
+                                                <div className="space-y-0.5">
+                                                    <Label htmlFor="blank_check_enabled" className="cursor-pointer font-medium">Check streams for blank screens</Label>
+                                                    <p className="text-[10px] text-muted-foreground">Runs black-screen detection during the normal quality probe.</p>
+                                                </div>
+                                            </div>
+                                            <div className="flex items-center space-x-3 bg-muted/50 p-3 rounded-md">
+                                                <Switch
+                                                    id="treat_blank_as_dead"
+                                                    checked={profile.stream_checking.treat_blank_as_dead ?? true}
+                                                    disabled={!(profile.stream_checking.blank_check_enabled ?? false)}
+                                                    onCheckedChange={(checked) => updateProfile('stream_checking.treat_blank_as_dead', checked)}
+                                                />
+                                                <div className="space-y-0.5">
+                                                    <Label htmlFor="treat_blank_as_dead" className="cursor-pointer font-medium">Treat Blank Screens as Dead</Label>
+                                                    <p className="text-[10px] text-muted-foreground">When disabled, blank metrics are logged and saved without marking the stream dead.</p>
                                                 </div>
                                             </div>
 


### PR DESCRIPTION
﻿## Summary
- add optional `stream_checking.blank_check_enabled` for blank-screen detection during quality checks
- keep the profile UI to one blank-detection switch: when blank checking is enabled, confirmed blank streams are classified as dead with reason `blank`
- keep the existing `Remove Dead Streams From Channel` setting as the separate control for whether dead streams are removed from channel ordering
- run ffmpeg `blackdetect` from the existing quality-check ffmpeg process/input, avoiding ffprobe or a second provider connection
- persist `blank_*` stream stats and add sanitized blank-detection audit logs for live-run verification without exposing stream URLs, provider names, or raw IDs
- refresh stale dead-stream reasons to `blank` when a stream was already tracked as dead and a later quality check classifies it as blank

## Provider-limit note
This follows the guidance from #334: the implementation keeps exactly one ffmpeg `-i` input for the provider URL and adds a second output from the same process for `blackdetect`. It does not create a second channel stream, run ffprobe, or open a separate provider connection.

## UI screenshots
The automation profile now has one blank-detection switch. Blank streams are marked dead when this switch is enabled, and the existing dead-stream removal setting controls whether they are removed from the channel.

![Single blank detection toggle in Stream Checking](https://raw.githubusercontent.com/bttfw/streamflow/pr-409-ui-screenshots/blank-detection-single-toggle-section.png)

Focused view:

![Focused single blank detection toggle](https://raw.githubusercontent.com/bttfw/streamflow/pr-409-ui-screenshots/blank-detection-single-toggle-focused.png)

## Validation
Automated checks:

- Branch image build completed successfully for amd64 and arm64 at revision `99c174a`
- Focused backend validation: `PYTHONPATH=backend python -m pytest backend/tests/test_blank_detection.py -q` (13 passed)
- Broader backend validation: `PYTHONPATH=backend python -m pytest backend/tests/test_blank_detection.py backend/tests/test_stream_check_utils.py backend/tests/test_codec_sanitization.py backend/tests/test_stream_stats_utils.py backend/tests/test_api_schemas.py -q` (75 passed)
- Combined in-flight branch validation: `PYTHONPATH=backend python -m pytest backend/tests/test_blank_detection.py backend/tests/test_stream_check_utils.py backend/tests/test_codec_sanitization.py backend/tests/test_stream_stats_utils.py backend/tests/test_api_schemas.py backend/tests/test_dispatcharr_fetch_pressure_config.py -q` (79 passed)
- `python -m py_compile backend/apps/database/manager.py backend/apps/stream/dead_streams_tracker.py backend/apps/stream/stream_checker_service.py backend/tests/test_blank_detection.py`
- `git diff --check`
- `npm.cmd run build` from `frontend/` after the UI toggle simplification

Live Full Check validation against a 200k+ stream catalog:

- Quality check completed `226/226` eligible channels with `0` failed checks
- Blank detection produced `226` channel summaries and `302` blank candidates across `53` anonymized channels
- Every blank candidate audit line had `marked_dead=True`, `reason=blank`, `removal_enabled=True`, and `action=remove`
- Dead-tracker audit recorded `45` newly marked blank streams and `152` stale dead-stream reason updates to `blank`
- Post-run verification found `0` missing dead-tracker entries, `0` missing `blank` reasons for candidate stream/channel pairs, and `0` candidates still present in their channel after a fresh UDI reload
- Sanitized blank-detection audit lines contained `0` stream URLs, provider names, or raw stream IDs
