### PR TITLE
Redact stream identifiers in operational logs

### DIFF
--- a/backend/apps/core/log_sanitizer.py
+++ b/backend/apps/core/log_sanitizer.py
@@ -1,17 +1,25 @@
 """Small helpers for URL/name-safe operational logging."""
 
 import hashlib
+import os
 import re
 from typing import Any, Optional
 
 
 _URL_RE = re.compile(r"(?i)\b(?:https?|rtmps?|rtsp|rtp|udp|tcp|acestream)://[^\s'\"<>]+")
+_TRUE_VALUES = {"true", "1", "yes", "on"}
+
+
+def debug_mode_enabled() -> bool:
+    return os.getenv("DEBUG_MODE", "false").strip().lower() in _TRUE_VALUES
 
 
 def audit_ref(kind: str, value: Any) -> str:
     """Return a stable, non-reversible reference for a logged object."""
     if value is None or value == "":
         return f"{kind}-unknown"
+    if debug_mode_enabled():
+        return f"{kind}-{value}"
     digest = hashlib.sha256(f"{kind}:{value}".encode("utf-8")).hexdigest()[:12]
     return f"{kind}-{digest}"
 
@@ -35,6 +43,8 @@ def url_ref(url: Optional[str]) -> str:
 def scrub_urls(message: Any) -> str:
     """Replace raw stream/API URLs inside a log message with stable URL refs."""
     text = str(message)
+    if debug_mode_enabled():
+        return text
 
     def _replace(match: re.Match) -> str:
         return f"<{url_ref(match.group(0))}>"

--- a/backend/apps/core/log_sanitizer.py
+++ b/backend/apps/core/log_sanitizer.py
@@ -1,0 +1,57 @@
+"""Small helpers for URL/name-safe operational logging."""
+
+import hashlib
+import re
+from typing import Any, Optional
+
+
+_URL_RE = re.compile(r"(?i)\b(?:https?|rtmps?|rtsp|rtp|udp|tcp|acestream)://[^\s'\"<>]+")
+
+
+def audit_ref(kind: str, value: Any) -> str:
+    """Return a stable, non-reversible reference for a logged object."""
+    if value is None or value == "":
+        return f"{kind}-unknown"
+    digest = hashlib.sha256(f"{kind}:{value}".encode("utf-8")).hexdigest()[:12]
+    return f"{kind}-{digest}"
+
+
+def channel_ref(channel_id: Any) -> str:
+    return audit_ref("channel", channel_id)
+
+
+def stream_ref(stream_id: Any = None, stream_url: Optional[str] = None) -> str:
+    if stream_id is not None and stream_id != "":
+        return audit_ref("stream", stream_id)
+    if stream_url:
+        return audit_ref("stream-url", stream_url)
+    return "stream-unknown"
+
+
+def url_ref(url: Optional[str]) -> str:
+    return audit_ref("url", url)
+
+
+def scrub_urls(message: Any) -> str:
+    """Replace raw stream/API URLs inside a log message with stable URL refs."""
+    text = str(message)
+
+    def _replace(match: re.Match) -> str:
+        return f"<{url_ref(match.group(0))}>"
+
+    return _URL_RE.sub(_replace, text)
+
+
+def stream_context(
+    *,
+    stream_id: Any = None,
+    stream_url: Optional[str] = None,
+    channel_id: Any = None,
+    reason: Optional[str] = None,
+) -> str:
+    parts = [f"stream_ref={stream_ref(stream_id, stream_url)}"]
+    if channel_id is not None:
+        parts.append(f"channel_ref={channel_ref(channel_id)}")
+    if reason:
+        parts.append(f"reason={reason}")
+    return ", ".join(parts)

--- a/backend/apps/stream/dead_streams_tracker.py
+++ b/backend/apps/stream/dead_streams_tracker.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Dict, Optional, Any, List, Tuple
 
 from apps.core.logging_config import setup_logging, log_function_call, log_function_return, log_exception
+from apps.core.log_sanitizer import channel_ref, scrub_urls, stream_context, stream_ref
 
 # Setup logging for this module
 logger = setup_logging(__name__)
@@ -44,10 +45,13 @@ class DeadStreamsTracker:
         try:
             res = self.db.mark_stream_dead(stream_url, stream_id, stream_name, channel_id, reason)
             if res:
-                logger.info(f"🔴 MARKED STREAM AS DEAD: {stream_name} (Reason: {reason}, URL: {stream_url})")
+                logger.info(
+                    f"Marked stream as dead: "
+                    f"{stream_context(stream_id=stream_id, stream_url=stream_url, channel_id=channel_id, reason=reason)}"
+                )
             return res
         except Exception as e:
-            logger.error(f"❌ Error marking stream as dead: {e}")
+            logger.error(f"Error marking stream as dead: {scrub_urls(e)}")
             return False
     
     def update_dead_reason(self, stream_url: str, reason: str, channel_id: int = None) -> bool:
@@ -66,10 +70,10 @@ class DeadStreamsTracker:
             if stream_url in dead:
                 stream_info = dead[stream_url]
                 self.db.remove_dead_stream(stream_url)
-                logger.info(f"🟢 REVIVED STREAM: {stream_info.get('stream_name', 'Unknown')} (URL: {stream_url})")
+                logger.info(f"Revived stream: {stream_ref(stream_info.get('stream_id'), stream_url)}")
             return True
         except Exception as e:
-            logger.error(f"❌ Error marking stream as alive: {e}")
+            logger.error(f"Error marking stream as alive: {scrub_urls(e)}")
             return False
     
     def is_dead(self, stream_url: str) -> bool:
