### PR TITLE
[codex] Add connectivity guard for quality checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN mkdir -p csv logs data
 # Set environment variable for config directory
 ENV CONFIG_DIR=/app/data
 
-# Set permissions for entrypoint
-RUN chmod +x entrypoint.sh
+# Normalize line endings for Windows build contexts and set permissions for entrypoint
+RUN sed -i 's/\r$//' entrypoint.sh && chmod +x entrypoint.sh
 
 # Create default configuration files in the data directory
 RUN python3 apps/core/create_default_configs.py

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -3046,6 +3046,30 @@ class AutomatedStreamManager:
                     refresh_success = False
             
             if refresh_success:
+                if channels_to_quality_check:
+                    try:
+                        from apps.stream.stream_checker_service import get_stream_checker_service
+                        stream_checker_for_guard = get_stream_checker_service()
+                        failed_connectivity = stream_checker_for_guard._require_quality_check_connectivity(
+                            phase='automation_quality_preflight',
+                            update_progress=False,
+                        )
+                        if failed_connectivity is not None:
+                            logger.error(
+                                "Automation quality-check connectivity guard failed. "
+                                "Skipping validation, assignment, and quality checks to preserve channel streams: %s",
+                                failed_connectivity.message,
+                            )
+                            refresh_success = False
+                    except Exception as guard_err:
+                        logger.error(
+                            "Automation quality-check connectivity guard could not prove connectivity. "
+                            "Skipping validation, assignment, and quality checks: %s",
+                            guard_err,
+                        )
+                        refresh_success = False
+
+            if refresh_success:
                 # Optional post-refresh delay for environments where provider updates
                 # are eventually consistent. Defaults to 0 to avoid fixed latency.
                 post_refresh_delay = self._get_post_refresh_delay_seconds()

--- a/backend/apps/stream/connectivity_guard.py
+++ b/backend/apps/stream/connectivity_guard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import socket
+import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterable, Optional
 from urllib.parse import urlparse, urlunparse
@@ -75,7 +76,12 @@ class StreamConnectivityGuard:
                 details={"enabled": False},
             )
 
-        timeout_seconds = float(cfg.get("timeout_seconds", 3.0))
+        timeout_seconds = max(0.1, self._safe_float(cfg.get("timeout_seconds", 3.0), 3.0))
+        retry_attempts = max(0, min(10, self._safe_int(cfg.get("retry_attempts", 2), 2)))
+        retry_backoff_seconds = max(
+            0.0,
+            min(30.0, self._safe_float(cfg.get("retry_backoff_seconds", 1.0), 1.0)),
+        )
         require_internet = cfg.get("require_internet", True) is not False
         require_dispatcharr_api = cfg.get("require_dispatcharr_api", True) is not False
         checked: Dict[str, Any] = {}
@@ -91,6 +97,8 @@ class StreamConnectivityGuard:
                 urls=internet_urls,
                 label="internet",
                 timeout_seconds=timeout_seconds,
+                retry_attempts=retry_attempts,
+                retry_backoff_seconds=retry_backoff_seconds,
             )
             checked["internet"] = internet_result.details
             if not internet_result.ok:
@@ -123,6 +131,8 @@ class StreamConnectivityGuard:
                 url=dispatcharr_probe_url,
                 label="dispatcharr_api",
                 timeout_seconds=timeout_seconds,
+                retry_attempts=retry_attempts,
+                retry_backoff_seconds=retry_backoff_seconds,
                 headers=headers,
                 accept_unauthorized=False,
             )
@@ -137,6 +147,8 @@ class StreamConnectivityGuard:
                     dispatcharr_headers_provider=dispatcharr_headers_provider,
                     dispatcharr_auth_refresh_provider=dispatcharr_auth_refresh_provider,
                     timeout_seconds=timeout_seconds,
+                    retry_attempts=retry_attempts,
+                    retry_backoff_seconds=retry_backoff_seconds,
                     previous_result=dispatcharr_result,
                 )
             checked["dispatcharr_api"] = dispatcharr_result.details
@@ -158,6 +170,8 @@ class StreamConnectivityGuard:
         dispatcharr_headers_provider: Callable[[], Dict[str, str]],
         dispatcharr_auth_refresh_provider: Callable[[], bool],
         timeout_seconds: float,
+        retry_attempts: int,
+        retry_backoff_seconds: float,
         previous_result: ConnectivityCheckResult,
     ) -> ConnectivityCheckResult:
         try:
@@ -200,6 +214,8 @@ class StreamConnectivityGuard:
             url=dispatcharr_probe_url,
             label="dispatcharr_api",
             timeout_seconds=timeout_seconds,
+            retry_attempts=retry_attempts,
+            retry_backoff_seconds=retry_backoff_seconds,
             headers=refreshed_headers,
             accept_unauthorized=False,
         )
@@ -216,6 +232,8 @@ class StreamConnectivityGuard:
         urls: Iterable[str],
         label: str,
         timeout_seconds: float,
+        retry_attempts: int,
+        retry_backoff_seconds: float,
     ) -> ConnectivityCheckResult:
         last_result: Optional[ConnectivityCheckResult] = None
         attempts = []
@@ -225,6 +243,8 @@ class StreamConnectivityGuard:
                 url=url,
                 label=label,
                 timeout_seconds=timeout_seconds,
+                retry_attempts=retry_attempts,
+                retry_backoff_seconds=retry_backoff_seconds,
                 accept_unauthorized=True,
             )
             attempts.append(result.details)
@@ -254,6 +274,8 @@ class StreamConnectivityGuard:
         url: str,
         label: str,
         timeout_seconds: float,
+        retry_attempts: int,
+        retry_backoff_seconds: float,
         headers: Optional[Dict[str, str]] = None,
         accept_unauthorized: bool,
     ) -> ConnectivityCheckResult:
@@ -287,48 +309,69 @@ class StreamConnectivityGuard:
                 details=safe_details,
             )
 
-        try:
-            response = self._requests.get(
-                url,
-                headers=headers or {},
-                timeout=timeout_seconds,
-                allow_redirects=True,
-            )
-        except requests.exceptions.Timeout:
-            return ConnectivityCheckResult(
-                ok=False,
-                reason="connectivity_timeout",
-                message=f"{label} connectivity probe timed out",
-                details=safe_details,
-            )
-        except requests.exceptions.RequestException:
-            return ConnectivityCheckResult(
-                ok=False,
-                reason="network_unreachable",
-                message=f"{label} connectivity probe could not reach its endpoint",
-                details=safe_details,
-            )
+        max_attempts = retry_attempts + 1
+        last_result: Optional[ConnectivityCheckResult] = None
 
-        safe_details["status_code"] = response.status_code
+        for attempt in range(1, max_attempts + 1):
+            attempt_details = {
+                **safe_details,
+                "attempts": attempt,
+                "max_attempts": max_attempts,
+            }
+            try:
+                response = self._requests.get(
+                    url,
+                    headers=headers or {},
+                    timeout=timeout_seconds,
+                    allow_redirects=True,
+                )
+            except requests.exceptions.Timeout:
+                last_result = ConnectivityCheckResult(
+                    ok=False,
+                    reason="connectivity_timeout",
+                    message=f"{label} connectivity probe timed out after {attempt} attempt(s)",
+                    details=attempt_details,
+                )
+            except requests.exceptions.RequestException:
+                last_result = ConnectivityCheckResult(
+                    ok=False,
+                    reason="network_unreachable",
+                    message=f"{label} connectivity probe could not reach its endpoint after {attempt} attempt(s)",
+                    details=attempt_details,
+                )
+            else:
+                attempt_details["status_code"] = response.status_code
 
-        if 200 <= response.status_code < 400:
-            return ConnectivityCheckResult(True, "ok", f"{label} connectivity verified", safe_details)
-        if accept_unauthorized and response.status_code in {401, 403}:
-            return ConnectivityCheckResult(True, "ok", f"{label} connectivity verified", safe_details)
+                if 200 <= response.status_code < 400:
+                    return ConnectivityCheckResult(True, "ok", f"{label} connectivity verified", attempt_details)
+                if accept_unauthorized and response.status_code in {401, 403}:
+                    return ConnectivityCheckResult(True, "ok", f"{label} connectivity verified", attempt_details)
 
