### PR TITLE
Fix stream checker queue abort lifecycle

### DIFF
--- a/backend/apps/api/stream_checker_handlers.py
+++ b/backend/apps/api/stream_checker_handlers.py
@@ -80,8 +80,8 @@ def clear_stream_checker_queue_response(*, get_stream_checker_service: Callable[
     """Handle clearing stream checker queue."""
     try:
         service = get_stream_checker_service()
-        service.clear_queue()
-        return jsonify({"message": "Queue cleared successfully"})
+        result = service.clear_queue()
+        return jsonify({"message": "Queue cleared successfully", **(result or {})})
     except Exception as exc:
         logger.error(f"Error clearing stream checker queue: {exc}")
         return jsonify({"error": "Internal Server Error"}), 500
@@ -342,7 +342,7 @@ def queue_all_channels_response(
             return jsonify({"message": "No channels found to queue", "count": 0})
 
         service.update_tracker.mark_channels_updated(channel_ids)
-        added = service.check_queue.add_channels(channel_ids, priority=10)
+        added = service.queue_channels(channel_ids, priority=10)
 
         return jsonify(
             {

--- a/backend/apps/stream/stream_checker_components.py
+++ b/backend/apps/stream/stream_checker_components.py
@@ -507,6 +507,8 @@ class StreamCheckQueue:
         import collections
         self.stream_processing_times = collections.deque(maxlen=100)
         self.channel_start_times = {}
+        self.last_cleared_at = None
+        self.last_clear_reason = None
         self.stats = {
             'total_queued': 0,
             'total_completed': 0,
@@ -518,28 +520,33 @@ class StreamCheckQueue:
     def add_channel(self, channel_id: int, priority: int = 0, stream_count: int = 1):
         """Add a channel to the checking queue."""
         with self.lock:
+            # Check if channel is already queued, in progress, or completed.
+            # Completed channels stay blocked until an explicit re-queue path
+            # removes them from the completed set.
+            if channel_id in self.queued or channel_id in self.in_progress or channel_id in self.completed:
+                return False
+
             # Check if this is a new "batch" starting (queue is completely empty and no workers are active)
             if self.queue.empty() and len(self.in_progress) == 0:
                 self.stats['total_queued'] = 0
                 self.stats['total_completed'] = 0
                 self.stats['total_failed'] = 0
                 self.queued.clear()
-                self.completed.clear()
                 self.failed.clear()
+                self.last_cleared_at = None
+                self.last_clear_reason = None
 
-            # Check if channel is already queued, in progress, or completed
-            if channel_id not in self.queued and channel_id not in self.in_progress and channel_id not in self.completed:
-                try:
-                    self.queue.put((priority, channel_id), block=False)
-                    # We default to 1 stream roughly if unknown, but add_channels will pass precise length 
-                    self.queued[channel_id] = stream_count
-                    self.stats['total_queued'] += 1
-                    self.stats['queue_size'] = self.queue.qsize()
-                    logger.debug(f"Added channel {channel_id} to queue (priority: {priority})")
-                    return True
-                except queue.Full:
-                    logger.warning(f"Queue is full, cannot add channel {channel_id}")
-                    return False
+            try:
+                self.queue.put((priority, channel_id), block=False)
+                # We default to 1 stream roughly if unknown, but add_channels will pass precise length
+                self.queued[channel_id] = stream_count
+                self.stats['total_queued'] += 1
+                self.stats['queue_size'] = self.queue.qsize()
+                logger.debug(f"Added channel {channel_id} to queue (priority: {priority})")
+                return True
+            except queue.Full:
+                logger.warning(f"Queue is full, cannot add channel {channel_id}")
+                return False
         return False
     
     def add_channels(self, channel_ids: List[int], priority: int = 0):
@@ -574,7 +581,14 @@ class StreamCheckQueue:
         try:
             priority, channel_id = self.queue.get(timeout=timeout)
             with self.lock:
-                stream_count = self.queued.pop(channel_id, 1)  # Remove from queued dict
+                if channel_id not in self.queued:
+                    logger.debug(
+                        f"Ignoring stale queued channel {channel_id}; queue entry was cleared"
+                    )
+                    self.stats['queue_size'] = self.queue.qsize()
+                    return None
+
+                stream_count = self.queued.pop(channel_id)  # Remove from queued dict
                 self.in_progress[channel_id] = stream_count
                 self.channel_start_times[channel_id] = datetime.now()
                 self.stats['current_channel'] = channel_id
@@ -583,9 +597,20 @@ class StreamCheckQueue:
         except queue.Empty:
             return None
     
-    def mark_completed(self, channel_id: int):
-        """Mark a channel check as completed."""
+    def mark_completed(self, channel_id: int) -> bool:
+        """Mark a channel check as completed.
+
+        Returns False when the channel is no longer registered as active. This
+        can happen when a queue clear aborts an in-flight check and the worker
+        exits slightly later.
+        """
         with self.lock:
+            if channel_id not in self.in_progress and channel_id not in self.channel_start_times:
+                logger.debug(
+                    f"Ignoring completion for channel {channel_id}; no active queue entry exists"
+                )
+                return False
+
             # Calculate stream processing duration
             if channel_id in self.channel_start_times:
                 duration_sec = (datetime.now() - self.channel_start_times[channel_id]).total_seconds()
@@ -602,10 +627,20 @@ class StreamCheckQueue:
             if self.stats['current_channel'] == channel_id:
                 self.stats['current_channel'] = None
             logger.debug(f"Marked channel {channel_id} as completed")
+            return True
     
-    def mark_failed(self, channel_id: int, error: str):
-        """Mark a channel check as failed."""
+    def mark_failed(self, channel_id: int, error: str) -> bool:
+        """Mark a channel check as failed.
+
+        Returns False when the channel is no longer registered as active.
+        """
         with self.lock:
+            if channel_id not in self.in_progress and channel_id not in self.channel_start_times:
+                logger.debug(
+                    f"Ignoring failure for channel {channel_id}; no active queue entry exists"
+                )
+                return False
+
             if channel_id in self.channel_start_times:
                 del self.channel_start_times[channel_id]
                 
@@ -619,6 +654,7 @@ class StreamCheckQueue:
             if self.stats['current_channel'] == channel_id:
                 self.stats['current_channel'] = None
             logger.warning(f"Marked channel {channel_id} as failed: {error}")
+            return True
     
     def get_status(self) -> Dict:
         """Get current queue status."""
@@ -638,12 +674,34 @@ class StreamCheckQueue:
                 'current_channel': self.stats['current_channel'],
                 'total_queued': self.stats['total_queued'],
                 'total_completed': self.stats['total_completed'],
-                'total_failed': self.stats['total_failed']
+                'total_failed': self.stats['total_failed'],
+                'state': self._state_locked(),
+                'last_cleared_at': self.last_cleared_at,
+                'last_clear_reason': self.last_clear_reason
             }
-    
-    def clear(self):
+
+    def _state_locked(self) -> str:
+        """Return the queue lifecycle state while self.lock is held."""
+        if self.in_progress:
+            return 'checking'
+        if not self.queue.empty() or self.queued:
+            return 'queued'
+        if self.completed or self.failed:
+            return 'completed'
+        if self.last_cleared_at:
+            return 'cleared'
+        return 'idle'
+
+    def clear(self, reason: str = 'manual') -> Dict:
         """Clear the queue and reset stats."""
         with self.lock:
+            cleared = {
+                'queued': len(self.queued),
+                'in_progress': len(self.in_progress),
+                'completed': len(self.completed),
+                'failed': len(self.failed),
+                'queue_size': self.queue.qsize()
+            }
             while not self.queue.empty():
                 try:
                     self.queue.get_nowait()
@@ -653,6 +711,7 @@ class StreamCheckQueue:
             self.in_progress.clear()
             self.completed.clear()
             self.failed.clear()
+            self.channel_start_times.clear()
             self.stats = {
                 'total_queued': 0,
                 'total_completed': 0,
@@ -660,7 +719,10 @@ class StreamCheckQueue:
                 'current_channel': None,
                 'queue_size': 0
             }
+            self.last_cleared_at = datetime.now().isoformat()
+            self.last_clear_reason = reason
         logger.info("Queue cleared")
+        return cleared
 
     def is_empty(self) -> bool:
         """Check if the queue is empty."""

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -199,6 +199,7 @@ class StreamCheckerService:
         self.scheduler_thread = None
         self.lock = threading.Lock()
         self._cancel_queueing = False
+        self._sync_batch_generation = 0
         
         self.sync_batch_state = {
             'active': False,
@@ -274,6 +275,10 @@ class StreamCheckerService:
         
         while self.running:
             try:
+                # Clear stale aborts before waiting for the next queue item. Do
+                # not clear this after a channel is pulled: a manual queue clear
+                # can legitimately request abort in that narrow handoff window.
+                self.abort_current_check.clear()
                 logger.debug("Worker waiting for next channel from queue...")
                 channel_id = self.check_queue.get_next_channel(timeout=1.0)
                 if channel_id is None:
@@ -289,8 +294,6 @@ class StreamCheckerService:
                     self._start_batch_changelog()
                 
                 logger.debug(f"Worker processing channel {channel_id}")
-                # Clear abort flag before checking
-                self.abort_current_check.clear()
                 # Check this channel
                 self._check_channel(channel_id)
                 logger.debug(f"Worker completed channel {channel_id}")
@@ -1140,6 +1143,48 @@ class StreamCheckerService:
             return self._check_channel_concurrent(channel_id, skip_batch_changelog=skip_batch_changelog, forced_profile_id=forced_profile_id)
         else:
             return self._check_channel_sequential(channel_id, skip_batch_changelog=skip_batch_changelog, forced_profile_id=forced_profile_id)
+
+    def _complete_channel_check(self, channel_id: int, on_completed=None) -> bool:
+        """Complete a queued channel and run side effects only if it is still active."""
+        accepted = self.check_queue.mark_completed(channel_id)
+        if accepted or not self.abort_current_check.is_set():
+            if on_completed:
+                on_completed()
+            return accepted
+
+        logger.info(
+            f"Skipping completion side effects for channel {channel_id}; "
+            "the queue entry was already cleared or aborted"
+        )
+        return False
+
+    def _abort_channel_check(self, channel_id: int, channel_name: Optional[str] = None) -> Dict[str, Any]:
+        """Finish an aborted channel check without writing completion state."""
+        if channel_name:
+            logger.info(f"Channel check aborted for {channel_name} (channel {channel_id})")
+        else:
+            logger.info(f"Channel check aborted for channel {channel_id}")
+
+        self.check_queue.mark_failed(channel_id, 'aborted')
+        self.progress.clear()
+        return {
+            'dead_streams_count': 0,
+            'revived_streams_count': 0,
+            'checked_streams': [],
+            'skipped': True,
+            'skip_reason': 'aborted',
+            'aborted': True
+        }
+
+    def _abort_channel_check_if_requested(
+        self,
+        channel_id: int,
+        channel_name: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return an aborted result when a clear/abort request is pending."""
+        if self.abort_current_check.is_set():
+            return self._abort_channel_check(channel_id, channel_name)
+        return None
     
     def _check_channel_concurrent(self, channel_id: int, skip_batch_changelog: bool = False, target_stream_ids: Optional[List[str]] = None, forced_profile_id: Optional[str] = None):
         """Check and reorder streams for a specific channel using parallel thread pool.
@@ -1272,6 +1317,9 @@ class StreamCheckerService:
                 raise Exception(f"Could not fetch channel {channel_id}")
             
             channel_name = channel_data.get('name', f'Channel {channel_id}')
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
             
             # Get streams for this channel
             self.progress.update(
@@ -1285,10 +1333,16 @@ class StreamCheckerService:
             )
             
             streams = fetch_channel_streams(channel_id)
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
+
             if not streams or len(streams) == 0:
                 logger.info(f"No streams found for channel {channel_name}")
-                self.check_queue.mark_completed(channel_id)
-                self.update_tracker.mark_channel_checked(channel_id)
+                self._complete_channel_check(
+                    channel_id,
+                    lambda: self.update_tracker.mark_channel_checked(channel_id)
+                )
                 return {
                     'dead_streams_count': 0,
                     'revived_streams_count': 0
@@ -1299,8 +1353,10 @@ class StreamCheckerService:
             # Check if channel has active viewers or if its playlist has reached max concurrent streams
             limit_check_result = self._check_channel_limits(channel_id, channel_name, streams)
             if limit_check_result is not None:
-                self.check_queue.mark_completed(channel_id)
-                self.update_tracker.mark_channel_checked(channel_id)
+                self._complete_channel_check(
+                    channel_id,
+                    lambda: self.update_tracker.mark_channel_checked(channel_id)
+                )
                 return limit_check_result
             
             # Check if this is a force check (bypasses 2-hour immunity)
@@ -1371,12 +1427,14 @@ class StreamCheckerService:
                     if (current_stream_count == previous_stream_count and 
                         set(current_stream_ids) == set(checked_stream_ids)):
                         logger.info(f"Channel {channel_name} unchanged since last check - skipping reorder")
-                        self.check_queue.mark_completed(channel_id)
                         # Update timestamp but keep existing checked_stream_ids
-                        self.update_tracker.mark_channel_checked(
+                        self._complete_channel_check(
                             channel_id,
-                            stream_count=current_stream_count,
-                            checked_stream_ids=checked_stream_ids
+                            lambda: self.update_tracker.mark_channel_checked(
+                                channel_id,
+                                stream_count=current_stream_count,
+                                checked_stream_ids=checked_stream_ids
+                            )
                         )
                         # Best effort to reconstruct stats for skipped/cached streams
                         cached_stats = []
@@ -1465,6 +1523,9 @@ class StreamCheckerService:
             
             # Start callback for parallel checker
             def start_callback(stream):
+                if self.abort_current_check.is_set():
+                    return
+
                 stream_id = stream.get('id')
                 if stream_id in stream_statuses:
                     stream_statuses[stream_id]['status'] = 'checking'
@@ -1483,6 +1544,9 @@ class StreamCheckerService:
                     )
             
             def progress_callback(completed, total, result):
+                if self.abort_current_check.is_set():
+                    return
+
                 completed_count[0] = completed
                 stream_name = result.get('stream_name', 'Unknown')
                 stream_id = result.get('stream_id')
@@ -1544,7 +1608,7 @@ class StreamCheckerService:
                 _heartbeat_stop = threading.Event()
 
                 def _heartbeat():
-                    while not _heartbeat_stop.wait(2):
+                    while not self.abort_current_check.is_set() and not _heartbeat_stop.wait(2):
                         try:
                             self.progress.update(
                                 channel_id=channel_id,
@@ -1586,6 +1650,10 @@ class StreamCheckerService:
                 finally:
                     _heartbeat_stop.set()
                     _hb_thread.join(timeout=3)
+
+                abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+                if abort_result:
+                    return abort_result
                 
                 # Process results - ALL checks are complete at this point
                 # Collect stats for batch update to minimize API calls
@@ -1715,6 +1783,10 @@ class StreamCheckerService:
 
                 logger.info(f"Completed smart parallel analysis of {len(results)} streams with account-aware limits")
 
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
+
             self._log_blank_detection_summary(
                 channel_id,
                 channel_name,
@@ -1743,6 +1815,10 @@ class StreamCheckerService:
 
             # Batch stats write after probes so the persisted score and loop
             # fields reflect the penalised score from this run.
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
+
             if batch_enabled and batch_stats_list:
                 # Rebuild batch list with updated scores post-penalty
                 batch_stats_list = []
@@ -1789,6 +1865,10 @@ class StreamCheckerService:
             
             if revived_stream_ids:
                 logger.info(f"{len(revived_stream_ids)} streams were revived in channel {channel_name}")
+
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
             
             # Update channel with reordered streams
             self.progress.update(
@@ -1946,8 +2026,6 @@ class StreamCheckerService:
                 except Exception as e:
                     logger.warning(f"Failed to add to batch changelog: {e}")
             
-            # Mark as completed
-            self.check_queue.mark_completed(channel_id)
             # Update current_stream_ids to exclude dead streams that were removed
             # This prevents dead stream IDs from being saved in checked_stream_ids
             # which would cause them to be skipped by 2-hour immunity even after revival
@@ -1957,10 +2035,13 @@ class StreamCheckerService:
                 final_stream_ids = [sid for sid in current_stream_ids if sid not in dead_stream_ids]
             else:
                 final_stream_ids = current_stream_ids  # Keep all streams if removal is disabled
-            self.update_tracker.mark_channel_checked(
-                channel_id, 
-                stream_count=len(streams),
-                checked_stream_ids=final_stream_ids
+            self._complete_channel_check(
+                channel_id,
+                lambda: self.update_tracker.mark_channel_checked(
+                    channel_id,
+                    stream_count=len(streams),
+                    checked_stream_ids=final_stream_ids
+                )
             )
             
             # Return statistics for callers that need them
@@ -2147,6 +2228,9 @@ class StreamCheckerService:
                 raise Exception(f"Could not fetch channel {channel_id}")
             
             channel_name = channel_data.get('name', f'Channel {channel_id}')
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
             
             # Get streams for this channel
             self.progress.update(
@@ -2160,10 +2244,16 @@ class StreamCheckerService:
             )
             
             streams = fetch_channel_streams(channel_id)
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
+
             if not streams or len(streams) == 0:
                 logger.info(f"No streams found for channel {channel_name}")
-                self.check_queue.mark_completed(channel_id)
-                self.update_tracker.mark_channel_checked(channel_id)
+                self._complete_channel_check(
+                    channel_id,
+                    lambda: self.update_tracker.mark_channel_checked(channel_id)
+                )
                 return {
                     'dead_streams_count': 0,
                     'revived_streams_count': 0
@@ -2174,8 +2264,10 @@ class StreamCheckerService:
             # Check if channel has active viewers or if its playlist has reached max concurrent streams
             limit_check_result = self._check_channel_limits(channel_id, channel_name, streams)
             if limit_check_result is not None:
-                self.check_queue.mark_completed(channel_id)
-                self.update_tracker.mark_channel_checked(channel_id)
+                self._complete_channel_check(
+                    channel_id,
+                    lambda: self.update_tracker.mark_channel_checked(channel_id)
+                )
                 return limit_check_result
             
             # Check if this is a force check (bypasses 2-hour immunity)
@@ -2241,12 +2333,14 @@ class StreamCheckerService:
                     if (current_stream_count == previous_stream_count and 
                         set(current_stream_ids) == set(checked_stream_ids)):
                         logger.info(f"Channel {channel_name} unchanged since last check - skipping reorder")
-                        self.check_queue.mark_completed(channel_id)
                         # Update timestamp but keep existing checked_stream_ids
-                        self.update_tracker.mark_channel_checked(
+                        self._complete_channel_check(
                             channel_id,
-                            stream_count=current_stream_count,
-                            checked_stream_ids=checked_stream_ids
+                            lambda: self.update_tracker.mark_channel_checked(
+                                channel_id,
+                                stream_count=current_stream_count,
+                                checked_stream_ids=checked_stream_ids
+                            )
                         )
                         return
                     else:
@@ -2410,6 +2504,10 @@ class StreamCheckerService:
                         stream_statuses[stream['id']]['bitrate'] = analyzed.get('bitrate_kbps')
                 
                 logger.info(f"Stream {idx}/{total_streams}: {stream.get('name')} - Score: {score:.2f}")
+
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
             
             # For already-checked streams, retrieve their cached data from UDI
             for stream in streams_already_checked:
@@ -2525,6 +2623,10 @@ class StreamCheckerService:
                     analyzed['score'] = score
                     analyzed_streams.append(analyzed)
 
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
+
             self._log_blank_detection_summary(
                 channel_id,
                 channel_name,
@@ -2557,6 +2659,10 @@ class StreamCheckerService:
                         self._update_stream_stats(analyzed)
             else:
                 logger.debug("[loop-probe] Loop checking disabled by profile — skipping")
+
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
 
             # Sort streams by score (highest first)
             self.progress.update(
@@ -2597,6 +2703,10 @@ class StreamCheckerService:
             
             if revived_stream_ids:
                 logger.info(f"{len(revived_stream_ids)} streams were revived in channel {channel_name}")
+
+            abort_result = self._abort_channel_check_if_requested(channel_id, channel_name)
+            if abort_result:
+                return abort_result
             
             # Update channel with reordered streams
             self.progress.update(
@@ -2757,8 +2867,6 @@ class StreamCheckerService:
                 except Exception as e:
                     logger.warning(f"Failed to add to batch changelog: {e}")
             
-            # Mark as completed with stream count and checked stream IDs
-            self.check_queue.mark_completed(channel_id)
             # Update current_stream_ids to exclude dead streams that were removed
             # This prevents dead stream IDs from being saved in checked_stream_ids
             # which would cause them to be skipped by 2-hour immunity even after revival
@@ -2768,10 +2876,13 @@ class StreamCheckerService:
                 final_stream_ids = [sid for sid in current_stream_ids if sid not in dead_stream_ids]
             else:
                 final_stream_ids = current_stream_ids  # Keep all streams if removal is disabled
-            self.update_tracker.mark_channel_checked(
-                channel_id, 
-                stream_count=len(streams),
-                checked_stream_ids=final_stream_ids
+            self._complete_channel_check(
+                channel_id,
+                lambda: self.update_tracker.mark_channel_checked(
+                    channel_id,
+                    stream_count=len(streams),
+                    checked_stream_ids=final_stream_ids
+                )
             )
             
             # Return statistics for callers that need them
@@ -3287,14 +3398,29 @@ class StreamCheckerService:
         if sync_state.get('active'):
             # Override queue status with our synchronous batch status
             # When active, ONLY the sync batch progress should be displayed
+            queued_channels = max(
+                0,
+                sync_state['total_channels']
+                - sync_state['completed']
+                - sync_state['failed']
+                - sync_state['in_progress'],
+            )
             queue_status['in_progress'] = sync_state['in_progress']
             queue_status['completed'] = sync_state['completed']
             queue_status['failed'] = sync_state['failed']
-            queue_status['queued'] = sync_state['total_channels'] - sync_state['completed'] - sync_state['failed'] - sync_state['in_progress']
+            queue_status['queued'] = queued_channels
             queue_status['total_queued'] = sync_state['total_channels']
             queue_status['total_completed'] = sync_state['completed']
             queue_status['total_failed'] = sync_state['failed']
             queue_status['queue_size'] = queue_status['queued']
+            if queue_status['in_progress'] > 0:
+                queue_status['state'] = 'checking'
+            elif queue_status['queue_size'] > 0:
+                queue_status['state'] = 'queued'
+            elif queue_status['completed'] or queue_status['failed']:
+                queue_status['state'] = 'completed'
+            else:
+                queue_status['state'] = 'idle'
             
             # Map tracking stream properties back over queue_status for calculations
             queue_status['queued_streams_count'] = sync_state.get('queued_streams_count', 0)
@@ -3368,6 +3494,8 @@ class StreamCheckerService:
             self.update_tracker.mark_channel_for_force_check(channel_id)
             logger.info(f"Marked channel {channel_id} for force check (bypasses 2-hour immunity)")
             
+        self._cancel_queueing = False
+
         # Ensure we can re-queue if it was completed (manual check overrides completion state)
         self.check_queue.remove_from_completed(channel_id)
         
@@ -3400,6 +3528,11 @@ class StreamCheckerService:
             for channel_id in channel_ids:
                 self.update_tracker.mark_channel_for_force_check(channel_id)
             logger.info(f"Marked {len(channel_ids)} channels for force check (bypasses 2-hour immunity)")
+
+        self._cancel_queueing = False
+        for channel_id in channel_ids:
+            self.check_queue.remove_from_completed(channel_id)
+
         return self.check_queue.add_channels(channel_ids, priority)
     
     def check_channels_synchronously(self, channel_ids: List[int], force_check: bool = False, target_stream_ids: Optional[Dict[int, List[str]]] = None) -> Dict[int, Dict]:
@@ -3440,6 +3573,9 @@ class StreamCheckerService:
             total_streams += stream_count
                 
         with self.lock:
+            self.abort_current_check.clear()
+            self._sync_batch_generation = getattr(self, '_sync_batch_generation', 0) + 1
+            sync_generation = self._sync_batch_generation
             self.sync_batch_state = {
                 'active': True,
                 'total_channels': len(channel_ids),
@@ -3447,16 +3583,24 @@ class StreamCheckerService:
                 'failed': 0,
                 'in_progress': 0,
                 'queued_streams_count': total_streams,
-                'in_progress_streams_count': 0
+                'in_progress_streams_count': 0,
+                'generation': sync_generation,
             }
             self.checking = True
         
         try:
             # Process each channel
             for channel_id in channel_ids:
+                if self.abort_current_check.is_set():
+                    logger.info("Synchronous channel batch aborted before next channel")
+                    break
+
                 stream_count = channel_streams.get(channel_id, 1)
                 
                 with self.lock:
+                    if self.sync_batch_state.get('generation') != sync_generation or not self.sync_batch_state.get('active'):
+                        logger.info("Synchronous channel batch was cleared; stopping remaining checks")
+                        break
                     self.sync_batch_state['in_progress'] = 1
                     self.sync_batch_state['queued_streams_count'] = max(0, self.sync_batch_state['queued_streams_count'] - stream_count)
                     self.sync_batch_state['in_progress_streams_count'] = stream_count
@@ -3479,12 +3623,21 @@ class StreamCheckerService:
                         
                     results[channel_id] = channel_result
                     with self.lock:
-                        self.sync_batch_state['completed'] += 1
+                        if self.sync_batch_state.get('generation') == sync_generation and self.sync_batch_state.get('active'):
+                            if isinstance(channel_result, dict) and channel_result.get('aborted'):
+                                self.sync_batch_state['failed'] += 1
+                            else:
+                                self.sync_batch_state['completed'] += 1
+
+                    if isinstance(channel_result, dict) and channel_result.get('aborted'):
+                        logger.info("Synchronous channel batch aborted; stopping remaining checks")
+                        break
                 except Exception as e:
                     logger.error(f"Error checking channel {channel_id} synchronously: {e}")
                     results[channel_id] = {'error': str(e)}
                     with self.lock:
-                        self.sync_batch_state['failed'] += 1
+                        if self.sync_batch_state.get('generation') == sync_generation and self.sync_batch_state.get('active'):
+                            self.sync_batch_state['failed'] += 1
                 finally:
                     duration_sec = (datetime.now() - channel_start_time).total_seconds()
                     if stream_count > 0:
@@ -3493,14 +3646,16 @@ class StreamCheckerService:
                             self.check_queue.stream_processing_times.append(time_per_stream)
                             
                     with self.lock:
-                        self.sync_batch_state['in_progress'] = 0
-                        self.sync_batch_state['in_progress_streams_count'] = 0
+                        if self.sync_batch_state.get('generation') == sync_generation and self.sync_batch_state.get('active'):
+                            self.sync_batch_state['in_progress'] = 0
+                            self.sync_batch_state['in_progress_streams_count'] = 0
         finally:
             with self.lock:
-                self.sync_batch_state['active'] = False
-                queue_status = self.check_queue.get_status()
-                if queue_status.get('queue_size', 0) == 0 and queue_status.get('in_progress', 0) == 0:
-                    self.checking = False
+                if self.sync_batch_state.get('generation') == sync_generation:
+                    self.sync_batch_state['active'] = False
+                    queue_status = self.check_queue.get_status()
+                    if queue_status.get('queue_size', 0) == 0 and queue_status.get('in_progress', 0) == 0:
+                        self.checking = False
                 
         return results
 
@@ -3534,6 +3689,7 @@ class StreamCheckerService:
         """
         import time as time_module
         start_time = time_module.time()
+        self.abort_current_check.clear()
         
         try:
             logger.info(f"Starting single channel check for channel {channel_id}")
@@ -4136,10 +4292,46 @@ class StreamCheckerService:
     
     def clear_queue(self):
         """Clear the checking queue."""
-        self.check_queue.clear()
-        self.abort_current_check.set()
+        queue_status = self.check_queue.get_status()
+        with self.lock:
+            sync_active = self.sync_batch_state.get('active', False)
+
+        has_active_check = (
+            self.checking or
+            queue_status.get('in_progress', 0) > 0 or
+            sync_active
+        )
+
         self._cancel_queueing = True
-        logger.info("Checking queue cleared and current check aborted")
+        if has_active_check:
+            self.abort_current_check.set()
+        else:
+            self.abort_current_check.clear()
+
+        cleared = self.check_queue.clear(reason='manual_clear')
+        self.progress.clear()
+        with self.lock:
+            if sync_active:
+                self._sync_batch_generation = getattr(self, '_sync_batch_generation', 0) + 1
+                self.sync_batch_state = {
+                    'active': False,
+                    'total_channels': 0,
+                    'completed': 0,
+                    'failed': 0,
+                    'in_progress': 0,
+                    'queued_streams_count': 0,
+                    'in_progress_streams_count': 0,
+                    'generation': self._sync_batch_generation,
+                }
+                self.checking = False
+        logger.info(
+            "Checking queue cleared%s",
+            " and current check abort requested" if has_active_check else ""
+        )
+        return {
+            'abort_requested': has_active_check,
+            'cleared': cleared,
+        }
     
     def trigger_check_updated_channels(self):
         """Trigger immediate check of channels with M3U updates.

--- a/backend/tests/test_stream_checker_queue_lifecycle.py
+++ b/backend/tests/test_stream_checker_queue_lifecycle.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Regression tests for stream-checker queue clear/abort lifecycle."""
+
+import os
+import sys
+import threading
+import unittest
+from unittest.mock import Mock
+
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from apps.api.stream_checker_handlers import (  # noqa: E402
+    clear_stream_checker_queue_response,
+    queue_all_channels_response,
+)
+from apps.stream.stream_checker_components import StreamCheckQueue  # noqa: E402
+from apps.stream.stream_checker_service import StreamCheckerService  # noqa: E402
+
+
+class TestStreamCheckQueueLifecycle(unittest.TestCase):
+    def test_clear_prevents_late_completion_from_repopulating_status(self):
+        check_queue = StreamCheckQueue(max_size=10)
+        self.assertTrue(check_queue.add_channel(101, priority=10, stream_count=3))
+        self.assertEqual(check_queue.get_next_channel(timeout=0.1), 101)
+
+        cleared = check_queue.clear(reason='test_clear')
+
+        self.assertEqual(cleared['in_progress'], 1)
+        self.assertFalse(check_queue.mark_completed(101))
+
+        status = check_queue.get_status()
+        self.assertEqual(status['completed'], 0)
+        self.assertEqual(status['total_completed'], 0)
+        self.assertEqual(status['in_progress'], 0)
+        self.assertEqual(status['state'], 'cleared')
+
+    def test_clear_prevents_late_failure_from_repopulating_status(self):
+        check_queue = StreamCheckQueue(max_size=10)
+        self.assertTrue(check_queue.add_channel(102, priority=10, stream_count=2))
+        self.assertEqual(check_queue.get_next_channel(timeout=0.1), 102)
+
+        check_queue.clear(reason='test_clear')
+        self.assertFalse(check_queue.mark_failed(102, 'late failure'))
+
+        status = check_queue.get_status()
+        self.assertEqual(status['failed'], 0)
+        self.assertEqual(status['total_failed'], 0)
+        self.assertEqual(status['in_progress'], 0)
+
+    def test_stale_queue_item_removed_by_clear_is_not_started(self):
+        check_queue = StreamCheckQueue(max_size=10)
+        self.assertTrue(check_queue.add_channel(104, priority=10, stream_count=4))
+
+        with check_queue.lock:
+            check_queue.queued.clear()
+
+        self.assertIsNone(check_queue.get_next_channel(timeout=0.1))
+
+        status = check_queue.get_status()
+        self.assertEqual(status['in_progress'], 0)
+        self.assertIsNone(status['current_channel'])
+        self.assertEqual(status['state'], 'idle')
+
+    def test_service_clear_queue_does_not_leave_abort_stuck_when_idle(self):
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        service.check_queue = StreamCheckQueue(max_size=10)
+        service.lock = threading.Lock()
+        service.sync_batch_state = {'active': False}
+        service.checking = False
+        service.abort_current_check = threading.Event()
+        service.progress = Mock()
+
+        result = service.clear_queue()
+
+        self.assertFalse(result['abort_requested'])
+        self.assertFalse(service.abort_current_check.is_set())
+        service.progress.clear.assert_called_once()
+
+    def test_service_clear_queue_requests_abort_for_active_check(self):
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        service.check_queue = StreamCheckQueue(max_size=10)
+        service.lock = threading.Lock()
+        service._sync_batch_generation = 0
+        service.sync_batch_state = {'active': False}
+        service.checking = True
+        service.abort_current_check = threading.Event()
+        service.progress = Mock()
+
+        service.check_queue.add_channel(103, priority=10)
+        service.check_queue.get_next_channel(timeout=0.1)
+
+        result = service.clear_queue()
+
+        self.assertTrue(result['abort_requested'])
+        self.assertTrue(service.abort_current_check.is_set())
+        self.assertEqual(service.check_queue.get_status()['state'], 'cleared')
+        service.progress.clear.assert_called_once()
+
+    def test_worker_keeps_abort_set_during_queue_handoff(self):
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        service.running = True
+        service.batch_start_time = None
+        service.abort_current_check = threading.Event()
+        service.check_queue = Mock()
+        service._start_batch_changelog = Mock()
+        service._finalize_batch_changelog = Mock()
+        seen_abort_states = []
+
+        def pull_channel(timeout):
+            service.abort_current_check.set()
+            return 105
+
+        def check_channel(channel_id):
+            seen_abort_states.append(service.abort_current_check.is_set())
+            service.running = False
+
+        service.check_queue.get_next_channel.side_effect = pull_channel
+        service._check_channel = check_channel
+
+        service._worker_loop()
+
+        self.assertEqual(seen_abort_states, [True])
+
+    def test_clear_queue_resets_active_sync_batch_state(self):
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        service.check_queue = StreamCheckQueue(max_size=10)
+        service.lock = threading.Lock()
+        service._sync_batch_generation = 4
+        service.sync_batch_state = {
+            'active': True,
+            'total_channels': 5,
+            'completed': 1,
+            'failed': 0,
+            'in_progress': 1,
+            'queued_streams_count': 10,
+            'in_progress_streams_count': 2,
+            'generation': 4,
+        }
+        service.checking = True
+        service.abort_current_check = threading.Event()
+        service.progress = Mock()
+
+        result = service.clear_queue()
+
+        self.assertTrue(result['abort_requested'])
+        self.assertTrue(service.abort_current_check.is_set())
+        self.assertFalse(service.sync_batch_state['active'])
+        self.assertEqual(service.sync_batch_state['total_channels'], 0)
+        self.assertEqual(service.sync_batch_state['in_progress'], 0)
+        self.assertEqual(service.sync_batch_state['queued_streams_count'], 0)
+        self.assertEqual(service._sync_batch_generation, 5)
+        self.assertFalse(service.checking)
+
+    def test_get_status_does_not_show_cleared_state_for_active_sync_batch(self):
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        service.check_queue = StreamCheckQueue(max_size=10)
+        service.check_queue.clear(reason='previous_manual_clear')
+        service.lock = threading.Lock()
+        service.sync_batch_state = {
+            'active': True,
+            'total_channels': 4,
+            'completed': 1,
+            'failed': 0,
+            'in_progress': 1,
+            'queued_streams_count': 6,
+            'in_progress_streams_count': 2,
+            'generation': 1,
+        }
+        service.checking = True
+        service.running = True
+        service.config = Mock()
+        service.config.get.side_effect = lambda key, default=None: default
+        service.connectivity_guard_status = {'ok': True}
+        service.progress = Mock()
+        service.progress.get.return_value = {'channel_id': 200}
+        service.update_tracker = Mock()
+        service.update_tracker.get_last_global_check.return_value = None
+
+        status = service.get_status()
+
+        self.assertEqual(status['queue']['state'], 'checking')
+        self.assertEqual(status['queue']['queued'], 2)
+        self.assertEqual(status['queue']['in_progress'], 1)
+        self.assertTrue(status['stream_checking_mode'])
+
+
+class TestStreamCheckerQueueHandlers(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+
+    def test_clear_queue_response_includes_abort_details(self):
+        service = Mock()
+        service.clear_queue.return_value = {
+            'abort_requested': True,
+            'cleared': {'queued': 2, 'in_progress': 1},
+        }
+
+        with self.app.app_context():
+            response = clear_stream_checker_queue_response(
+                get_stream_checker_service=lambda: service
+            )
+
+        data = response.get_json()
+        self.assertEqual(data['message'], 'Queue cleared successfully')
+        self.assertTrue(data['abort_requested'])
+        self.assertEqual(data['cleared']['in_progress'], 1)
+
+    def test_queue_all_channels_uses_service_queue_path(self):
+        class UpdateTracker:
+            def __init__(self):
+                self.marked = None
+
+            def mark_channels_updated(self, channel_ids):
+                self.marked = list(channel_ids)
+
+        class Service:
+            def __init__(self):
+                self.update_tracker = UpdateTracker()
+                self.queued = None
+
+            def queue_channels(self, channel_ids, priority=10, force_check=False):
+                self.queued = {
+                    'channel_ids': list(channel_ids),
+                    'priority': priority,
+                    'force_check': force_check,
+                }
+                return 2
+
+        service = Service()
+        udi = Mock()
+        udi.get_channels.return_value = [{'id': 1}, {'id': 2}, {'id': 3}]
+
+        with self.app.app_context():
+            response = queue_all_channels_response(
+                get_stream_checker_service=lambda: service,
+                get_udi_manager=lambda: udi,
+            )
+
+        data = response.get_json()
+        self.assertEqual(service.update_tracker.marked, [1, 2, 3])
+        self.assertEqual(service.queued['channel_ids'], [1, 2, 3])
+        self.assertEqual(service.queued['priority'], 10)
+        self.assertFalse(service.queued['force_check'])
+        self.assertEqual(data['queued'], 2)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- make queue clear/abort a real lifecycle transition instead of allowing late in-flight completion to repopulate queue status
- reset active synchronous check batches when the queue is cleared, so status cannot keep reporting stale queued/in-progress work after an abort
- guard synchronous batch counters with a generation id so late batch updates from an aborted run cannot revive old status
- expose additive queue lifecycle fields (`state`, `last_cleared_at`, `last_clear_reason`) and clear-response details (`abort_requested`, `cleared`)
- route queue-all through the service queue path so completed channels are reset consistently before requeueing
- add regression coverage for stale completions, stale failures, cleared queue items, worker handoff abort races, and active sync-batch clears

## Problem
Clearing the stream-checker queue could leave stale status behind after a channel had already been pulled by the worker. In the worst handoff window, `clear` reset the queue while the worker immediately cleared the abort flag and continued analyzing the channel. That could leave users seeing a cleared/empty queue while the quality checker was still running, and late completion could repopulate completed counters.

There was a second path through synchronous batch checks: a clear/abort could leave batch counters and progress active even though the queue state was already `cleared`. That produced contradictory status such as cleared queue state with active checking, queued/in-progress counts, or stale progress details. This PR now invalidates that batch generation and clears those counters as part of the same abort lifecycle.

## Validation
- `python -m unittest backend.tests.test_stream_checker_queue_lifecycle backend.tests.test_queue_no_duplicates backend.tests.test_stream_checking_mode` passed locally after the sync-batch fix.
- `python -m compileall backend/apps/stream/stream_checker_service.py backend/tests/test_stream_checker_queue_lifecycle.py` passed locally.
- `git diff --check` passed.
- Compatibility check with open PR #411 applied on top of current `dev`: `python -m unittest backend.tests.test_connectivity_guard backend.tests.test_stream_checker_queue_lifecycle backend.tests.test_queue_no_duplicates backend.tests.test_stream_checking_mode` passed.
- Stacked validation with open PR #411 and the queued CI cleanup branch passed: `python scripts/run_ci_checks.py` (69 tests), targeted queue/connectivity suite (21 tests), `python -m pytest backend/tests/test_connectivity_guard.py` (6 tests), `npm run test:ci` (1 test), and `npm run build`.
- Built and deployed a production image from the combined PR #411 + this branch + CI cleanup stack; health check stayed healthy after restart.
- Live verification confirmed deployment cleared the previously observed stale sync-batch status: stream checker status returned idle/empty queue with no stale progress, no in-progress channel, and no stale queued counters.
- Live verification queued one channel, observed active queue state (`queue.state=checking`, one in-progress item), cleared the queue, and confirmed `abort_requested=true`, one in-progress item cleared, no stale `current_channel`, no stale completed count, `checking=false`, `stream_checking_mode=false`, `queue.state=cleared`, and empty progress.
- Live verification repeated the flow after the connectivity preflight reached `ok`; the queue still settled cleanly after clear.
- Live logs were checked after the abort flows: expected clear/abort messages were present, with no traceback or new error during the verification window.

## Screenshots
No UI changes in this PR.



## Final Combined Verification
- Deployed the combined PR #411-#423 stack as a production image through the normal update path.
- Completed a full automation run after playlist refresh, cache/UDI sync, stream matching, queueing, and quality checking.
- Final run processed 226/226 channels with `quality_checked=226`, `quality_failed=0`, `quality_incomplete=0`, `quality_aborted=0`, and `quality_skipped=0`.
- Final run analyzed 2445 streams, revived 75 streams, and assigned/reordered 94 channels without aborting.
- Connectivity guard ended in a verified state, and post-run log review found no traceback, critical, or error entries from the verification window.

## Release State
Ready for review after final combined verification. This PR was validated both independently and as part of the stacked PR #411-#423 release candidate.