@@ -102,18 +106,18 @@ class DeadStreamsTracker:
         removed_count = 0
         try:
             dead_streams = self.get_dead_streams_for_channel(channel_id)
-            removed_streams = []
-            
             for url, stream_info in dead_streams.items():
                 self.db.remove_dead_stream(url)
                 removed_count += 1
-                removed_streams.append(stream_info.get('stream_name', 'Unknown'))
                 
             if removed_count > 0:
-                logger.info(f"🗑️ Removed {removed_count} dead stream(s) from channel {channel_id} before refresh: {', '.join(removed_streams)}")
+                logger.info(
+                    f"Removed {removed_count} dead stream(s) from "
+                    f"{channel_ref(channel_id)} before refresh"
+                )
             return removed_count
         except Exception as e:
-            logger.error(f"❌ Error removing dead streams for channel {channel_id}: {e}")
+            logger.error(f"Error removing dead streams for {channel_ref(channel_id)}: {scrub_urls(e)}")
             return 0
     
     def remove_dead_streams_for_channel(self, channel_stream_urls: set) -> int:
@@ -124,10 +128,13 @@ class DeadStreamsTracker:
                 if url in channel_stream_urls:
                     self.db.remove_dead_stream(url)
                     removed_count += 1
-                    logger.info(f"🗑️ Removed dead stream from channel tracking: {stream_info.get('stream_name', 'Unknown')} (URL: {url})")
+                    logger.info(
+                        f"Removed dead stream from channel tracking: "
+                        f"{stream_ref(stream_info.get('stream_id'), url)}"
+                    )
             return removed_count
         except Exception as e:
-            logger.error(f"❌ Error removing dead streams for channel: {e}")
+            logger.error(f"Error removing dead streams for channel: {scrub_urls(e)}")
             return 0
     
     def cleanup_removed_streams(self, current_stream_urls: set) -> int:
@@ -157,7 +164,10 @@ class DeadStreamsTracker:
                         continue
                     self.db.remove_dead_stream(url)
                     removed_count += 1
-                    logger.info(f"🗑️ Removed dead stream (no longer in playlist): {stream_info.get('stream_name', 'Unknown')} (URL: {url})")
+                    logger.info(
+                        f"Removed dead stream no longer in playlist: "
+                        f"{stream_ref(stream_info.get('stream_id'), url)}"
+                    )
             if skipped_low_quality:
                 logger.debug(
                     f"Skipped cleanup of {skipped_low_quality} low_quality stream(s) "
@@ -165,7 +175,7 @@ class DeadStreamsTracker:
                 )
             return removed_count
         except Exception as e:
-            logger.error(f"❌ Error cleaning up removed streams: {e}")
+            logger.error(f"Error cleaning up removed streams: {scrub_urls(e)}")
             return 0
     
     def clear_all_dead_streams(self) -> int:

--- a/backend/apps/stream/ffmpeg_stream_monitor.py
+++ b/backend/apps/stream/ffmpeg_stream_monitor.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import Optional, Callable, Dict, Any
 
 from apps.core.logging_config import setup_logging
+from apps.core.log_sanitizer import scrub_urls, url_ref
 
 logger = setup_logging(__name__)
 
@@ -287,7 +288,7 @@ class FFmpegStreamMonitor:
             try:
                 # Validate URL to prevent command injection
                 if not self._validate_url(self.url):
-                    logger.error(f"Invalid or unsafe URL: {self.url}")
+                    logger.error(f"Invalid or unsafe URL: {url_ref(self.url)}")
                     self.stats.error_message = "Invalid URL"
                     return False
                 
@@ -337,14 +338,14 @@ class FFmpegStreamMonitor:
                 )
                 self._monitor_thread.start()
                 
-                logger.info(f"Started monitoring stream: {self.url[:100]}")
+                logger.info(f"Started monitoring stream: {url_ref(self.url)}")
                 return True
                 
             except Exception as e:
-                logger.error(f"Failed to start FFmpeg monitor: {e}")
+                logger.error(f"Failed to start FFmpeg monitor: {scrub_urls(e)}")
                 self._running = False
                 self.stats.is_alive = False
-                self.stats.error_message = str(e)
+                self.stats.error_message = scrub_urls(e)
                 return False
     
     def _validate_url(self, url: str) -> bool:
@@ -363,7 +364,7 @@ class FFmpegStreamMonitor:
         # Check for command injection attempts
         dangerous_chars = ['`', '$', ';', '|', '&', '\n', '\r']
         if any(char in url for char in dangerous_chars):
-            logger.warning(f"Rejected URL with dangerous characters: {url[:50]}")
+            logger.warning(f"Rejected URL with dangerous characters: {url_ref(url)}")
             return False
         
         # Check for supported protocols
@@ -371,7 +372,7 @@ class FFmpegStreamMonitor:
         # Allow http(s), acestream, rtmp(s), etc.
         protocol_pattern = r'^(https?|acestream|rtmp|rtmps|rtp|rtsp|udp|tcp)://'
         if not re.match(protocol_pattern, url, re.IGNORECASE):
-            logger.warning(f"Rejected URL with unsupported protocol: {url[:50]}")
+            logger.warning(f"Rejected URL with unsupported protocol: {url_ref(url)}")
             return False
         
         # Basic length check
@@ -402,14 +403,14 @@ class FFmpegStreamMonitor:
                 except subprocess.TimeoutExpired:
                     self._process.kill()
             except Exception as e:
-                logger.error(f"Error stopping FFmpeg process: {e}")
+                logger.error(f"Error stopping FFmpeg process: {scrub_urls(e)}")
             finally:
                 self._process = None
         
         # Cleanup process
         self.stats.is_alive = False
         