-        if response.status_code in {401, 403}:
-            return ConnectivityCheckResult(
-                ok=False,
-                reason="dispatcharr_auth_failed",
-                message="Dispatcharr API connectivity could not be verified because authentication failed",
-                details=safe_details,
-            )
+                if response.status_code in {401, 403}:
+                    return ConnectivityCheckResult(
+                        ok=False,
+                        reason="dispatcharr_auth_failed",
+                        message="Dispatcharr API connectivity could not be verified because authentication failed",
+                        details=attempt_details,
+                    )
 
-        return ConnectivityCheckResult(
+                last_result = ConnectivityCheckResult(
+                    ok=False,
+                    reason="endpoint_unhealthy",
+                    message=f"{label} connectivity probe returned HTTP {response.status_code} after {attempt} attempt(s)",
+                    details=attempt_details,
+                )
+                if not self._should_retry_status(response.status_code):
+                    return last_result
+
+            if attempt < max_attempts and retry_backoff_seconds > 0:
+                time.sleep(retry_backoff_seconds)
+
+        return last_result or ConnectivityCheckResult(
             ok=False,
-            reason="endpoint_unhealthy",
-            message=f"{label} connectivity probe returned HTTP {response.status_code}",
-            details=safe_details,
+            reason="network_unreachable",
+            message=f"{label} connectivity probe could not reach its endpoint",
+            details={**safe_details, "attempts": max_attempts, "max_attempts": max_attempts},
         )
 
     @staticmethod
@@ -339,6 +382,24 @@ class StreamConnectivityGuard:
     @staticmethod
     def _safe_host(url: str) -> Optional[str]:
         return urlparse(url).hostname
+
+    @staticmethod
+    def _should_retry_status(status_code: int) -> bool:
+        return status_code in {408, 425, 429} or status_code >= 500
+
+    @staticmethod
+    def _safe_float(value: Any, default: float) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _safe_int(value: Any, default: int) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
 
 
 def sanitize_probe_url(url: str) -> str:

--- a/backend/apps/stream/connectivity_guard.py
+++ b/backend/apps/stream/connectivity_guard.py
@@ -64,6 +64,7 @@ class StreamConnectivityGuard:
         config: Optional[Dict[str, Any]] = None,
         dispatcharr_base_url: Optional[str],
         dispatcharr_headers_provider: Optional[Callable[[], Dict[str, str]]] = None,
+        dispatcharr_auth_refresh_provider: Optional[Callable[[], bool]] = None,
     ) -> ConnectivityCheckResult:
         cfg = config or {}
         if cfg.get("enabled", True) is False:
@@ -125,6 +126,19 @@ class StreamConnectivityGuard:
                 headers=headers,
                 accept_unauthorized=False,
             )
+            if (
+                dispatcharr_result.reason == "dispatcharr_auth_failed"
+                and dispatcharr_headers_provider is not None
+                and dispatcharr_auth_refresh_provider is not None
+            ):
+                dispatcharr_result = self._retry_dispatcharr_probe_after_auth_refresh(
+                    dispatcharr_base_url=dispatcharr_base_url,
+                    dispatcharr_probe_url=dispatcharr_probe_url,
+                    dispatcharr_headers_provider=dispatcharr_headers_provider,
+                    dispatcharr_auth_refresh_provider=dispatcharr_auth_refresh_provider,
+                    timeout_seconds=timeout_seconds,
+                    previous_result=dispatcharr_result,
+                )
             checked["dispatcharr_api"] = dispatcharr_result.details
             if not dispatcharr_result.ok:
                 return dispatcharr_result
@@ -135,6 +149,66 @@ class StreamConnectivityGuard:
             message="Connectivity verified",
             details=checked,
         )
