### PR TITLE
Add pull request test workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,7 @@ __pycache__/
 *$py.class
 *.so
 .Python
-build/
+/build/
 develop-eggs/
 dist/
 downloads/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,64 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: ["main", "dev"]
+  push:
+    branches: ["main", "dev"]
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install -r backend/requirements.txt
+          python -m pip install -r backend/requirements-dev.txt
+
+      - name: Run backend checks
+        run: python scripts/run_ci_checks.py
+
+  frontend:
+    name: Frontend build and tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run frontend tests
+        working-directory: frontend
+        run: npm run test:ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Verify Docker build context includes frontend build
+        run: test -f frontend/build/index.html

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:ci": "vitest run"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { cn } from './utils'
+
+describe('cn', () => {
+  it('merges class names and ignores falsey values', () => {
+    expect(cn('flex', false && 'hidden', ['items-center', null], 'gap-2')).toBe(
+      'flex items-center gap-2'
+    )
+  })
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,10 @@ import path from 'path'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
+    exclude: ['node_modules', 'build', 'context/**'],
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/scripts/run_ci_checks.py
+++ b/scripts/run_ci_checks.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Run the backend checks that are stable enough for pull-request CI."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND = ROOT / "backend"
+
+BACKEND_TEST_MODULES = [
+    "backend.tests.test_stream_checking_mode",
+    "backend.tests.test_dispatcharr_fetch_pressure_config",
+    "backend.tests.test_api_schemas",
+    "backend.tests.test_stream_stats_utils",
+    "backend.tests.test_blank_detection",
+    "backend.tests.test_bitrate_detection",
+    "backend.tests.test_stream_check_utils",
+]
+
+
+def run(cmd: list[str], *, env: dict[str, str]) -> None:
+    print(f"+ {' '.join(cmd)}", flush=True)
+    subprocess.run(cmd, cwd=ROOT, env=env, check=True)
+
+
+def main() -> int:
+    env = os.environ.copy()
+    existing_path = env.get("PYTHONPATH")
+    pythonpath = str(BACKEND)
+    if existing_path:
+        pythonpath = pythonpath + os.pathsep + existing_path
+    env["PYTHONPATH"] = pythonpath
+
+    run([sys.executable, "-m", "compileall", "backend/apps"], env=env)
+    run([sys.executable, "-m", "unittest", *BACKEND_TEST_MODULES], env=env)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a pull request test workflow for backend and frontend checks
- add a backend CI runner that compiles `backend/apps` and runs the stable unit-test modules
- install existing backend test dependencies from `backend/requirements-dev.txt` in CI
- add a minimal real Vitest test and `npm run test:ci`
- scope Vitest discovery to real `src` tests so stale context/helper files do not masquerade as CI tests
- fix `.dockerignore` so the prebuilt `frontend/build` directory is included in Docker build context while top-level `/build/` remains ignored

## Problem
PRs can look healthy while the repository's Python and frontend checks are not actually exercised by GitHub Actions. The Docker build also depends on `frontend/build` being present in the build context, but the previous ignore pattern could exclude build directories too broadly.

The first GitHub Actions run exposed a CI dependency gap rather than a product-code failure: the backend smoke runner includes test modules that import `pytest`, but the initial workflow only installed runtime dependencies from `backend/requirements.txt`. Local validation passed because the developer environment already had the test dependency installed. The fix is intentionally small and explicit: the backend Actions job now installs the repository's existing `backend/requirements-dev.txt` after runtime requirements, so CI mirrors the local test environment for pytest-based test modules.

## Validation
- On this branch after the CI dependency fix: `python scripts/run_ci_checks.py` passed locally: compileall plus 69 backend tests.
- On this branch: `npm run test:ci` passed locally: 1 Vitest test.
- On this branch: `npm run build` passed locally.
- `git diff --check` passed.
- GitHub Actions after the dependency fix: Backend smoke tests, Frontend build and tests, and CodeQL all passed.
- Stacked validation with open PR #411 and #412 passed before the workflow-only dependency fix: `python scripts/run_ci_checks.py` (69 tests), targeted queue/connectivity suite (21 tests), `python -m pytest backend/tests/test_connectivity_guard.py` (6 tests), `npm run test:ci` (1 test), and `npm run build`.
- Built a production image from the combined PR #411 + PR #412 + this branch stack. The build copied `frontend/build` from the normal Docker context without editing `.dockerignore`, confirming the ignore fix.
- Deployed that combined production image and verified `/api/health` stayed healthy after restart.
- Live verification after deploy confirmed stream checker status was idle/empty with no stale queue/progress state, then repeated focused queue/clear flows successfully.
- Live logs were checked after deployment and focused verification: expected startup/auth and queue clear messages were present, with no traceback or new error during the verification window.

## Screenshots
No UI changes in this PR.

## Final Combined Verification
- Deployed the combined PR #411-#423 stack as a production image through the normal update path.
- Completed a full automation run after playlist refresh, cache/UDI sync, stream matching, queueing, and quality checking.
- Final run processed 226/226 channels with `quality_checked=226`, `quality_failed=0`, `quality_incomplete=0`, `quality_aborted=0`, and `quality_skipped=0`.
- Final run analyzed 2445 streams, revived 75 streams, and assigned/reordered 94 channels without aborting.
- Connectivity guard ended in a verified state, and post-run log review found no traceback, critical, or error entries from the verification window.
## Release State
Ready for review after final combined verification. This PR was validated both independently and as part of the stacked PR #411-#423 release candidate.