-        logger.info(f"Stopped monitoring stream: {self.url[:100]}")
+        logger.info(f"Stopped monitoring stream: {url_ref(self.url)}")
     
     def _monitor_output(self):
         """Monitor FFmpeg stderr output for statistics"""
@@ -438,7 +439,7 @@ class FFmpegStreamMonitor:
                 if self._REGEX_GENERAL_ERROR.search(line):
                     if is_non_fatal_error:
                         # Log non-fatal errors at debug level to avoid spam
-                        logger.debug(f"FFmpeg non-fatal error for {self.url[:50]}: {line.strip()}")
+                        logger.debug(f"FFmpeg non-fatal error for {url_ref(self.url)}: {scrub_urls(line.strip())}")
                         
                         # Track non-fatal error frequency for health checks
                         current_time = time.time()
@@ -447,7 +448,7 @@ class FFmpegStreamMonitor:
                         # If more than 50 errors in 30 seconds, consider it a stalled stream that needs restart
                         recent_errors = [t for t in self._error_history if current_time - t < 30]
                         if len(recent_errors) > 50:
-                            logger.debug(f"Excessive decoding errors ({len(recent_errors)} in 30s) for {self.url[:50]}. Triggering restart.")
+                            logger.debug(f"Excessive decoding errors ({len(recent_errors)} in 30s) for {url_ref(self.url)}. Triggering restart.")
                             self.stats.error_message = "Excessive decoding errors"
                             self.stats.is_alive = False
                             self.stats.is_fatal = False # Explicitly non-fatal, just needs restart
@@ -455,14 +456,14 @@ class FFmpegStreamMonitor:
                             break
                     else:
                         # Log other errors at warning level
-                        logger.warning(f"FFmpeg error for {self.url[:50]}: {line.strip()}")
+                        logger.warning(f"FFmpeg error for {url_ref(self.url)}: {scrub_urls(line.strip())}")
                     
                     if is_fatal or self._REGEX_FATAL_WORD.search(line):
-                        self.stats.error_message = line.strip()
+                        self.stats.error_message = scrub_urls(line.strip())
                         self.stats.is_alive = False
                         self.stats.is_fatal = True # Fatal error, stop and quarantine
                         # Stop monitoring on fatal error
-                        logger.warning(f"Fatal FFmpeg error detected, stopping monitor for {self.url[:50]}")
+                        logger.warning(f"Fatal FFmpeg error detected, stopping monitor for {url_ref(self.url)}")
                         self._running = False
                         break
                 
@@ -471,10 +472,10 @@ class FFmpegStreamMonitor:
                     try:
                         self.on_stats_update(self.stats)
                     except Exception as e:
-                        logger.error(f"Error in stats callback: {e}")
+                        logger.error(f"Error in stats callback: {scrub_urls(e)}")
         
         except Exception as e:
-            logger.error(f"Error monitoring FFmpeg output: {e}")
+            logger.error(f"Error monitoring FFmpeg output: {scrub_urls(e)}")
         
         finally:
             # Check if process exited unexpectedly
@@ -482,10 +483,10 @@ class FFmpegStreamMonitor:
                 try:
                     exit_code = self._process.poll()
                     if exit_code is not None and exit_code != 0:
-                        logger.warning(f"FFmpeg process exited with code {exit_code} for {self.url[:50]}")
+                        logger.warning(f"FFmpeg process exited with code {exit_code} for {url_ref(self.url)}")
                         self.stats.error_message = f"FFmpeg exited with code {exit_code}"
                 except Exception as e:
-                    logger.error(f"Error checking FFmpeg exit code: {e}")
+                    logger.error(f"Error checking FFmpeg exit code: {scrub_urls(e)}")
             
             with self._lock:
                 self._running = False
@@ -511,7 +512,7 @@ class FFmpegStreamMonitor:
             lang_match = self._REGEX_AUDIO_LANG.search(output)
             if lang_match:
                 self.stats.audio_language = lang_match.group(1)
-                logger.debug(f"Detected audio language for {self.url[:50]}: {self.stats.audio_language}")
+                logger.debug(f"Detected audio language for {url_ref(self.url)}: {self.stats.audio_language}")
     
     def _parse_stats(self, output: str):
         """Parse real-time statistics from FFmpeg output"""

--- a/backend/apps/stream/stream_check_utils.py
+++ b/backend/apps/stream/stream_check_utils.py
@@ -39,7 +39,6 @@ stats line is produced the stream is considered unanalyzable — a missing
 bitrate is a meaningful signal that the stream is dead or unresponsive.
 """
 
-import hashlib
 import io
 import json
 import logging
@@ -54,15 +53,9 @@ from typing import Dict, Optional, Tuple, Any, List
 
 from PIL import Image
 from apps.core.logging_config import setup_logging
+from apps.core.log_sanitizer import audit_ref as _audit_ref, scrub_urls, stream_ref, url_ref
 
 logger = setup_logging(__name__)
-
-
-def _audit_ref(kind: str, value: Any) -> str:
-    if value is None:
-        return f"{kind}-unknown"
-    digest = hashlib.sha256(f"{kind}:{value}".encode("utf-8")).hexdigest()[:12]
-    return f"{kind}-{digest}"
 
 # ── Loop probe constants ──────────────────────────────────────────────────────
 # Hamming tolerance for one-shot probes is tighter than the live sidecar value
@@ -140,14 +133,14 @@ def _log_ffmpeg_errors(output: str, logger: logging.Logger, error_patterns: list
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(f"  ffmpeg error details (DEBUG_MODE):")
             for error_line in error_lines[:MAX_DEBUG_LINES_TO_LOG]:
-                logger.debug(f"     {error_line}")
+                logger.debug(f"     {scrub_urls(error_line)}")
         else:
             logger.warning(f"  ffmpeg encountered {len(error_lines)} error(s) (set DEBUG_MODE=true for details)")
     elif logger.isEnabledFor(logging.DEBUG):
         logger.debug(f"  Last lines of ffmpeg output (DEBUG_MODE):")
         for line in output.splitlines()[-MAX_DEBUG_LINES_TO_LOG:]:
             if line.strip():
-                logger.debug(f"     {line.strip()}")
+                logger.debug(f"     {scrub_urls(line.strip())}")
 
 
 def _parse_ffmpeg_progress_time(line: str) -> Optional[float]:
@@ -353,7 +346,7 @@ def _get_hdr_metadata(url: str, timeout: int = 10, user_agent: str = 'VLC/3.0.14
     Returns:
         Dictionary with HDR metadata fields, or None if extraction fails
     """