+
+    def _retry_dispatcharr_probe_after_auth_refresh(
+        self,
+        *,
+        dispatcharr_base_url: str,
+        dispatcharr_probe_url: str,
+        dispatcharr_headers_provider: Callable[[], Dict[str, str]],
+        dispatcharr_auth_refresh_provider: Callable[[], bool],
+        timeout_seconds: float,
+        previous_result: ConnectivityCheckResult,
+    ) -> ConnectivityCheckResult:
+        try:
+            refreshed = dispatcharr_auth_refresh_provider()
+        except Exception as exc:
+            logger.warning("Connectivity guard could not refresh Dispatcharr auth: %s", exc)
+            previous_result.details = {
+                **previous_result.details,
+                "auth_refresh_attempted": True,
+                "auth_refresh_ok": False,
+            }
+            return previous_result
+
+        if not refreshed:
+            previous_result.details = {
+                **previous_result.details,
+                "auth_refresh_attempted": True,
+                "auth_refresh_ok": False,
+            }
+            return previous_result
+
+        try:
+            refreshed_headers = dispatcharr_headers_provider()
+        except Exception as exc:
+            logger.warning("Connectivity guard could not prepare refreshed Dispatcharr auth headers: %s", exc)
+            return ConnectivityCheckResult(
+                ok=False,
+                reason="dispatcharr_auth_unavailable",
+                message="Dispatcharr API connectivity could not be verified because authentication is unavailable",
+                details={
+                    "dispatcharr_api": {
+                        "host": self._safe_host(dispatcharr_base_url),
+                        "auth_refresh_attempted": True,
+                        "auth_refresh_ok": True,
+                    }
+                },
+            )
+
+        retry_result = self._probe_http_endpoint(
+            url=dispatcharr_probe_url,
+            label="dispatcharr_api",
+            timeout_seconds=timeout_seconds,
+            headers=refreshed_headers,
+            accept_unauthorized=False,
+        )
+        retry_result.details = {
+            **retry_result.details,
+            "auth_refresh_attempted": True,
+            "auth_refresh_ok": True,
+        }
+        return retry_result
 
     def _probe_any_http_endpoint(
         self,

--- a/backend/apps/stream/connectivity_guard.py
+++ b/backend/apps/stream/connectivity_guard.py
@@ -1,0 +1,277 @@
+"""Connectivity preflight checks for destructive stream quality operations."""
+
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, Optional
+from urllib.parse import urlparse, urlunparse
+
+import requests
+
+from apps.core.logging_config import setup_logging
+
+logger = setup_logging(__name__)
+
+
+DEFAULT_INTERNET_PROBE_URLS = (
+    "https://www.google.com/generate_204",
+    "https://cloudflare.com/cdn-cgi/trace",
+)
+
+
+@dataclass
+class ConnectivityCheckResult:
+    """Sanitized result for a connectivity guard check."""
+
+    ok: bool
+    reason: str
+    message: str
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "reason": self.reason,
+            "message": self.message,
+            "details": self.details,
+        }
+
+
+class StreamConnectivityGuard:
+    """Proves network/API reachability before destructive quality checks.
+
+    The checker intentionally fails closed. A result is considered healthy only
+    when a public internet probe and the configured Dispatcharr API probe both
+    complete successfully. Details contain only probe labels, hosts, and HTTP
+    status codes so status payloads and logs can be shared safely.
+    """
+
+    def __init__(
+        self,
+        *,
+        requests_module=requests,
+        socket_module=socket,
+        default_internet_probe_urls: Iterable[str] = DEFAULT_INTERNET_PROBE_URLS,
+    ) -> None:
+        self._requests = requests_module
+        self._socket = socket_module
+        self._default_internet_probe_urls = tuple(default_internet_probe_urls)
+
+    def check(
+        self,
+        *,
+        config: Optional[Dict[str, Any]] = None,
+        dispatcharr_base_url: Optional[str],
+        dispatcharr_headers_provider: Optional[Callable[[], Dict[str, str]]] = None,
+    ) -> ConnectivityCheckResult:
+        cfg = config or {}
+        if cfg.get("enabled", True) is False:
+            return ConnectivityCheckResult(
+                ok=True,
+                reason="disabled",
+                message="Connectivity guard is disabled",
+                details={"enabled": False},
+            )
+
+        timeout_seconds = float(cfg.get("timeout_seconds", 3.0))
+        require_internet = cfg.get("require_internet", True) is not False
+        require_dispatcharr_api = cfg.get("require_dispatcharr_api", True) is not False
+        checked: Dict[str, Any] = {}
+
+        if require_internet:
+            internet_urls = cfg.get("internet_probe_urls") or cfg.get("internet_probe_url")
+            if isinstance(internet_urls, str):
+                internet_urls = [internet_urls]
+            if not internet_urls:
+                internet_urls = self._default_internet_probe_urls
+
+            internet_result = self._probe_any_http_endpoint(
+                urls=internet_urls,
+                label="internet",
+                timeout_seconds=timeout_seconds,
+            )
+            checked["internet"] = internet_result.details
+            if not internet_result.ok:
+                return internet_result
+
+        if require_dispatcharr_api:
+            if not dispatcharr_base_url:
+                return ConnectivityCheckResult(
+                    ok=False,
+                    reason="dispatcharr_base_url_missing",
+                    message="Dispatcharr API connectivity could not be verified because no base URL is configured",
+                    details={"dispatcharr_api": {"configured": False}},
+                )
+
+            headers: Dict[str, str] = {}
+            if dispatcharr_headers_provider is not None:
+                try:
+                    headers = dispatcharr_headers_provider()
+                except Exception as exc:
+                    logger.warning("Connectivity guard could not prepare Dispatcharr auth headers: %s", exc)
+                    return ConnectivityCheckResult(
+                        ok=False,
+                        reason="dispatcharr_auth_unavailable",
+                        message="Dispatcharr API connectivity could not be verified because authentication is unavailable",
+                        details={"dispatcharr_api": {"host": self._safe_host(dispatcharr_base_url)}},
+                    )
+
+            dispatcharr_probe_url = self._build_dispatcharr_probe_url(dispatcharr_base_url)
+            dispatcharr_result = self._probe_http_endpoint(
+                url=dispatcharr_probe_url,
+                label="dispatcharr_api",
+                timeout_seconds=timeout_seconds,
+                headers=headers,
+                accept_unauthorized=False,
+            )
+            checked["dispatcharr_api"] = dispatcharr_result.details
+            if not dispatcharr_result.ok:
+                return dispatcharr_result
+
+        return ConnectivityCheckResult(
+            ok=True,
+            reason="ok",
+            message="Connectivity verified",
+            details=checked,
+        )
+
+    def _probe_any_http_endpoint(
+        self,
+        *,
+        urls: Iterable[str],
+        label: str,
+        timeout_seconds: float,
+    ) -> ConnectivityCheckResult:
+        last_result: Optional[ConnectivityCheckResult] = None
+        attempts = []
+
+        for url in urls:
+            result = self._probe_http_endpoint(
+                url=url,
+                label=label,
+                timeout_seconds=timeout_seconds,
+                accept_unauthorized=True,
+            )
+            attempts.append(result.details)
+            if result.ok:
+                result.details = {"attempts": attempts}
+                return result
+            last_result = result
+
+        if last_result is None:
+            return ConnectivityCheckResult(
+                ok=False,
+                reason="internet_probe_missing",
+                message="Internet connectivity could not be verified because no probe endpoint is configured",
+                details={label: {"configured": False}},
+            )
+
+        return ConnectivityCheckResult(
+            ok=False,
+            reason=last_result.reason,
+            message=last_result.message,
+            details={"attempts": attempts},
+        )
+
+    def _probe_http_endpoint(
+        self,
+        *,
+        url: str,
+        label: str,
+        timeout_seconds: float,
+        headers: Optional[Dict[str, str]] = None,
+        accept_unauthorized: bool,
+    ) -> ConnectivityCheckResult:
+        parsed = urlparse(url)
+        host = parsed.hostname
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        safe_details: Dict[str, Any] = {"label": label, "host": host}
+
+        if parsed.scheme not in {"http", "https"} or not host:
+            return ConnectivityCheckResult(
+                ok=False,
+                reason="invalid_probe_endpoint",
+                message=f"{label} connectivity probe is not a valid HTTP endpoint",
+                details=safe_details,
+            )
+
+        try:
+            self._socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        except socket.gaierror:
+            return ConnectivityCheckResult(
+                ok=False,
+                reason="dns_resolution_failed",
+                message=f"DNS resolution failed for {label} connectivity probe",
+                details=safe_details,
+            )
+        except OSError:
+            return ConnectivityCheckResult(
+                ok=False,
+                reason="network_unreachable",
+                message=f"Network resolution failed for {label} connectivity probe",
+                details=safe_details,
+            )
+
+        try:
+            response = self._requests.get(
+                url,
+                headers=headers or {},
+                timeout=timeout_seconds,
+                allow_redirects=True,
+            )
+        except requests.exceptions.Timeout:
+            return ConnectivityCheckResult(
+                ok=False,
+                reason="connectivity_timeout",
+                message=f"{label} connectivity probe timed out",
+                details=safe_details,
+            )
+        except requests.exceptions.RequestException:
+            return ConnectivityCheckResult(
+                ok=False,
+                reason="network_unreachable",
+                message=f"{label} connectivity probe could not reach its endpoint",
+                details=safe_details,
+            )
+
+        safe_details["status_code"] = response.status_code
+
+        if 200 <= response.status_code < 400:
+            return ConnectivityCheckResult(True, "ok", f"{label} connectivity verified", safe_details)
+        if accept_unauthorized and response.status_code in {401, 403}:
+            return ConnectivityCheckResult(True, "ok", f"{label} connectivity verified", safe_details)
+
+        if response.status_code in {401, 403}:
+            return ConnectivityCheckResult(
+                ok=False,
+                reason="dispatcharr_auth_failed",
+                message="Dispatcharr API connectivity could not be verified because authentication failed",
+                details=safe_details,
+            )
+
+        return ConnectivityCheckResult(
+            ok=False,
+            reason="endpoint_unhealthy",
+            message=f"{label} connectivity probe returned HTTP {response.status_code}",
+            details=safe_details,
+        )
+
+    @staticmethod
+    def _build_dispatcharr_probe_url(base_url: str) -> str:
+        clean = base_url.rstrip("/")
+        return f"{clean}/api/channels/channels/"
+
+    @staticmethod
+    def _safe_host(url: str) -> Optional[str]:
+        return urlparse(url).hostname
+
+
+def sanitize_probe_url(url: str) -> str:
+    """Return scheme/host/port/path only; query and credentials are dropped."""
+
+    parsed = urlparse(url)
+    netloc = parsed.hostname or ""
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse((parsed.scheme, netloc, parsed.path, "", "", ""))

--- a/backend/apps/stream/stream_checker_components.py
+++ b/backend/apps/stream/stream_checker_components.py
@@ -82,6 +82,8 @@ class StreamCheckConfig:
             'require_internet': True,
             'require_dispatcharr_api': True,
             'timeout_seconds': 3.0,
+            'retry_attempts': 2,
+            'retry_backoff_seconds': 1.0,
             'internet_probe_urls': [
                 'https://www.google.com/generate_204',
                 'https://cloudflare.com/cdn-cgi/trace',

--- a/backend/apps/stream/stream_checker_components.py
+++ b/backend/apps/stream/stream_checker_components.py
@@ -76,6 +76,16 @@ class StreamCheckConfig:
             'enabled': True,  # Enable batch stats updates to reduce API calls
             'batch_size': 10,  # Number of streams to update per batch
             'verify_updates': False  # Verify channel updates by refreshing UDI (adds API overhead)
+        },
+        'connectivity_guard': {
+            'enabled': True,
+            'require_internet': True,
+            'require_dispatcharr_api': True,
+            'timeout_seconds': 3.0,
+            'internet_probe_urls': [
+                'https://www.google.com/generate_204',
+                'https://cloudflare.com/cdn-cgi/trace',
+            ],
         }
     }
     

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -35,6 +35,7 @@ from apps.core.api_utils import (
     fetch_channel_streams,
     update_channel_streams,
     _get_base_url,
+    _get_auth_headers,
     patch_request,
     batch_update_stream_stats
 )
@@ -44,6 +45,7 @@ from apps.udi import get_udi_manager
 
 # Import dead streams tracker
 from apps.stream.dead_streams_tracker import DeadStreamsTracker
+from apps.stream.connectivity_guard import ConnectivityCheckResult, StreamConnectivityGuard
 
 # Import channel settings manager
 # Import channel settings manager - DEPRECATED/REMOVED
@@ -176,6 +178,15 @@ class StreamCheckerService:
         
         self.dead_streams_tracker = DeadStreamsTracker()
         logger.debug("Dead streams tracker initialized")
+
+        self.connectivity_guard = StreamConnectivityGuard()
+        self.connectivity_guard_status = {
+            'ok': True,
+            'reason': 'not_checked',
+            'message': 'Connectivity guard has not run yet',
+            'details': {},
+        }
+        logger.debug("Connectivity guard initialized")
         
         # Initialize changelog manager
         self.changelog = None
@@ -1124,6 +1135,96 @@ class StreamCheckerService:
         return 0
 
     # Removed _refine_sorted_streams in favor of lexicographical Sort Keys.
