### PR TITLE
Add configurable Dispatcharr fetch pressure

### DIFF
--- a/backend/apps/api/dispatcharr_handlers.py
+++ b/backend/apps/api/dispatcharr_handlers.py
@@ -40,8 +40,16 @@ def update_dispatcharr_config_response(
         base_url = data.get("base_url")
         username = data.get("username")
         password = data.get("password")
+        stream_fetch_page_size = data.get("stream_fetch_page_size")
+        stream_fetch_max_workers = data.get("stream_fetch_max_workers")
 
-        success = config_manager.update_config(base_url=base_url, username=username, password=password)
+        success = config_manager.update_config(
+            base_url=base_url,
+            username=username,
+            password=password,
+            stream_fetch_page_size=stream_fetch_page_size,
+            stream_fetch_max_workers=stream_fetch_max_workers,
+        )
 
         if not success:
             return jsonify({"error": "Failed to save configuration"}), 500

--- a/backend/apps/config/dispatcharr_config.py
+++ b/backend/apps/config/dispatcharr_config.py
@@ -11,7 +11,7 @@ import json
 import os
 import threading
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from apps.core.logging_config import setup_logging
 
@@ -20,6 +20,21 @@ logger = setup_logging(__name__)
 # Configuration directory
 CONFIG_DIR = Path(os.environ.get('CONFIG_DIR', '/app/data'))
 DISPATCHARR_CONFIG_FILE = CONFIG_DIR / 'dispatcharr_config.json'
+DEFAULT_STREAM_FETCH_PAGE_SIZE = 1000
+DEFAULT_STREAM_FETCH_MAX_WORKERS = 10
+MIN_STREAM_FETCH_PAGE_SIZE = 100
+MAX_STREAM_FETCH_PAGE_SIZE = 10000
+MIN_STREAM_FETCH_MAX_WORKERS = 1
+MAX_STREAM_FETCH_MAX_WORKERS = 20
+
+
+def _coerce_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    """Return a bounded integer for user-tunable fetch pressure settings."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return min(max(parsed, minimum), maximum)
 
 
 class DispatcharrConfig:
@@ -34,7 +49,7 @@ class DispatcharrConfig:
     def __init__(self):
         """Initialize the configuration manager."""
         self._lock = threading.RLock()
-        self._config: Dict[str, str] = {}
+        self._config: Dict[str, Any] = {}
         self._load_config()
         logger.info("Dispatcharr configuration manager initialized")
     
@@ -130,28 +145,56 @@ class DispatcharrConfig:
         from apps.database.manager import get_db_manager
         db_config = get_db_manager().get_system_setting('dispatcharr_config', {})
         return db_config.get('password')
+
+    def get_stream_fetch_page_size(self) -> int:
+        """Get Dispatcharr stream page size for UDI stream refreshes."""
+        from apps.database.manager import get_db_manager
+        db_config = get_db_manager().get_system_setting('dispatcharr_config', {})
+        return _coerce_int(
+            db_config.get('stream_fetch_page_size'),
+            DEFAULT_STREAM_FETCH_PAGE_SIZE,
+            MIN_STREAM_FETCH_PAGE_SIZE,
+            MAX_STREAM_FETCH_PAGE_SIZE,
+        )
+
+    def get_stream_fetch_max_workers(self) -> int:
+        """Get Dispatcharr stream page concurrency for UDI stream refreshes."""
+        from apps.database.manager import get_db_manager
+        db_config = get_db_manager().get_system_setting('dispatcharr_config', {})
+        return _coerce_int(
+            db_config.get('stream_fetch_max_workers'),
+            DEFAULT_STREAM_FETCH_MAX_WORKERS,
+            MIN_STREAM_FETCH_MAX_WORKERS,
+            MAX_STREAM_FETCH_MAX_WORKERS,
+        )
     
-    def get_config(self) -> Dict[str, str]:
+    def get_config(self) -> Dict[str, Any]:
         """Get complete configuration (without password for security).
         
         Returns:
-            Dictionary with base_url, username, and has_password
+            Dictionary with base_url, username, password state, and fetch tuning.
         """
         return {
             'base_url': self.get_base_url() or '',
             'username': self.get_username() or '',
-            'has_password': bool(self.get_password())
+            'has_password': bool(self.get_password()),
+            'stream_fetch_page_size': self.get_stream_fetch_page_size(),
+            'stream_fetch_max_workers': self.get_stream_fetch_max_workers(),
         }
     
     def update_config(self, base_url: Optional[str] = None, 
                      username: Optional[str] = None,
-                     password: Optional[str] = None) -> bool:
+                     password: Optional[str] = None,
+                     stream_fetch_page_size: Optional[Any] = None,
+                     stream_fetch_max_workers: Optional[Any] = None) -> bool:
         """Update configuration and save to database.
         
         Args:
             base_url: Dispatcharr base URL
             username: Dispatcharr username
             password: Dispatcharr password
+            stream_fetch_page_size: Items per stream page during UDI stream refreshes
+            stream_fetch_max_workers: Concurrent stream page requests during UDI stream refreshes
             
         Returns:
             True if successful, False otherwise
@@ -170,6 +213,20 @@ class DispatcharrConfig:
                 self._config['username'] = username.strip()
             if password is not None:
                 self._config['password'] = password
+            if stream_fetch_page_size is not None:
+                self._config['stream_fetch_page_size'] = _coerce_int(
+                    stream_fetch_page_size,
+                    DEFAULT_STREAM_FETCH_PAGE_SIZE,
+                    MIN_STREAM_FETCH_PAGE_SIZE,
+                    MAX_STREAM_FETCH_PAGE_SIZE,
+                )
+            if stream_fetch_max_workers is not None:
+                self._config['stream_fetch_max_workers'] = _coerce_int(
+                    stream_fetch_max_workers,
+                    DEFAULT_STREAM_FETCH_MAX_WORKERS,
+                    MIN_STREAM_FETCH_MAX_WORKERS,
+                    MAX_STREAM_FETCH_MAX_WORKERS,
+                )
             
             return self._save_config()
     

--- a/backend/apps/udi/fetcher.py
+++ b/backend/apps/udi/fetcher.py
@@ -282,7 +282,7 @@ class UDIFetcher:
             logger.error(f"Error POSTing to {url}: {e}")
             return None
 
-    def _fetch_paginated(self, base_url: str, page_size: int = 1000) -> FetchResult:
+    def _fetch_paginated(self, base_url: str, page_size: int = 1000, max_workers: int = 10) -> FetchResult:
         """Fetch paginated data from an API endpoint.
 
         Page 1 is fetched synchronously to capture the total ``count``.  All
@@ -292,11 +292,23 @@ class UDIFetcher:
         Args:
             base_url:  The base URL for the endpoint (no query string).
             page_size: Number of items per page.
+            max_workers: Maximum number of concurrent page requests.
 
         Returns:
             FetchResult with all collected items and the expected_count
             reported by the API on the first page (None if not present).
         """
+        try:
+            page_size = int(page_size or 1000)
+        except (TypeError, ValueError):
+            page_size = 1000
+        try:
+            max_workers = int(max_workers or 10)
+        except (TypeError, ValueError):
+            max_workers = 10
+        page_size = max(1, page_size)
+        max_workers = max(1, max_workers)
+
         # Include page=1 explicitly so ChannelPagination does not short-circuit
         # into bare-list mode (it disables pagination when no 'page' param is
         # present, which drops the DRF count/results envelope).
@@ -331,14 +343,13 @@ class UDIFetcher:
         remaining = range(2, total_pages + 1)
         logger.debug(
             f"Fetching {total_pages - 1} remaining pages of {base_url} concurrently "
-            f"(page_size={page_size}, expected={expected_count})"
+            f"(page_size={page_size}, max_workers={max_workers}, expected={expected_count})"
         )
 
-        # Fetch remaining pages concurrently.  Cap at 10 workers to avoid
-        # overwhelming Dispatcharr; auth retries inside _fetch_url are
+        # Fetch remaining pages concurrently. Auth retries inside _fetch_url are
         # serialised by _token_refresh_lock so 401 bursts are safe.
         page_results: Dict[int, List] = {}
-        with ThreadPoolExecutor(max_workers=min(10, len(remaining))) as executor:
+        with ThreadPoolExecutor(max_workers=min(max_workers, len(remaining))) as executor:
             future_to_page = {
                 executor.submit(
                     self._fetch_url,
@@ -423,10 +434,14 @@ class UDIFetcher:
             return FetchResult()
         
         url = f"{self.base_url}/api/channels/streams/"
-        result = self._fetch_paginated(url)
+        config = get_dispatcharr_config()
+        page_size = config.get_stream_fetch_page_size()
+        max_workers = config.get_stream_fetch_max_workers()
+        result = self._fetch_paginated(url, page_size=page_size, max_workers=max_workers)
         logger.info(
             f"Fetched {len(result)} streams"
             + (f" (expected {result.expected_count})" if result.expected_count is not None else "")
+            + f" with page_size={page_size}, max_workers={max_workers}"
         )
         return result
     

--- a/backend/tests/test_dispatcharr_fetch_pressure_config.py
+++ b/backend/tests/test_dispatcharr_fetch_pressure_config.py
@@ -1,0 +1,107 @@
+from unittest.mock import Mock
+
+import pytest
+
+
+class FakeDB:
+    def __init__(self, config=None):
+        self.settings = {}
+        if config is not None:
+            self.settings["dispatcharr_config"] = config
+
+    def get_system_setting(self, key, default=None):
+        return self.settings.get(key, default)
+
+    def set_system_setting(self, key, value):
+        self.settings[key] = value
+        return True
+
+
+def test_dispatcharr_config_returns_default_fetch_pressure(monkeypatch):
+    from apps.config import dispatcharr_config as config_module
+
+    fake_db = FakeDB({})
+    monkeypatch.setattr("apps.database.manager.get_db_manager", lambda: fake_db)
+
+    config = config_module.DispatcharrConfig()
+
+    assert config.get_stream_fetch_page_size() == 1000
+    assert config.get_stream_fetch_max_workers() == 10
+    assert config.get_config()["stream_fetch_page_size"] == 1000
+    assert config.get_config()["stream_fetch_max_workers"] == 10
+
+
+def test_dispatcharr_config_saves_bounded_fetch_pressure(monkeypatch):
+    from apps.config import dispatcharr_config as config_module
+
+    fake_db = FakeDB({})
+    monkeypatch.setattr("apps.database.manager.get_db_manager", lambda: fake_db)
+
+    config = config_module.DispatcharrConfig()
+    assert config.update_config(stream_fetch_page_size=50000, stream_fetch_max_workers=0)
+
+    saved = fake_db.settings["dispatcharr_config"]
+    assert saved["stream_fetch_page_size"] == 10000
+    assert saved["stream_fetch_max_workers"] == 1
+
+
+def test_update_dispatcharr_config_accepts_fetch_pressure_fields():
+    flask = pytest.importorskip("flask")
+    from apps.api.dispatcharr_handlers import update_dispatcharr_config_response
+
+    config_manager = Mock()
+    config_manager.update_config.return_value = True
+    config_manager.is_configured.return_value = False
+
+    app = flask.Flask(__name__)
+    with app.app_context():
+        response = update_dispatcharr_config_response(
+            payload={
+                "base_url": "http://dispatcharr.test",
+                "username": "user",
+                "stream_fetch_page_size": 5000,
+                "stream_fetch_max_workers": 2,
+            },
+            get_dispatcharr_config=lambda: config_manager,
+            get_udi_manager=Mock(),
+        )
+
+    assert response.status_code == 200
+    config_manager.update_config.assert_called_once_with(
+        base_url="http://dispatcharr.test",
+        username="user",
+        password=None,
+        stream_fetch_page_size=5000,
+        stream_fetch_max_workers=2,
+    )
+
+
+def test_fetch_streams_uses_configured_fetch_pressure(monkeypatch):
+    from apps.udi import fetcher as fetcher_module
+
+    fetcher = fetcher_module.UDIFetcher.__new__(fetcher_module.UDIFetcher)
+    fetcher.base_url = "http://dispatcharr.test"
+
+    config = Mock()
+    config.get_stream_fetch_page_size.return_value = 5000
+    config.get_stream_fetch_max_workers.return_value = 2
+    monkeypatch.setattr(fetcher_module, "get_dispatcharr_config", lambda: config)
+
+    calls = {}
+
+    def fake_fetch_paginated(url, page_size=1000, max_workers=10):
+        calls["url"] = url
+        calls["page_size"] = page_size
+        calls["max_workers"] = max_workers
+        return fetcher_module.FetchResult(items=[{"id": 1}], expected_count=1)
+
+    monkeypatch.setattr(fetcher, "_fetch_paginated", fake_fetch_paginated)
+
+    result = fetcher.fetch_streams()
+
+    assert len(result) == 1
+    assert calls == {
+        "url": "http://dispatcharr.test/api/channels/streams/",
+        "page_size": 5000,
+        "max_workers": 2,
+    }

--- a/frontend/src/pages/AutomationSettings.jsx
+++ b/frontend/src/pages/AutomationSettings.jsx
@@ -372,6 +372,35 @@ export default function AutomationSettings() {
                 />
               </div>
 
+              <Separator />
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="stream-fetch-page-size">Stream fetch page size</Label>
+                  <Input
+                    id="stream-fetch-page-size"
+                    type="number"
+                    min="100"
+                    max="10000"
+                    step="100"
+                    value={dispatcharrConfig?.stream_fetch_page_size || 1000}
+                    onChange={(e) => handleDispatcharrConfigChange('stream_fetch_page_size', parseInt(e.target.value) || 1000)}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="stream-fetch-max-workers">Stream fetch max workers</Label>
+                  <Input
+                    id="stream-fetch-max-workers"
+                    type="number"
+                    min="1"
+                    max="20"
+                    value={dispatcharrConfig?.stream_fetch_max_workers || 10}
+                    onChange={(e) => handleDispatcharrConfigChange('stream_fetch_max_workers', parseInt(e.target.value) || 10)}
+                  />
+                </div>
+              </div>
+
               <div className="flex items-center gap-2 pt-2">
                 <Button
                   onClick={handleTestConnection}


### PR DESCRIPTION
## Summary
- add configurable Dispatcharr stream fetch pressure settings for UDI stream refreshes
- expose `stream_fetch_page_size` and `stream_fetch_max_workers` in the Dispatcharr connection settings
- keep existing defaults (`1000` page size, `10` workers) for backward compatibility
- apply the settings to `UDIFetcher.fetch_streams()`, which is used by initial UDI load, manual Reload UDI, scheduled UDI refresh, and post-playlist stream refresh
- add focused tests for defaults, bounds, config update handling, and fetcher propagation

## Why
A read-only pressure probe against a large Dispatcharr stream list with 200k+ streams showed that the current hard-coded stream pagination can create measurable API pressure. The probe did not open provider streams and did not record stream URLs, provider names, hostnames, or environment-specific identifiers.

Sanitized timing results:

| Probe | Page size | Workers | Pages | Duration | Control p95 | Control max | Page p95 | Page max |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Idle baseline | - | - | - | 20s | 121.0ms | 182.7ms | - | - |
| Current behavior | 1000 | 10 | 216 | 218.93s | 8219.0ms | 12204.0ms | 25373.5ms | 34894.5ms |
| Reduced pressure | 2000 | 4 | 108 | 113.20s | 5602.5ms | 6632.0ms | 7002.8ms | 11992.0ms |
| Gentle pressure | 5000 | 2 | 44 | 97.49s | 73.5ms | 302.4ms | 6924.1ms | 7644.5ms |

A follow-up live StreamFlow validation used `UDIManager.refresh_streams()` directly, again without Full Check and without provider stream connections:

| Probe | Page size | Workers | Duration | Streams | Control median | Control p95 | Control p99 | Control max |
| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: |
| Idle baseline | - | - | 20s | - | 53.0ms | 246.4ms | 290.6ms | 290.6ms |
| Current behavior | 1000 | 10 | 219.13s | 200k+ | 3383.4ms | 11071.5ms | 12705.8ms | 12705.8ms |
| Reduced pressure | 2000 | 4 | 112.64s | 200k+ | 2282.1ms | 6447.4ms | 6558.8ms | 6558.8ms |
| Gentle pressure | 5000 | 2 | 98.63s | 200k+ | 56.7ms | 97.8ms | 303.9ms | 304.8ms |

`p95` and `p99` are the 95th and 99th percentile response times for a cheap Dispatcharr control API request sampled during the refresh. They show whether normal API traffic is delayed while StreamFlow is fetching stream pages, not just how long the refresh itself takes.

The important bit is not that one set of values should be universal; it is that large Dispatcharr instances need a way to tune stream fetch pressure instead of being locked to `1000x10`.

## Scope
- No auth changes.
- No scheduling interval changes.
- No provider stream connections or stream checking changes.
- Defaults preserve current behavior until an operator changes the settings.

## UI screenshots
Dispatcharr connection settings with the new fetch pressure fields:

![Dispatcharr connection settings with fetch pressure fields](https://raw.githubusercontent.com/bttfw/streamflow/pr-410-ui-screenshots/dispatcharr-connection-settings-sanitized-5000x2.png)

Focused view of the new fields:

![Stream fetch page size and max worker fields](https://raw.githubusercontent.com/bttfw/streamflow/pr-410-ui-screenshots/stream-fetch-pressure-fields-5000x2.png)

## Validation
- `PYTHONPATH=backend python -m pytest backend/tests/test_dispatcharr_fetch_pressure_config.py -q` (4 passed)
- `python -m py_compile backend/apps/config/dispatcharr_config.py backend/apps/api/dispatcharr_handlers.py backend/apps/udi/fetcher.py backend/tests/test_dispatcharr_fetch_pressure_config.py`
- `git diff --check`
- `npm.cmd run build` from `frontend/`
- live `UDIManager.refresh_streams()` validation against a 200k+ stream list using `1000x10`, `2000x4`, and `5000x2`