-    logger.debug(f"Extracting HDR metadata with ffprobe for: {url[:50]}...")
+    logger.debug(f"Extracting HDR metadata with ffprobe for: {url_ref(url)}")
     command = [
         'ffprobe',
         '-user_agent', user_agent,
@@ -476,7 +469,7 @@ def get_stream_info(url: str, timeout: int = 30, user_agent: str = 'VLC/3.0.14')
 
     Get stream information using ffprobe to extract codec, resolution, and FPS.
     """
-    logger.debug(f"Running ffprobe for URL: {url[:50]}...")
+    logger.debug(f"Running ffprobe for URL: {url_ref(url)}")
     command = [
         'ffprobe',
         '-user_agent', user_agent,
@@ -509,13 +502,13 @@ def get_stream_info(url: str, timeout: int = 30, user_agent: str = 'VLC/3.0.14')
         return None, None
 
     except subprocess.TimeoutExpired:
-        logger.warning(f"Timeout ({timeout}s) while fetching stream info for: {url[:50]}...")
+        logger.warning(f"Timeout ({timeout}s) while fetching stream info for: {url_ref(url)}")
         return None, None
     except json.JSONDecodeError as e:
-        logger.warning(f"Failed to decode JSON from ffprobe for {url[:50]}...: {e}")
+        logger.warning(f"Failed to decode JSON from ffprobe for {url_ref(url)}: {scrub_urls(e)}")
         return None, None
     except Exception as e:
-        logger.error(f"Stream info check failed for {url[:50]}...: {e}")
+        logger.error(f"Stream info check failed for {url_ref(url)}: {scrub_urls(e)}")
         return None, None
 
 
@@ -576,7 +569,10 @@ def get_stream_info_and_bitrate(
     url_lower = url.lower()
     if not (url_lower.startswith('http://') or url_lower.startswith('https://') or
             url_lower.startswith('rtmp://') or url_lower.startswith('rtmps://')):
-        logger.error(f"Invalid URL protocol: {url[:50]}... (must be http://, https://, rtmp://, or rtmps://)")
+        logger.error(
+            f"Invalid URL protocol: {url_ref(url)} "
+            "(must be http://, https://, rtmp://, or rtmps://)"
+        )
         return {
             'video_codec': 'N/A', 'audio_codec': 'N/A', 'resolution': '0x0',
             'fps': 0, 'bitrate_kbps': None, 'hdr_format': None,
@@ -588,7 +584,7 @@ def get_stream_info_and_bitrate(
             'blank_segments': []
         }
 
-    logger.debug(f"Analyzing stream with ffmpeg for {duration}s: {url[:50]}...")
+    logger.debug(f"Analyzing stream with ffmpeg for {duration}s: {url_ref(url)}")
 
     extra_args = _get_ffmpeg_extra_args()
 
@@ -1175,7 +1171,7 @@ def _probe_stream_for_loops(
             f"inconclusive. Stream may not expose decodable video frames."
         )
         if stderr_out:
-            logger.warning(f"[loop-probe:{stream_tag}] FFmpeg said: {stderr_out[:300]}")
+            logger.warning(f"[loop-probe:{stream_tag}] FFmpeg said: {scrub_urls(stderr_out[:300])}")
     elif loop_detected:
         logger.warning(
             f"[loop-probe:{stream_tag}] LOOP DETECTED — "
@@ -1234,10 +1230,12 @@ def analyze_stream(
         - hdr_format, pixel_format, audio_sample_rate, audio_channels
         - channel_layout, audio_bitrate, status
     """
+    stream_audit_ref = stream_ref(stream_id, stream_url)
+
     if logger.isEnabledFor(logging.DEBUG):
-        logger.info(f"Analyzing stream: {stream_name} (ID: {stream_id})")
+        logger.info(f"Analyzing stream: {stream_audit_ref}")
     else:
-        logger.debug(f"Checking {stream_name}")
+        logger.debug(f"Checking {stream_audit_ref}")
 
     result = {
         'stream_id': stream_id,
@@ -1270,9 +1268,12 @@ def analyze_stream(
         for attempt in range(total_attempts):
             if attempt > 0:
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.info(f"  Retry attempt {attempt} of {retries} (attempt {attempt + 1} of {total_attempts}) for {stream_name}")
+                    logger.info(
+                        f"  Retry attempt {attempt} of {retries} "
+                        f"(attempt {attempt + 1} of {total_attempts}) for {stream_audit_ref}"
+                    )
                 else:
-                    logger.info(f"  Retry {attempt + 1}/{total_attempts} for {stream_name}")
+                    logger.info(f"  Retry {attempt + 1}/{total_attempts} for {stream_audit_ref}")
                 time.sleep(retry_delay)
 
             try:
@@ -1346,16 +1347,16 @@ def analyze_stream(
                             logger.info(f"    Bitrate: {result['bitrate_kbps']:.2f} kbps (elapsed: {result_data['elapsed_time']:.2f}s)")
                         else:
                             logger.warning(f"    Bitrate detection failed (elapsed: {result_data['elapsed_time']:.2f}s)")
-                        logger.info(f"  Stream analysis complete for {stream_name}")
+                        logger.info(f"  Stream analysis complete for {stream_audit_ref}")
                     else:
                         logger.warning(f"    Status: {result['status']} (elapsed: {result_data['elapsed_time']:.2f}s)")
                 else:
                     if result['status'] == "OK":
                         bitrate_str = f"{result['bitrate_kbps']:.2f} kbps" if result['bitrate_kbps'] is not None else "N/A"
                         hdr_str = f", {result['hdr_format']}" if result.get('hdr_format') else ""
-                        logger.info(f"  {stream_name}: {result['resolution']}, {result['fps']} FPS, {bitrate_str}, {result['video_codec']}/{result['audio_codec']}{hdr_str} ({result_data['elapsed_time']:.2f}s)")
+                        logger.info(f"  {stream_audit_ref}: {result['resolution']}, {result['fps']} FPS, {bitrate_str}, {result['video_codec']}/{result['audio_codec']}{hdr_str} ({result_data['elapsed_time']:.2f}s)")
                     else:
-                        logger.warning(f"  {stream_name}: Check failed - {result['status']} ({result_data['elapsed_time']:.2f}s)")
+                        logger.warning(f"  {stream_audit_ref}: Check failed - {result['status']} ({result_data['elapsed_time']:.2f}s)")
 
                 if result['status'] == "OK":
                     # Check whether FFmpeg ran for a meaningful portion of the
@@ -1369,13 +1370,13 @@ def analyze_stream(
                     elif attempt < total_attempts - 1:
                         if logger.isEnabledFor(logging.DEBUG):
                             logger.warning(
-                                f"  Stream '{stream_name}' exited early "
+                                f"  Stream {stream_audit_ref} exited early "
                                 f"({elapsed:.1f}s / {ffmpeg_duration}s expected) — "
                                 f"retrying (attempt {attempt + 2}/{total_attempts})"
                             )
                         else:
                             logger.warning(
-                                f"  {stream_name} exited early "
+                                f"  {stream_audit_ref} exited early "
                                 f"({elapsed:.1f}s/{ffmpeg_duration}s) — "
                                 f"retrying (attempt {attempt + 2}/{total_attempts})"
                             )
@@ -1384,16 +1385,26 @@ def analyze_stream(
                 else:
                     if attempt < total_attempts - 1:
                         if logger.isEnabledFor(logging.DEBUG):
-                            logger.warning(f"  Stream '{stream_name}' failed with status '{result['status']}'. Retrying in {retry_delay} seconds...")
+                            logger.warning(
+                                f"  Stream {stream_audit_ref} failed with status "
+                                f"'{result['status']}'. Retrying in {retry_delay} seconds..."
+                            )
                         else:
-                            logger.warning(f"  Retrying {stream_name} in {retry_delay}s (attempt {attempt + 2}/{total_attempts})")
+                            logger.warning(
+                                f"  Retrying {stream_audit_ref} in {retry_delay}s "
+                                f"(attempt {attempt + 2}/{total_attempts})"
+                            )
 
             except Exception as inner_e:
-                logger.error(f"  Exception during stream analysis (attempt {attempt + 1} of {total_attempts}): {inner_e}")
+                logger.error(
+                    f"  Exception during stream analysis "
+                    f"(attempt {attempt + 1} of {total_attempts}) for {stream_audit_ref}: "
+                    f"{scrub_urls(inner_e)}"
+                )
                 if attempt < total_attempts - 1:
                     logger.warning(f"  Retrying in {retry_delay} seconds...")
 
     except Exception as outer_e:
-        logger.error(f"Unexpected error in analyze_stream for {stream_name}: {outer_e}")
+        logger.error(f"Unexpected error in analyze_stream for {stream_audit_ref}: {scrub_urls(outer_e)}")
 
     return result

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -19,7 +19,6 @@ updates and maintaining a queue of channels that need checking. It
 integrates with the stream_check_utils.py module for stream analysis.
 """
 
-import hashlib
 import json
 import logging
 import os
@@ -38,6 +37,7 @@ from apps.core.api_utils import (
     patch_request,
     batch_update_stream_stats
 )
+from apps.core.log_sanitizer import audit_ref as _audit_ref, scrub_urls, stream_context, stream_ref
 
 # Import UDI for direct data access
 from apps.udi import get_udi_manager
@@ -86,13 +86,6 @@ logger = setup_logging(__name__)
 
 # Configuration directory
 CONFIG_DIR = Path(os.environ.get('CONFIG_DIR', '/app/data'))
-
-
-def _audit_ref(kind: str, value: Any) -> str:
-    if value is None:
-        return f"{kind}-unknown"
-    digest = hashlib.sha256(f"{kind}:{value}".encode("utf-8")).hexdigest()[:12]
-    return f"{kind}-{digest}"
 
 
 from apps.stream.stream_checker_components import (
@@ -1622,18 +1615,27 @@ class StreamCheckerService:
                                     f"reason={dead_reason}"
                                 )
                             else:
-                                logger.warning(f"Stream {stream_id} detected as DEAD: {stream_name} (reason={dead_reason})")
+                                logger.warning(
+                                    f"Stream detected as dead: "
+                                    f"{stream_context(stream_id=stream_id, stream_url=stream_url, channel_id=channel_id, reason=dead_reason)}"
+                                )
                         else:
                             logger.error(f"Failed to mark stream {stream_id} as dead in tracker")
                     elif not is_dead and was_dead:
                         if allow_revive:
                             if self.dead_streams_tracker.mark_as_alive(stream_url):
                                 revived_stream_ids.append(stream_id)
-                                logger.info(f"Stream {stream_id} REVIVED: {stream_name}")
+                                logger.info(
+                                    f"Stream revived: "
+                                    f"{stream_context(stream_id=stream_id, stream_url=stream_url, channel_id=channel_id)}"
+                                )
                         else:
                             # Not allowed to revive, treat as still dead
                             dead_stream_ids.add(stream_id)
-                            logger.info(f"Stream {stream_id} is alive but revival disabled by profile: {stream_name}")
+                            logger.info(
+                                f"Stream is alive but revival is disabled by profile: "
+                                f"{stream_context(stream_id=stream_id, stream_url=stream_url, channel_id=channel_id)}"
+                            )
                     elif is_dead and was_dead:
                         logger.debug(f"Stream {stream_id} remains dead (already marked)")
                         # Only act on stale dead state if this stream was part of the current
@@ -2360,7 +2362,10 @@ class StreamCheckerService:
                                 f"reason={dead_reason}"
                             )
                         else:
-                            logger.warning(f"Stream {stream['id']} detected as DEAD: {stream_name} (reason={dead_reason})")
+                            logger.warning(
+                                f"Stream detected as dead: "
+                                f"{stream_context(stream_id=stream['id'], stream_url=stream_url, channel_id=channel_id, reason=dead_reason)}"
+                            )
                     else:
                         logger.error(f"Failed to mark stream {stream['id']} as DEAD, will not remove from channel")
                 elif not is_dead and was_dead:
@@ -2368,10 +2373,16 @@ class StreamCheckerService:
                     if allow_revive:
                         if self.dead_streams_tracker.mark_as_alive(stream_url):
                             revived_stream_ids.append(stream['id'])
-                            logger.info(f"Stream {stream['id']} REVIVED: {stream_name}")
+                            logger.info(
+                                f"Stream revived: "
+                                f"{stream_context(stream_id=stream['id'], stream_url=stream_url, channel_id=channel_id)}"
+                            )
                     else:
                         dead_stream_ids.add(stream['id'])
-                        logger.info(f"Stream {stream['id']} is alive but revival disabled by profile: {stream_name}")
+                        logger.info(
+                            f"Stream is alive but revival is disabled by profile: "
+                            f"{stream_context(stream_id=stream['id'], stream_url=stream_url, channel_id=channel_id)}"
+                        )
                 elif is_dead and was_dead:
                     # Stream remains dead. Guard is redundant here — this loop
                     # iterates streams_to_check by definition — but kept for
@@ -2590,7 +2601,7 @@ class StreamCheckerService:
                     for stream_id in dead_stream_ids:
                         dead_stream = next((s for s in analyzed_streams if s.get('stream_id') == stream_id), None)
                         if dead_stream:
-                            logger.info(f"  - Removing dead stream {stream_id}: {dead_stream.get('stream_name', 'Unknown')}")
+                            logger.info(f"  - Removing dead stream {stream_ref(stream_id, dead_stream.get('stream_url'))}")
                     analyzed_streams = [s for s in analyzed_streams if s.get('stream_id') not in dead_stream_ids]
                 else:
                     logger.info(f"⚠️ Found {len(dead_stream_ids)} dead streams in channel {channel_name}, but removal is disabled in config")
@@ -2960,6 +2971,7 @@ class StreamCheckerService:
             stream_name = stream.get('stream_name', 'Unknown')
             stream_id   = stream.get('stream_id')
             score       = stream.get('score', 0)
+            stream_audit_ref = stream_ref(stream_id, stream_url)
 
             # Resolve numeric account ID from UDI.
             # analyzed dicts carry stream_id from quality analysis — use that
@@ -2974,14 +2986,7 @@ class StreamCheckerService:
             except Exception:
                 pass
 
-            # Build a short readable tag for log messages
-            try:
-                from urllib.parse import urlparse as _up
-                _p    = _up(stream_url)
-                _segs = [seg for seg in _p.path.split('/') if seg]
-                tag   = f"{_p.hostname}/{_segs[-1]}" if _segs else (_p.hostname or stream_url[:20])
-            except Exception:
-                tag = stream_url[:30]
+            tag = stream_audit_ref
 
             # Acquire account slot — same mechanism used by quality analysis.
             # Timeout of 60s: if the account is saturated (e.g. live viewers
@@ -2989,15 +2994,15 @@ class StreamCheckerService:
             acquired, reason = account_limiter.acquire(account_id, timeout=60)
             if not acquired:
                 logger.info(
-                    f"[loop-probe:{tag}] Skipping '{stream_name}' — "
+                    f"[loop-probe:{tag}] Skipping stream - "
                     f"account slot unavailable ({reason})"
                 )
                 return
 
             try:
                 logger.info(
-                    f"[loop-probe:{tag}] Probing '{stream_name}' "
-                    f"(ID: {stream_id}, score: {score:.2f})"
+                    f"[loop-probe:{tag}] Probing stream "
+                    f"(score: {score:.2f})"
                 )
                 loop_detected, loop_duration, frames = _probe_stream_for_loops(
                     url=stream_url,
@@ -3011,7 +3016,7 @@ class StreamCheckerService:
 
             except Exception as e:
                 logger.error(
-                    f"[loop-probe:{tag}] Probe failed for '{stream_name}': {e}"
+                    f"[loop-probe:{tag}] Probe failed: {scrub_urls(e)}"
                 )
                 # loop_detected remains None — distinguishable from clean (False)
                 # or detected (True)
@@ -3038,7 +3043,7 @@ class StreamCheckerService:
                             stream_duration=probe_duration,
                         )
                     logger.info(
-                        f"[loop-probe] Completed {completed[0]}/{total}: {stream_name}"
+                        f"[loop-probe] Completed {completed[0]}/{total}: {stream_audit_ref}"
                     )
 
         with ThreadPoolExecutor(max_workers=global_limit) as executor:
@@ -3050,7 +3055,7 @@ class StreamCheckerService:
                     stream = futures[future]
                     logger.error(
                         f"[loop-probe] Unhandled error for stream "
-                        f"{stream.get('stream_name', 'Unknown')}: {e}"
+                        f"{stream_ref(stream.get('stream_id'), stream.get('stream_url'))}: {scrub_urls(e)}"
                     )
 
         logger.info(f"[loop-probe] Parallel probe complete — {completed[0]}/{total} streams probed")
@@ -3065,8 +3070,9 @@ class StreamCheckerService:
                     original = stream.get('score', 0.0)
                     stream['score'] = round(max(0.0, original + loop_penalty), 2)
                     stream['loop_score_penalty'] = loop_penalty
+                    penalty_ref = stream_ref(stream.get('stream_id'), stream.get('stream_url'))
                     logger.info(
-                        f"[loop-probe] Penalty applied to '{stream.get('stream_name', 'Unknown')}': "
+                        f"[loop-probe] Penalty applied to {penalty_ref}: "
                         f"{original:.2f} → {stream['score']:.2f} (penalty={loop_penalty:+.2f})"
                     )
                     penalised += 1
@@ -3699,7 +3705,10 @@ class StreamCheckerService:
                         m3u_account = stream.get('m3u_account')
                         if m3u_account:
                             account_ids.add(m3u_account)
-                            logger.info(f"Found M3U account {m3u_account} from dead stream {dead_info.get('stream_name', 'Unknown')}")
+                            logger.info(
+                                f"Found M3U account {m3u_account} from dead stream "
+                                f"{stream_ref(stream_id, dead_url)}"
+                            )
             
             # Step 2a: Provider fetch — only if m3u_update is enabled in the profile.
             #

--- a/backend/tests/test_log_sanitizer.py
+++ b/backend/tests/test_log_sanitizer.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import unittest
+from unittest.mock import patch
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -69,6 +70,29 @@ class LogSanitizerTests(unittest.TestCase):
         self.assertIn("reason=offline", context)
         self.assertNotIn(raw_url, context)
         self.assertNotIn("provider.example", context)
+
+    def test_debug_mode_keeps_raw_stream_identifiers_visible(self):
+        raw_url = "http://provider.example/live/user/password/123.ts?token=secret"
+
+        with patch.dict(os.environ, {"DEBUG_MODE": "true"}):
+            self.assertEqual(
+                scrub_urls(f"ffmpeg failed while opening {raw_url}"),
+                f"ffmpeg failed while opening {raw_url}",
+            )
+            self.assertIn("stream-123", stream_ref(123, raw_url))
+
+            context = stream_context(
+                stream_id=123,
+                stream_url=raw_url,
+                channel_id=456,
+                reason="offline",
+            )
+
+        self.assertIn("stream_ref=stream-123", context)
+        self.assertIn("channel_ref=channel-456", context)
+        default_context = stream_context(stream_id=123, stream_url=raw_url)
+        self.assertNotIn("stream_ref=stream-123", default_context)
+        self.assertNotIn(raw_url, default_context)
 
     def test_dead_stream_tracker_logs_refs_without_names_or_urls(self):
         raw_url = "http://provider.example/live/user/password/123.ts?token=secret"

--- a/backend/tests/test_log_sanitizer.py
+++ b/backend/tests/test_log_sanitizer.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Regression tests for operational log redaction helpers."""
+
+import os
+import sys
+import unittest
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from apps.core.log_sanitizer import audit_ref, scrub_urls, stream_context, stream_ref
+from apps.stream.dead_streams_tracker import DeadStreamsTracker
+from apps.stream.ffmpeg_stream_monitor import FFmpegStreamMonitor
+
+
+class FakeDeadStreamDb:
+    def __init__(self):
+        self.dead_streams = {}
+
+    def mark_stream_dead(self, stream_url, stream_id, stream_name, channel_id, reason):
+        self.dead_streams[stream_url] = {
+            "stream_id": stream_id,
+            "stream_name": stream_name,
+            "channel_id": channel_id,
+            "reason": reason,
+        }
+        return True
+
+    def get_dead_streams(self, as_dict=True):
+        return self.dead_streams
+
+    def remove_dead_stream(self, stream_url):
+        self.dead_streams.pop(stream_url, None)
+
+
+class LogSanitizerTests(unittest.TestCase):
+    def test_audit_refs_are_stable_and_do_not_include_raw_values(self):
+        raw_value = "http://provider.example/live/user/password/123.ts?token=secret"
+
+        first = audit_ref("url", raw_value)
+        second = audit_ref("url", raw_value)
+
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("url-"))
+        self.assertNotIn("provider.example", first)
+        self.assertNotIn("token=secret", first)
+
+    def test_scrub_urls_replaces_raw_urls_with_refs(self):
+        raw_url = "http://provider.example/live/user/password/123.ts?token=secret"
+
+        message = scrub_urls(f"ffmpeg failed while opening {raw_url}")
+
+        self.assertNotIn(raw_url, message)
+        self.assertNotIn("provider.example", message)
+        self.assertIn("<url-", message)
+
+    def test_stream_context_uses_refs_only(self):
+        raw_url = "http://provider.example/live/user/password/123.ts?token=secret"
+
+        context = stream_context(
+            stream_id=123,
+            stream_url=raw_url,
+            channel_id=456,
+            reason="offline",
+        )
+
+        self.assertIn("stream_ref=stream-", context)
+        self.assertIn("channel_ref=channel-", context)
+        self.assertIn("reason=offline", context)
+        self.assertNotIn(raw_url, context)
+        self.assertNotIn("provider.example", context)
+
+    def test_dead_stream_tracker_logs_refs_without_names_or_urls(self):
+        raw_url = "http://provider.example/live/user/password/123.ts?token=secret"
+        raw_name = "Private Provider UHD Secret Channel"
+        tracker = DeadStreamsTracker.__new__(DeadStreamsTracker)
+        tracker.db = FakeDeadStreamDb()
+
+        with self.assertLogs("apps.stream.dead_streams_tracker", level="INFO") as captured:
+            tracker.mark_as_dead(raw_url, 123, raw_name, channel_id=456, reason="offline")
+            tracker.mark_as_alive(raw_url)
+
+        logs = "\n".join(captured.output)
+        self.assertIn("stream-", logs)
+        self.assertIn("channel-", logs)
+        self.assertNotIn(raw_url, logs)
+        self.assertNotIn(raw_name, logs)
+        self.assertNotIn("provider.example", logs)
+
+    def test_ffmpeg_url_validation_log_uses_url_ref(self):
+        raw_url = "http://provider.example/live/user/password/123.ts?token=secret;rm"
+        monitor = FFmpegStreamMonitor.__new__(FFmpegStreamMonitor)
+
+        with self.assertLogs("apps.stream.ffmpeg_stream_monitor", level="WARNING") as captured:
+            self.assertFalse(monitor._validate_url(raw_url))
+
+        logs = "\n".join(captured.output)
+        self.assertIn("url-", logs)
+        self.assertNotIn(raw_url, logs)
+        self.assertNotIn("provider.example", logs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small shared log-sanitizer helper for stable, non-reversible stream/channel/URL references
- replace raw stream URLs and stream names in stream-analysis, dead-stream, ffmpeg monitor, and loop-probe operational logs
- scrub URLs from ffmpeg stderr snippets and exception messages before logging
- keep existing result payloads and progress data unchanged; this PR only changes operational log output
- add regression coverage for URL scrubbing, stable refs, dead-stream tracker logs, and ffmpeg URL-validation logs

## Problem
Operational logs can include raw provider URLs, stream names, or ffmpeg stderr snippets that may expose environment-specific details. Blank-detect logging already uses audit-style references; the rest of the stream/dead-stream log paths should follow the same pattern.

## Validation
- On this branch: `PYTHONPATH=backend python -m pytest backend/tests/test_log_sanitizer.py backend/tests/test_blank_detection.py backend/tests/test_stream_check_utils.py` passed: 28 tests.
- On this branch: `python -m py_compile backend/apps/core/log_sanitizer.py backend/apps/stream/dead_streams_tracker.py backend/apps/stream/ffmpeg_stream_monitor.py backend/apps/stream/stream_check_utils.py backend/apps/stream/stream_checker_service.py backend/tests/test_log_sanitizer.py` passed.
- On this branch: `git diff --check` passed.
- Stacked validation with PR #411, PR #412, PR #413, PR #414, and this branch passed: `python scripts/run_ci_checks.py` (compileall plus 69 backend tests), targeted PR1-PR5 suite (40 tests), `npm run test:ci` (1 Vitest test), `npm run build`, and `git diff --check`.
- Built a production image from the combined PR #411 + #412 + #413 + #414 + this branch stack.
- Live verification after managed deploy: health endpoint stayed healthy, startup data refresh completed, `/api/automation/status` returned sanitized run and API timing data, stream checker status stayed idle with an empty queue and no stale progress, and live logs showed no traceback/exception/error entries in the verification window.
- Live verification also confirmed the container was recreated through the managed template/update path, preserving normal edit/update metadata.
- Additional exploratory test note: existing `backend/tests/test_stream_checker_single_channel_profile_flags.py`, `backend/tests/test_dead_streams.py`, and `backend/tests/test_configurable_dead_streams.py` currently fail on current `dev` for pre-existing stale test contracts/import paths, unrelated to this PR. Examples: missing `get_session_manager` patch target, tests importing top-level `dead_streams_tracker`, and tests expecting boolean-only dead-stream results although the code now returns `(is_dead, reason)`.

## Screenshots
No UI changes in this PR.

## Final Combined Verification
- Deployed the combined PR #411-#423 stack as a production image through the normal update path.
- Completed a full automation run after playlist refresh, cache/UDI sync, stream matching, queueing, and quality checking.
- Final run processed 226/226 channels with `quality_checked=226`, `quality_failed=0`, `quality_incomplete=0`, `quality_aborted=0`, and `quality_skipped=0`.
- Final run analyzed 2445 streams, revived 75 streams, and assigned/reordered 94 channels without aborting.
- Connectivity guard ended in a verified state, and post-run log review found no traceback, critical, or error entries from the verification window.
## Release State
Ready for review after final combined verification. This PR was validated both independently and as part of the stacked PR #411-#423 release candidate.