+
+    def _run_connectivity_guard(self, phase: str) -> ConnectivityCheckResult:
+        """Run and record the fail-closed connectivity guard."""
+        try:
+            result = self.connectivity_guard.check(
+                config=self.config.get('connectivity_guard', {}),
+                dispatcharr_base_url=_get_base_url(),
+                dispatcharr_headers_provider=_get_auth_headers,
+            )
+        except Exception as exc:
+            logger.warning("Connectivity guard failed unexpectedly during %s: %s", phase, exc)
+            result = ConnectivityCheckResult(
+                ok=False,
+                reason='connectivity_guard_error',
+                message='Connectivity could not be verified',
+                details={'phase': phase},
+            )
+
+        status = result.to_dict()
+        status['phase'] = phase
+        status['checked_at'] = datetime.now().isoformat()
+        self.connectivity_guard_status = status
+        return result
+
+    def _connectivity_abort_payload(
+        self,
+        result: ConnectivityCheckResult,
+        *,
+        channel_id: Optional[int] = None,
+        channel_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload = {
+            'success': False,
+            'error': 'connectivity_guard',
+            'message': result.message,
+            'connectivity_guard': result.to_dict(),
+        }
+        if channel_id is not None:
+            payload['channel_id'] = channel_id
+        if channel_name is not None:
+            payload['channel_name'] = channel_name
+        return payload
+
+    def _fail_channel_for_connectivity(
+        self,
+        result: ConnectivityCheckResult,
+        *,
+        channel_id: int,
+        channel_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        self.check_queue.mark_failed(channel_id, result.message)
+        return self._connectivity_abort_payload(
+            result,
+            channel_id=channel_id,
+            channel_name=channel_name,
+        )
+
+    def _require_quality_check_connectivity(
+        self,
+        *,
+        phase: str,
+        channel_id: Optional[int] = None,
+        channel_name: Optional[str] = None,
+        update_progress: bool = True,
+    ) -> Optional[ConnectivityCheckResult]:
+        """Return a failed result when destructive quality work must abort."""
+        result = self._run_connectivity_guard(phase)
+        if result.ok:
+            return None
+
+        self.abort_current_check.set()
+        self._cancel_queueing = True
+        safe_channel_name = channel_name or (f"Channel {channel_id}" if channel_id is not None else "Quality check")
+        logger.error("Aborting quality check at %s: %s", phase, result.message)
+
+        if update_progress and channel_id is not None:
+            try:
+                self.progress.update(
+                    channel_id=channel_id,
+                    channel_name=safe_channel_name,
+                    current=0,
+                    total=0,
+                    status='aborted',
+                    step='Connectivity check failed',
+                    step_detail=result.message,
+                )
+            except Exception as exc:
+                logger.debug("Failed to publish connectivity abort progress: %s", exc)
+
+        return result
     
     def _check_channel(self, channel_id: int, skip_batch_changelog: bool = False, forced_profile_id: Optional[str] = None):
         """Check and reorder streams for a specific channel.
@@ -1134,6 +1235,16 @@ class StreamCheckerService:
             channel_id: ID of the channel to check
             skip_batch_changelog: If True, don't add this check to the batch changelog
         """
+        failed_connectivity = self._require_quality_check_connectivity(
+            phase='quality_check_preflight',
+            channel_id=channel_id,
+        )
+        if failed_connectivity is not None:
+            return self._fail_channel_for_connectivity(
+                failed_connectivity,
+                channel_id=channel_id,
+            )
+
         concurrent_enabled = self.config.get('concurrent_streams.enabled', True)
         
         if concurrent_enabled:
@@ -1612,6 +1723,17 @@ class StreamCheckerService:
                         analyzed['dead_reason'] = dead_reason
                     
                     if is_dead and not was_dead:
+                        failed_connectivity = self._require_quality_check_connectivity(
+                            phase='mark_dead_stream',
+                            channel_id=channel_id,
+                            channel_name=channel_name,
+                        )
+                        if failed_connectivity is not None:
+                            return self._fail_channel_for_connectivity(
+                                failed_connectivity,
+                                channel_id=channel_id,
+                                channel_name=channel_name,
+                            )
                         if self.dead_streams_tracker.mark_as_dead(stream_url, stream_id, stream_name, channel_id, reason=dead_reason):
                             dead_stream_ids.add(stream_id)
                             if analyzed.get('blank_detected'):
@@ -1640,6 +1762,17 @@ class StreamCheckerService:
                         # check pass. Unchecked streams must not be culled based on prior-run
                         # tracker state — their status will be re-evaluated in the next full check.
                         if stream_id in checked_stream_id_set:
+                            failed_connectivity = self._require_quality_check_connectivity(
+                                phase='keep_dead_stream_marked',
+                                channel_id=channel_id,
+                                channel_name=channel_name,
+                            )
+                            if failed_connectivity is not None:
+                                return self._fail_channel_for_connectivity(
+                                    failed_connectivity,
+                                    channel_id=channel_id,
+                                    channel_name=channel_name,
+                                )
                             self._refresh_dead_stream_reason_if_needed(
                                 stream_url,
                                 stream_id,
@@ -1822,6 +1955,18 @@ class StreamCheckerService:
                     f"{_uncached_ids[:5]}{'...' if len(_uncached_ids) > 5 else ''}"
                 )
                 reordered_ids.extend(_uncached_ids)
+
+            failed_connectivity = self._require_quality_check_connectivity(
+                phase='channel_stream_update',
+                channel_id=channel_id,
+                channel_name=channel_name,
+            )
+            if failed_connectivity is not None:
+                return self._fail_channel_for_connectivity(
+                    failed_connectivity,
+                    channel_id=channel_id,
+                    channel_name=channel_name,
+                )
 
             update_channel_streams(channel_id, reordered_ids, allow_dead_streams=(not dead_stream_removal_enabled))
             
@@ -2349,6 +2494,17 @@ class StreamCheckerService:
                     analyzed['dead_reason'] = dead_reason
                 
                 if is_dead and not was_dead:
+                    failed_connectivity = self._require_quality_check_connectivity(
+                        phase='mark_dead_stream',
+                        channel_id=channel_id,
+                        channel_name=channel_name,
+                    )
+                    if failed_connectivity is not None:
+                        return self._fail_channel_for_connectivity(
+                            failed_connectivity,
+                            channel_id=channel_id,
+                            channel_name=channel_name,
+                        )
                     # Mark as dead in tracker
                     if self.dead_streams_tracker.mark_as_dead(stream_url, stream['id'], stream_name, channel_id, reason=dead_reason):
                         dead_stream_ids.add(stream['id'])
@@ -2378,6 +2534,17 @@ class StreamCheckerService:
                     # symmetry with the concurrent method and to make the scope
                     # constraint explicit at review time.
                     if stream['id'] in checked_stream_id_set:
+                        failed_connectivity = self._require_quality_check_connectivity(
+                            phase='keep_dead_stream_marked',
+                            channel_id=channel_id,
+                            channel_name=channel_name,
+                        )
+                        if failed_connectivity is not None:
+                            return self._fail_channel_for_connectivity(
+                                failed_connectivity,
+                                channel_id=channel_id,
+                                channel_name=channel_name,
+                            )
                         self._refresh_dead_stream_reason_if_needed(
                             stream_url,
                             stream['id'],
@@ -2630,6 +2797,18 @@ class StreamCheckerService:
                     f"{_uncached_ids[:5]}{'...' if len(_uncached_ids) > 5 else ''}"
                 )
                 reordered_ids.extend(_uncached_ids)
+
+            failed_connectivity = self._require_quality_check_connectivity(
+                phase='channel_stream_update',
+                channel_id=channel_id,
+                channel_name=channel_name,
+            )
+            if failed_connectivity is not None:
+                return self._fail_channel_for_connectivity(
+                    failed_connectivity,
+                    channel_id=channel_id,
+                    channel_name=channel_name,
+                )
 
             update_channel_streams(channel_id, reordered_ids, allow_dead_streams=(not dead_stream_removal_enabled))
             
@@ -3344,6 +3523,7 @@ class StreamCheckerService:
             'enabled': self.config.get('enabled', True),
             'queue': queue_status,
             'progress': progress,
+            'connectivity_guard': self.connectivity_guard_status,
             'last_global_check': self.update_tracker.get_last_global_check(),
             'config': {
                 'automation_controls': self.config.get('automation_controls', {}),
@@ -3421,6 +3601,19 @@ class StreamCheckerService:
             Dict mapping channel_id to result dict (containing dead/revived streams)
         """
         results = {}
+
+        failed_connectivity = self._require_quality_check_connectivity(
+            phase='sync_batch_preflight',
+            update_progress=False,
+        )
+        if failed_connectivity is not None:
+            return {
+                channel_id: self._connectivity_abort_payload(
+                    failed_connectivity,
+                    channel_id=channel_id,
+                )
+                for channel_id in channel_ids
+            }
         
         # Mark force check if requested
         if force_check:
@@ -3650,6 +3843,18 @@ class StreamCheckerService:
             )
             logger.info(f"UDI cache {udi.get_cache_age_description()}")
 
+            failed_connectivity = self._require_quality_check_connectivity(
+                phase='single_channel_preflight',
+                channel_id=channel_id,
+                channel_name=channel_name,
+            )
+            if failed_connectivity is not None:
+                return self._connectivity_abort_payload(
+                    failed_connectivity,
+                    channel_id=channel_id,
+                    channel_name=channel_name,
+                )
+
             # Signal to the frontend that this is a single channel check so the
             # stale batch progress card from the previous automation run is suppressed.
             self.progress.update(
@@ -3823,6 +4028,17 @@ class StreamCheckerService:
             # Step 4: Validate existing streams against regex patterns (if matching is enabled)
             if matching_enabled:
                 logger.info(f"Step 4/6: Validating existing streams for channel {channel_name}...")
+                failed_connectivity = self._require_quality_check_connectivity(
+                    phase='single_channel_validation_removal',
+                    channel_id=channel_id,
+                    channel_name=channel_name,
+                )
+                if failed_connectivity is not None:
+                    return self._connectivity_abort_payload(
+                        failed_connectivity,
+                        channel_id=channel_id,
+                        channel_name=channel_name,
+                    )
                 try:
                     from apps.automation.automated_stream_manager import AutomatedStreamManager
                     automation_manager = AutomatedStreamManager()
@@ -3856,6 +4072,17 @@ class StreamCheckerService:
 
             if matching_enabled:
                 logger.info(f"Step 5/6: Re-matching streams for channel {channel_name}...")
+                failed_connectivity = self._require_quality_check_connectivity(
+                    phase='single_channel_matching_update',
+                    channel_id=channel_id,
+                    channel_name=channel_name,
+                )
+                if failed_connectivity is not None:
+                    return self._connectivity_abort_payload(
+                        failed_connectivity,
+                        channel_id=channel_id,
+                        channel_name=channel_name,
+                    )
                 try:
                     # Import here to allow better test mocking
                     from apps.automation.automated_stream_manager import AutomatedStreamManager

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -46,6 +46,7 @@ from apps.udi import get_udi_manager
 # Import dead streams tracker
 from apps.stream.dead_streams_tracker import DeadStreamsTracker
 from apps.stream.connectivity_guard import ConnectivityCheckResult, StreamConnectivityGuard
+from apps.core.auth import _refresh_token
 
 # Import channel settings manager
 # Import channel settings manager - DEPRECATED/REMOVED
@@ -1143,6 +1144,7 @@ class StreamCheckerService:
                 config=self.config.get('connectivity_guard', {}),
                 dispatcharr_base_url=_get_base_url(),
                 dispatcharr_headers_provider=_get_auth_headers,
+                dispatcharr_auth_refresh_provider=_refresh_token,
             )
         except Exception as exc:
             logger.warning("Connectivity guard failed unexpectedly during %s: %s", phase, exc)

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -3517,6 +3517,11 @@ class StreamCheckerService:
             queue_status.get('in_progress', 0) > 0 or
             sync_state.get('active', False)
         )
+
+        connectivity_guard_status = dict(self.connectivity_guard_status or {})
+        guard_failed = connectivity_guard_status.get('ok') is False
+        connectivity_guard_status['active_failure'] = bool(guard_failed and stream_checking_mode)
+        connectivity_guard_status['stale_failure'] = bool(guard_failed and not stream_checking_mode)
         
         return {
             'running': self.running,
@@ -3525,7 +3530,7 @@ class StreamCheckerService:
             'enabled': self.config.get('enabled', True),
             'queue': queue_status,
             'progress': progress,
-            'connectivity_guard': self.connectivity_guard_status,
+            'connectivity_guard': connectivity_guard_status,
             'last_global_check': self.update_tracker.get_last_global_check(),
             'config': {
                 'automation_controls': self.config.get('automation_controls', {}),

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -1171,6 +1171,8 @@ class StreamCheckerService:
         payload = {
             'success': False,
             'error': 'connectivity_guard',
+            'aborted': True,
+            'skip_reason': 'connectivity_guard',
             'message': result.message,
             'connectivity_guard': result.to_dict(),
         }

--- a/backend/tests/test_connectivity_guard.py
+++ b/backend/tests/test_connectivity_guard.py
@@ -3,6 +3,8 @@ import socket
 import sys
 from unittest.mock import Mock, patch
 
+import requests
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from apps.stream.connectivity_guard import ConnectivityCheckResult, StreamConnectivityGuard
@@ -49,6 +51,34 @@ class _RequestsAuthRefresh:
         if self.dispatcharr_attempts == 1:
             return _Response(401)
         return _Response(200)
+
+
+class _RequestsDispatcharrTimeoutThenOk:
+    def __init__(self):
+        self.urls = []
+        self.dispatcharr_attempts = 0
+
+    def get(self, url, **kwargs):
+        self.urls.append(url)
+        if "channels/channels" not in url:
+            return _Response(204)
+
+        self.dispatcharr_attempts += 1
+        if self.dispatcharr_attempts == 1:
+            raise requests.exceptions.Timeout("temporary timeout")
+        return _Response(200)
+
+
+class _RequestsDispatcharrAlwaysTimeout:
+    def __init__(self):
+        self.dispatcharr_attempts = 0
+
+    def get(self, url, **kwargs):
+        if "channels/channels" not in url:
+            return _Response(204)
+
+        self.dispatcharr_attempts += 1
+        raise requests.exceptions.Timeout("persistent timeout")
 
 
 def test_connectivity_guard_passes_when_internet_and_dispatcharr_are_reachable():
@@ -100,6 +130,58 @@ def test_connectivity_guard_refreshes_auth_once_when_dispatcharr_token_is_stale(
     assert headers.call_count == 2
     assert result.details["dispatcharr_api"]["auth_refresh_attempted"] is True
     assert result.details["dispatcharr_api"]["auth_refresh_ok"] is True
+
+
+def test_connectivity_guard_retries_transient_dispatcharr_timeout():
+    requests_retry = _RequestsDispatcharrTimeoutThenOk()
+    guard = StreamConnectivityGuard(
+        requests_module=requests_retry,
+        socket_module=_ResolvingSocket(),
+        default_internet_probe_urls=("https://probe.example/generate_204",),
+    )
+
+    result = guard.check(
+        config={
+            "enabled": True,
+            "timeout_seconds": 1,
+            "retry_attempts": 1,
+            "retry_backoff_seconds": 0,
+        },
+        dispatcharr_base_url="http://dispatcharr.local",
+        dispatcharr_headers_provider=lambda: {"Authorization": "Bearer test"},
+    )
+
+    assert result.ok is True
+    assert result.reason == "ok"
+    assert requests_retry.dispatcharr_attempts == 2
+    assert result.details["dispatcharr_api"]["attempts"] == 2
+    assert result.details["dispatcharr_api"]["max_attempts"] == 2
+
+
+def test_connectivity_guard_fails_after_configured_dispatcharr_timeout_retries():
+    requests_timeout = _RequestsDispatcharrAlwaysTimeout()
+    guard = StreamConnectivityGuard(
+        requests_module=requests_timeout,
+        socket_module=_ResolvingSocket(),
+        default_internet_probe_urls=("https://probe.example/generate_204",),
+    )
+
+    result = guard.check(
+        config={
+            "enabled": True,
+            "timeout_seconds": 1,
+            "retry_attempts": 2,
+            "retry_backoff_seconds": 0,
+        },
+        dispatcharr_base_url="http://dispatcharr.local",
+        dispatcharr_headers_provider=lambda: {"Authorization": "Bearer test"},
+    )
+
+    assert result.ok is False
+    assert result.reason == "connectivity_timeout"
+    assert requests_timeout.dispatcharr_attempts == 3
+    assert result.details["attempts"] == 3
+    assert result.details["max_attempts"] == 3
 
 
 def test_connectivity_guard_fails_closed_on_dns_failure():

--- a/backend/tests/test_connectivity_guard.py
+++ b/backend/tests/test_connectivity_guard.py
@@ -155,6 +155,40 @@ def test_quality_check_startup_offline_aborts_before_channel_check():
     assert service.connectivity_guard_status["ok"] is False
 
 
+def test_idle_status_marks_previous_connectivity_failure_as_stale():
+    service = StreamCheckerService()
+    service.checking = False
+    service.connectivity_guard_status = {
+        "ok": False,
+        "reason": "connectivity_timeout",
+        "message": "internet connectivity probe timed out",
+    }
+
+    with patch.object(service.progress, "get", return_value=None):
+        status = service.get_status()
+
+    assert status["stream_checking_mode"] is False
+    assert status["connectivity_guard"]["active_failure"] is False
+    assert status["connectivity_guard"]["stale_failure"] is True
+
+
+def test_active_status_marks_current_connectivity_failure_as_active():
+    service = StreamCheckerService()
+    service.checking = True
+    service.connectivity_guard_status = {
+        "ok": False,
+        "reason": "connectivity_timeout",
+        "message": "internet connectivity probe timed out",
+    }
+
+    with patch.object(service.progress, "get", return_value=None):
+        status = service.get_status()
+
+    assert status["stream_checking_mode"] is True
+    assert status["connectivity_guard"]["active_failure"] is True
+    assert status["connectivity_guard"]["stale_failure"] is False
+
+
 def test_mid_run_outage_does_not_mark_dead_or_update_channel():
     service = StreamCheckerService()
     service.config.config["concurrent_streams"]["enabled"] = False

--- a/backend/tests/test_connectivity_guard.py
+++ b/backend/tests/test_connectivity_guard.py
@@ -1,0 +1,176 @@
+import os
+import socket
+import sys
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from apps.stream.connectivity_guard import ConnectivityCheckResult, StreamConnectivityGuard
+from apps.stream.stream_checker_service import StreamCheckerService
+
+
+class _Response:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+class _ResolvingSocket:
+    def getaddrinfo(self, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443))]
+
+
+class _DnsFailureSocket:
+    def getaddrinfo(self, *args, **kwargs):
+        raise socket.gaierror("dns failed")
+
+
+class _RequestsOk:
+    def __init__(self):
+        self.urls = []
+
+    def get(self, url, **kwargs):
+        self.urls.append(url)
+        if "channels/channels" in url:
+            return _Response(200)
+        return _Response(204)
+
+
+def test_connectivity_guard_passes_when_internet_and_dispatcharr_are_reachable():
+    requests_ok = _RequestsOk()
+    guard = StreamConnectivityGuard(
+        requests_module=requests_ok,
+        socket_module=_ResolvingSocket(),
+        default_internet_probe_urls=("https://probe.example/generate_204",),
+    )
+
+    result = guard.check(
+        config={"enabled": True, "timeout_seconds": 1},
+        dispatcharr_base_url="http://dispatcharr.local",
+        dispatcharr_headers_provider=lambda: {"Authorization": "Bearer test"},
+    )
+
+    assert result.ok is True
+    assert result.reason == "ok"
+    assert requests_ok.urls == [
+        "https://probe.example/generate_204",
+        "http://dispatcharr.local/api/channels/channels/",
+    ]
+
+
+def test_connectivity_guard_fails_closed_on_dns_failure():
+    guard = StreamConnectivityGuard(
+        requests_module=_RequestsOk(),
+        socket_module=_DnsFailureSocket(),
+        default_internet_probe_urls=("https://probe.example/generate_204",),
+    )
+
+    result = guard.check(
+        config={"enabled": True},
+        dispatcharr_base_url="http://dispatcharr.local",
+        dispatcharr_headers_provider=lambda: {},
+    )
+
+    assert result.ok is False
+    assert result.reason == "dns_resolution_failed"
+
+
+def test_connectivity_guard_can_be_disabled_by_config():
+    requests_ok = _RequestsOk()
+    guard = StreamConnectivityGuard(
+        requests_module=requests_ok,
+        socket_module=_DnsFailureSocket(),
+    )
+
+    result = guard.check(
+        config={"enabled": False},
+        dispatcharr_base_url=None,
+        dispatcharr_headers_provider=lambda: {},
+    )
+
+    assert result.ok is True
+    assert result.reason == "disabled"
+    assert requests_ok.urls == []
+
+
+def test_quality_check_startup_offline_aborts_before_channel_check():
+    service = StreamCheckerService()
+    failed = ConnectivityCheckResult(
+        ok=False,
+        reason="network_unreachable",
+        message="internet connectivity probe could not reach its endpoint",
+    )
+    service.connectivity_guard.check = Mock(return_value=failed)
+
+    with patch.object(service, "_check_channel_sequential") as sequential:
+        result = service._check_channel(42)
+
+    sequential.assert_not_called()
+    assert result["success"] is False
+    assert result["error"] == "connectivity_guard"
+    assert service.connectivity_guard_status["ok"] is False
+
+
+def test_mid_run_outage_does_not_mark_dead_or_update_channel():
+    service = StreamCheckerService()
+    service.config.config["concurrent_streams"]["enabled"] = False
+    service._check_channel_limits = Mock(return_value=None)
+    service._get_m3u_account_name = Mock(return_value="Provider")
+    service._update_stream_stats = Mock(return_value=True)
+    service.dead_streams_tracker.is_dead = Mock(return_value=False)
+    service.dead_streams_tracker.mark_as_dead = Mock(return_value=True)
+
+    ok = ConnectivityCheckResult(ok=True, reason="ok", message="Connectivity verified")
+    failed = ConnectivityCheckResult(
+        ok=False,
+        reason="network_unreachable",
+        message="internet connectivity probe could not reach its endpoint",
+    )
+    service.connectivity_guard.check = Mock(side_effect=[ok, failed])
+
+    mock_udi = Mock()
+    mock_udi.get_channel_by_id.return_value = {
+        "id": 42,
+        "name": "Test Channel",
+        "streams": [1001],
+    }
+    mock_udi.apply_profile_url_transformation.side_effect = lambda stream: stream["url"]
+    mock_udi.get_stream_by_id.return_value = None
+
+    mock_profile = {
+        "id": "profile-1",
+        "name": "Default",
+        "stream_checking": {
+            "enabled": True,
+            "remove_dead_streams": True,
+            "allow_revive": True,
+            "grace_period": False,
+        },
+    }
+    mock_automation_config = Mock()
+    mock_automation_config.get_effective_configuration.return_value = {"profile": mock_profile}
+
+    streams = [{"id": 1001, "name": "Dead Candidate", "url": "http://stream.example/live"}]
+    dead_analysis = {
+        "stream_id": 1001,
+        "stream_name": "Dead Candidate",
+        "stream_url": "http://stream.example/live",
+        "resolution": "0x0",
+        "fps": 0,
+        "video_codec": "N/A",
+        "audio_codec": "N/A",
+        "bitrate_kbps": 0,
+        "status": "ERROR",
+    }
+
+    with patch("apps.stream.stream_checker_service.get_udi_manager", return_value=mock_udi), \
+         patch("apps.stream.stream_checker_service.fetch_channel_streams", return_value=streams), \
+         patch("apps.automation.automation_config_manager.get_automation_config_manager", return_value=mock_automation_config), \
+         patch("apps.stream.stream_check_utils.analyze_stream", return_value=dead_analysis), \
+         patch("apps.stream.stream_checker_service.update_channel_streams") as update_channel_streams:
+        result = service._check_channel(42)
+
+    assert result["success"] is False
+    assert result["error"] == "connectivity_guard"
+    service.dead_streams_tracker.mark_as_dead.assert_not_called()
+    update_channel_streams.assert_not_called()
+    assert service.connectivity_guard.check.call_count == 2

--- a/backend/tests/test_connectivity_guard.py
+++ b/backend/tests/test_connectivity_guard.py
@@ -35,6 +35,22 @@ class _RequestsOk:
         return _Response(204)
 
 
+class _RequestsAuthRefresh:
+    def __init__(self):
+        self.urls = []
+        self.dispatcharr_attempts = 0
+
+    def get(self, url, **kwargs):
+        self.urls.append(url)
+        if "channels/channels" not in url:
+            return _Response(204)
+
+        self.dispatcharr_attempts += 1
+        if self.dispatcharr_attempts == 1:
+            return _Response(401)
+        return _Response(200)
+
+
 def test_connectivity_guard_passes_when_internet_and_dispatcharr_are_reachable():
     requests_ok = _RequestsOk()
     guard = StreamConnectivityGuard(
@@ -55,6 +71,35 @@ def test_connectivity_guard_passes_when_internet_and_dispatcharr_are_reachable()
         "https://probe.example/generate_204",
         "http://dispatcharr.local/api/channels/channels/",
     ]
+
+
+def test_connectivity_guard_refreshes_auth_once_when_dispatcharr_token_is_stale():
+    requests_refresh = _RequestsAuthRefresh()
+    refresh = Mock(return_value=True)
+    headers = Mock(side_effect=[
+        {"Authorization": "Bearer stale"},
+        {"Authorization": "Bearer fresh"},
+    ])
+    guard = StreamConnectivityGuard(
+        requests_module=requests_refresh,
+        socket_module=_ResolvingSocket(),
+        default_internet_probe_urls=("https://probe.example/generate_204",),
+    )
+
+    result = guard.check(
+        config={"enabled": True, "timeout_seconds": 1},
+        dispatcharr_base_url="http://dispatcharr.local",
+        dispatcharr_headers_provider=headers,
+        dispatcharr_auth_refresh_provider=refresh,
+    )
+
+    assert result.ok is True
+    assert result.reason == "ok"
+    assert requests_refresh.dispatcharr_attempts == 2
+    refresh.assert_called_once()
+    assert headers.call_count == 2
+    assert result.details["dispatcharr_api"]["auth_refresh_attempted"] is True
+    assert result.details["dispatcharr_api"]["auth_refresh_ok"] is True
 
 
 def test_connectivity_guard_fails_closed_on_dns_failure():

--- a/backend/tests/test_connectivity_guard.py
+++ b/backend/tests/test_connectivity_guard.py
@@ -152,6 +152,8 @@ def test_quality_check_startup_offline_aborts_before_channel_check():
     sequential.assert_not_called()
     assert result["success"] is False
     assert result["error"] == "connectivity_guard"
+    assert result["aborted"] is True
+    assert result["skip_reason"] == "connectivity_guard"
     assert service.connectivity_guard_status["ok"] is False
 
 

--- a/docs/stream-checking.md
+++ b/docs/stream-checking.md
@@ -78,6 +78,30 @@ If `allow_revive: true` is set in the profile, dead streams are re-checked on ea
 
 ---
 
+## Connectivity guard
+
+Stream checking includes a fail-closed connectivity guard before destructive
+quality-check operations. By default, StreamFlow verifies both general internet
+reachability and the configured Dispatcharr API before a quality check can mark
+streams dead or write a changed stream list back to a channel.
+
+The guard also re-checks connectivity immediately before dead-stream marking and
+channel stream updates. If DNS, internet access, the gateway, or the Dispatcharr
+API cannot be verified, the quality-check step aborts and leaves channel stream
+assignments unchanged.
+
+The guard can be disabled from Stream Checker -> Safety or by setting:
+
+```json
+{
+  "connectivity_guard": {
+    "enabled": false
+  }
+}
+```
+
+---
+
 ## Stream protection (hysteresis)
 
 StreamFlow distinguishes between streams that are **currently in use** and streams that are idle. Currently active streams receive a longer grace period before being replaced — even if a higher-scoring stream is available — to avoid interrupting live playback. Idle streams are replaced aggressively.

--- a/frontend/src/pages/StreamChecker.jsx
+++ b/frontend/src/pages/StreamChecker.jsx
@@ -255,7 +255,7 @@ export default function StreamChecker() {
   const queued = status?.queue?.queued || 0
   const totalBatch = queued + inProgress + completed + failed
   const batchProgress = totalBatch > 0 ? ((completed + failed) / totalBatch) * 100 : 0
-  const connectivityGuardFailed = status?.connectivity_guard?.ok === false
+  const connectivityGuardFailed = status?.connectivity_guard?.active_failure === true
 
   return (
     <div className="space-y-6">

--- a/frontend/src/pages/StreamChecker.jsx
+++ b/frontend/src/pages/StreamChecker.jsx
@@ -22,6 +22,8 @@ import {
   Settings,
   Trash2,
   AlertCircle,
+  ShieldAlert,
+  ShieldCheck,
   RefreshCw,
   List
 } from 'lucide-react'
@@ -253,6 +255,7 @@ export default function StreamChecker() {
   const queued = status?.queue?.queued || 0
   const totalBatch = queued + inProgress + completed + failed
   const batchProgress = totalBatch > 0 ? ((completed + failed) / totalBatch) * 100 : 0
+  const connectivityGuardFailed = status?.connectivity_guard?.ok === false
 
   return (
     <div className="space-y-6">
@@ -325,6 +328,16 @@ export default function StreamChecker() {
           </CardContent>
         </Card>
       </div>
+
+      {connectivityGuardFailed && (
+        <Alert variant="destructive">
+          <ShieldAlert className="h-4 w-4" />
+          <AlertTitle>Connectivity Check Failed</AlertTitle>
+          <AlertDescription>
+            {status?.connectivity_guard?.message || 'Quality checking was stopped before channel streams were changed.'}
+          </AlertDescription>
+        </Alert>
+      )}
 
       {/* Batch Progress — hidden during single channel checks to avoid showing
            stale counters from the previous automation run */}
@@ -573,9 +586,10 @@ export default function StreamChecker() {
 
               {/* Tabs for Configuration Sections */}
               <Tabs defaultValue="analysis" className="w-full">
-                <TabsList className="grid w-full grid-cols-3">
+                <TabsList className="grid w-full grid-cols-4">
                   <TabsTrigger value="analysis">Stream Analysis</TabsTrigger>
                   <TabsTrigger value="concurrent">Concurrent Checking</TabsTrigger>
+                  <TabsTrigger value="safety">Safety</TabsTrigger>
                   <TabsTrigger value="dead-streams">Dead Streams</TabsTrigger>
                 </TabsList>
 
@@ -743,6 +757,55 @@ export default function StreamChecker() {
                     <p className="text-xs text-muted-foreground">
                       Delay between starting each concurrent check to prevent overload
                     </p>
+                  </div>
+                </TabsContent>
+
+
+                {/* Safety Tab */}
+                <TabsContent value="safety" className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label htmlFor="connectivity_guard_enabled">Connectivity Guard</Label>
+                      <p className="text-xs text-muted-foreground">
+                        Verify internet and Dispatcharr API reachability before stream checks can mark streams dead or update channel assignments
+                      </p>
+                    </div>
+                    <Switch
+                      id="connectivity_guard_enabled"
+                      checked={editedConfig?.connectivity_guard?.enabled !== false}
+                      onCheckedChange={(checked) => updateConfigValue('connectivity_guard.enabled', checked)}
+                      disabled={!configEditing}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="connectivity_guard_timeout">Connectivity Timeout (seconds)</Label>
+                    <Input
+                      id="connectivity_guard_timeout"
+                      type="number"
+                      step="0.5"
+                      value={editedConfig?.connectivity_guard?.timeout_seconds ?? 3}
+                      onChange={(e) => updateConfigValue('connectivity_guard.timeout_seconds', parseFloat(e.target.value))}
+                      disabled={!configEditing || editedConfig?.connectivity_guard?.enabled === false}
+                      min={1}
+                      max={15}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Probe timeout used by the fail-closed safety check
+                    </p>
+                  </div>
+
+                  <div className="flex items-center gap-2 rounded-md border p-3 text-sm">
+                    {editedConfig?.connectivity_guard?.enabled === false ? (
+                      <ShieldAlert className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+                    )}
+                    <span>
+                      {editedConfig?.connectivity_guard?.enabled === false
+                        ? 'Connectivity guard disabled'
+                        : 'Connectivity guard enabled'}
+                    </span>
                   </div>
                 </TabsContent>
 

--- a/frontend/src/pages/StreamChecker.jsx
+++ b/frontend/src/pages/StreamChecker.jsx
@@ -586,7 +586,7 @@ export default function StreamChecker() {
 
               {/* Tabs for Configuration Sections */}
               <Tabs defaultValue="analysis" className="w-full">
-                <TabsList className="grid w-full grid-cols-4">
+                <TabsList className="grid h-auto min-h-10 w-full grid-cols-1 gap-1 sm:grid-cols-2 lg:grid-cols-4">
                   <TabsTrigger value="analysis">Stream Analysis</TabsTrigger>
                   <TabsTrigger value="concurrent">Concurrent Checking</TabsTrigger>
                   <TabsTrigger value="safety">Safety</TabsTrigger>
@@ -594,7 +594,7 @@ export default function StreamChecker() {
                 </TabsList>
 
                 {/* Stream Analysis Tab */}
-                <TabsContent value="analysis" className="space-y-4">
+                <TabsContent value="analysis" className="mt-4 space-y-4">
                   <div className="grid gap-4 md:grid-cols-2">
                     <div className="space-y-2">
                       <Label htmlFor="ffmpeg_duration">FFmpeg Duration (seconds)</Label>
@@ -710,7 +710,7 @@ export default function StreamChecker() {
                 </TabsContent>
 
                 {/* Concurrent Checking Tab */}
-                <TabsContent value="concurrent" className="space-y-4">
+                <TabsContent value="concurrent" className="mt-4 space-y-4">
                   <div className="flex items-center justify-between">
                     <div className="space-y-0.5">
                       <Label htmlFor="concurrent_enabled">Enable Concurrent Checking</Label>
@@ -762,7 +762,7 @@ export default function StreamChecker() {
 
 
                 {/* Safety Tab */}
-                <TabsContent value="safety" className="space-y-4">
+                <TabsContent value="safety" className="mt-4 space-y-4">
                   <div className="flex items-center justify-between">
                     <div className="space-y-0.5">
                       <Label htmlFor="connectivity_guard_enabled">Connectivity Guard</Label>
@@ -846,7 +846,7 @@ export default function StreamChecker() {
 
 
                 {/* Dead Streams Tab */}
-                <TabsContent value="dead-streams" className="space-y-4">
+                <TabsContent value="dead-streams" className="mt-4 space-y-4">
                   <p className="text-sm text-muted-foreground">
                     View and manage streams that have been marked as dead. Removal from channels during stream checks depends on each automation profile&apos;s Stream Checking settings.
                   </p>

--- a/frontend/src/pages/StreamChecker.jsx
+++ b/frontend/src/pages/StreamChecker.jsx
@@ -778,21 +778,56 @@ export default function StreamChecker() {
                     />
                   </div>
 
-                  <div className="space-y-2">
-                    <Label htmlFor="connectivity_guard_timeout">Connectivity Timeout (seconds)</Label>
-                    <Input
-                      id="connectivity_guard_timeout"
-                      type="number"
-                      step="0.5"
-                      value={editedConfig?.connectivity_guard?.timeout_seconds ?? 3}
-                      onChange={(e) => updateConfigValue('connectivity_guard.timeout_seconds', parseFloat(e.target.value))}
-                      disabled={!configEditing || editedConfig?.connectivity_guard?.enabled === false}
-                      min={1}
-                      max={15}
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Probe timeout used by the fail-closed safety check
-                    </p>
+                  <div className="grid gap-4 md:grid-cols-3">
+                    <div className="space-y-2">
+                      <Label htmlFor="connectivity_guard_timeout">Connectivity Timeout (seconds)</Label>
+                      <Input
+                        id="connectivity_guard_timeout"
+                        type="number"
+                        step="0.5"
+                        value={editedConfig?.connectivity_guard?.timeout_seconds ?? 3}
+                        onChange={(e) => updateConfigValue('connectivity_guard.timeout_seconds', parseFloat(e.target.value))}
+                        disabled={!configEditing || editedConfig?.connectivity_guard?.enabled === false}
+                        min={1}
+                        max={15}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Per-attempt probe timeout
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="connectivity_guard_retries">Connectivity Retries</Label>
+                      <Input
+                        id="connectivity_guard_retries"
+                        type="number"
+                        value={editedConfig?.connectivity_guard?.retry_attempts ?? 2}
+                        onChange={(e) => updateConfigValue('connectivity_guard.retry_attempts', parseInt(e.target.value))}
+                        disabled={!configEditing || editedConfig?.connectivity_guard?.enabled === false}
+                        min={0}
+                        max={10}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Extra attempts before fail-closed abort
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="connectivity_guard_retry_backoff">Retry Backoff (seconds)</Label>
+                      <Input
+                        id="connectivity_guard_retry_backoff"
+                        type="number"
+                        step="0.5"
+                        value={editedConfig?.connectivity_guard?.retry_backoff_seconds ?? 1}
+                        onChange={(e) => updateConfigValue('connectivity_guard.retry_backoff_seconds', parseFloat(e.target.value))}
+                        disabled={!configEditing || editedConfig?.connectivity_guard?.enabled === false}
+                        min={0}
+                        max={30}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Pause between transient retry attempts
+                      </p>
+                    </div>
                   </div>
 
                   <div className="flex items-center gap-2 rounded-md border p-3 text-sm">


### PR DESCRIPTION
## Summary
- add a fail-closed connectivity guard before destructive stream quality-check work
- verify both public internet reachability and the configured Dispatcharr API before removing, marking, or reordering streams
- re-check connectivity before destructive per-channel/per-stream decisions so a mid-run outage cannot drain channels
- surface sanitized guard status in the stream checker status payload and Stream Checker UI
- show active guard failures only while stream checking work is active; keep older idle failures as stale status data instead of a persistent red current-error banner
- refresh stale Dispatcharr auth once and retry the API probe before reporting an auth failure
- add UI controls for enabling/disabling the guard and configuring its timeout
- normalize the Docker entrypoint line endings so production image startup is not affected by CRLF checkout state

## Problem
Quality checks can be destructive: they may mark streams dead, remove streams from channels, or persist new stream ordering. If the network, DNS, gateway, or upstream API is unavailable, the checker should not interpret temporary connectivity failures as bad streams.

Live stack testing also exposed a case where an expired in-process Dispatcharr token could make the guard report an auth failure even though username/password configuration was available. The guard now follows the same recovery model as the existing API helpers: on an authenticated probe returning 401/403, refresh auth once and retry before failing closed.

A later live verification pass showed the fail-closed protection working, but the last failed guard result could remain visible as a current Stream Checker warning after the run had already stopped. The status payload now marks previous idle failures as stale, and the UI only shows the destructive warning for active guard failures.

## Validation
- `python -m pytest backend/tests/test_connectivity_guard.py` passed locally: 8 tests.
- `python -m compileall backend/apps/stream/connectivity_guard.py backend/apps/stream/stream_checker_service.py backend/tests/test_connectivity_guard.py` passed locally.
- `npm run build` passed locally after the UI status update.
- `git diff --check` passed.
- Stacked validation with open PR #412 and the queued CI cleanup branch passed: `python scripts/run_ci_checks.py` (69 tests), targeted queue/connectivity suite (21 tests), `python -m pytest backend/tests/test_connectivity_guard.py` (6 tests at that time), `npm run test:ci` (1 test), and `npm run build`.
- Built and deployed a production image from the combined PR #411 + PR #412 + CI cleanup stack; health check stayed healthy after restart.
- Live verification confirmed the stream checker status returned idle/empty queue state after deployment, with no stale progress or stale queue counters from the previous run.
- Live verification queued one channel until `quality_check_preflight` reported `Connectivity verified`, then cleared the queue. The clear returned `abort_requested=true` with one in-progress item cleared, and the service settled to `checking=false`, `stream_checking_mode=false`, `queue.state=cleared`, `current_channel=null`, and no progress.
- Live verification of the combined stack later hit an unavailable container internet probe path; the guard failed closed, did not continue destructive quality-check work, and the queue lifecycle settled with no active channel or in-progress item remaining. Final combined full-run release verification passed.
- Live logs were checked after deployment and verification: startup auth login succeeded, expected queue clear/abort messages were present, and no traceback or new error appeared during the verification window.

## Screenshots
Sanitized Stream Checker Safety tab screenshot captured during live verification, showing the Connectivity Guard control and timeout setting without exposing environment details.

![Sanitized Stream Checker Safety tab](https://raw.githubusercontent.com/bttfw/streamflow/codex/pr411-screenshot-assets/pr-assets/streamflow-pr411-safety-sanitized.png)


## Final Combined Verification
- Deployed the combined PR #411-#423 stack as a production image through the normal update path.
- Completed a full automation run after playlist refresh, cache/UDI sync, stream matching, queueing, and quality checking.
- Final run processed 226/226 channels with `quality_checked=226`, `quality_failed=0`, `quality_incomplete=0`, `quality_aborted=0`, and `quality_skipped=0`.
- Final run analyzed 2445 streams, revived 75 streams, and assigned/reordered 94 channels without aborting.
- Connectivity guard ended in a verified state, and post-run log review found no traceback, critical, or error entries from the verification window.

## Release State
Ready for review after final combined verification. This PR was validated both independently and as part of the stacked PR #411-#423 release candidate.
