### PR TITLE
Fix automation run status and setup UDI initialization

### DIFF
--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -1525,15 +1525,42 @@ class AutomatedStreamManager:
         return {
             "run_id": run_id,
             "state": state,
+            "status": state,
+            "active": state == "running",
             "stage": stage,
             "stage_label": stage_label,
             "message": message,
             "forced": forced,
             "forced_period_id": forced_period_id,
             "started_at": now if state == "running" else None,
+            "stage_started_at": now if state == "running" else None,
             "updated_at": now,
             "completed_at": None,
             "duration_seconds": None,
+            "stage_duration_seconds": None,
+            "elapsed_seconds": 0,
+            "stage_elapsed_seconds": 0,
+            "current": 0,
+            "total": None,
+            "percent": 0,
+            "progress": {
+                "current": 0,
+                "total": None,
+                "percent": 0,
+                "message": "",
+            },
+            "stages": [
+                {
+                    "key": key,
+                    "label": label,
+                    "status": "running" if key == stage and state == "running" else "pending",
+                    "current": 0,
+                    "total": None,
+                    "percent": 0,
+                    "message": message if key == stage else "",
+                }
+                for key, label in self.RUN_STAGES
+            ],
             "counts": {},
             "durations": {},
             "last_error": None,
@@ -1553,7 +1580,7 @@ class AutomatedStreamManager:
                 message="No automation cycle has run yet",
             )
 
-    def _start_run_status(self, *, forced: bool, forced_period_id: Optional[str]) -> None:
+    def _start_run_status(self, *, forced: bool = False, forced_period_id: Optional[str] = None) -> None:
         self._ensure_run_status_fields()
         with self._run_status_lock:
             self._run_sequence += 1
@@ -1583,10 +1610,15 @@ class AutomatedStreamManager:
         with self._run_status_lock:
             status = self._run_status
             now = datetime.now()
+            previous_stage = status.get("stage")
             if state:
                 status["state"] = state
+                status["status"] = state
+                status["active"] = state == "running"
             if stage:
                 status["stage"] = stage
+                if stage != previous_stage:
+                    status["stage_started_at"] = now.isoformat()
             if stage_label:
                 status["stage_label"] = stage_label
             if message is not None:
@@ -1610,30 +1642,164 @@ class AutomatedStreamManager:
                 try:
                     started = datetime.fromisoformat(started_at)
                     status["duration_seconds"] = round((now - started).total_seconds(), 3)
+                    status["elapsed_seconds"] = int((now - started).total_seconds())
+                except (TypeError, ValueError):
+                    pass
+            stage_started_at = status.get("stage_started_at")
+            if stage_started_at:
+                try:
+                    stage_started = datetime.fromisoformat(stage_started_at)
+                    status["stage_duration_seconds"] = round((now - stage_started).total_seconds(), 3)
+                    status["stage_elapsed_seconds"] = int((now - stage_started).total_seconds())
                 except (TypeError, ValueError):
                     pass
 
-    def _finish_run_status(self, *, state: str, stage: str, stage_label: str, message: str, error: Optional[str] = None) -> None:
+    def _update_run_stage(
+        self,
+        stage_key: str,
+        *,
+        message: str = "",
+        current: int = 0,
+        total: Optional[int] = None,
+        status: str = "running",
+    ) -> None:
+        stage_keys = [key for key, _label in self.RUN_STAGES]
+        stage_index = stage_keys.index(stage_key) if stage_key in stage_keys else -1
+        percent = int((current / total) * 100) if total else 0
+        percent = max(0, min(100, percent))
+        state = status if status not in {"running", "completed", "skipped"} else "running"
+
+        self._update_run_status(
+            stage=stage_key,
+            stage_label=self._stage_label(stage_key),
+            message=message,
+            state=state,
+        )
+
+        with self._run_status_lock:
+            self._run_status["current"] = current
+            self._run_status["total"] = total
+            self._run_status["percent"] = percent
+            self._run_status["progress"] = {
+                "current": current,
+                "total": total,
+                "percent": percent,
+                "message": message,
+            }
+            for idx, stage in enumerate(self._run_status.get("stages", [])):
+                if stage_index >= 0 and idx < stage_index and stage["status"] in {"pending", "running"}:
+                    stage.update({"status": "completed", "percent": 100})
+                elif idx == stage_index:
+                    stage.update(
+                        {
+                            "status": status,
+                            "current": current,
+                            "total": total,
+                            "percent": percent,
+                            "message": message,
+                        }
+                    )
+
+    def _update_run_progress(
+        self,
+        *,
+        stage_key: Optional[str] = None,
+        current: Optional[int] = None,
+        total: Optional[int] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        self._ensure_run_status_fields()
+        with self._run_status_lock:
+            key = stage_key or self._run_status.get("stage")
+            current_value = self._run_status.get("current", 0) if current is None else current
+            total_value = self._run_status.get("total") if total is None else total
+            percent = int((current_value / total_value) * 100) if total_value else self._run_status.get("percent", 0)
+            percent = max(0, min(100, int(percent or 0)))
+
+        self._update_run_status(
+            stage=key,
+            stage_label=self._stage_label(key),
+            message=message,
+        )
+
+        with self._run_status_lock:
+            self._run_status["current"] = current_value
+            self._run_status["total"] = total_value
+            self._run_status["percent"] = percent
+            if message is not None:
+                self._run_status["message"] = message
+            self._run_status["progress"] = {
+                "current": current_value,
+                "total": total_value,
+                "percent": percent,
+                "message": message or self._run_status.get("message", ""),
+            }
+            for stage in self._run_status.get("stages", []):
+                if stage["key"] == key:
+                    stage.update(
+                        {
+                            "status": "running",
+                            "current": current_value,
+                            "total": total_value,
+                            "percent": percent,
+                        }
+                    )
+                    if message is not None:
+                        stage["message"] = message
+                    break
+
+    def _finish_run_status(
+        self,
+        status: Optional[str] = None,
+        message: str = "",
+        *,
+        state: Optional[str] = None,
+        stage: Optional[str] = None,
+        stage_label: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> None:
         self._ensure_run_status_fields()
         now = datetime.now()
+        final_state = state or status or "completed"
+        final_stage = stage or final_state
+        final_stage_label = stage_label or self._stage_label(final_stage)
         with self._run_status_lock:
-            status = self._run_status
-            status["state"] = state
-            status["stage"] = stage
-            status["stage_label"] = stage_label
-            status["message"] = message
-            status["updated_at"] = now.isoformat()
-            status["completed_at"] = now.isoformat()
+            status_data = self._run_status
+            active_stage = status_data.get("stage")
+            status_data["state"] = final_state
+            status_data["status"] = final_state
+            status_data["active"] = False
+            status_data["stage"] = final_stage
+            status_data["stage_label"] = final_stage_label
+            status_data["message"] = message
+            status_data["updated_at"] = now.isoformat()
+            status_data["completed_at"] = now.isoformat()
             if error is not None:
-                status["last_error"] = error
+                status_data["last_error"] = error
 
-            started_at = status.get("started_at")
+            started_at = status_data.get("started_at")
             if started_at:
                 try:
                     started = datetime.fromisoformat(started_at)
-                    status["duration_seconds"] = round((now - started).total_seconds(), 3)
+                    duration = (now - started).total_seconds()
+                    status_data["duration_seconds"] = round(duration, 3)
+                    status_data["elapsed_seconds"] = int(duration)
                 except (TypeError, ValueError):
                     pass
+            stage_started_at = status_data.get("stage_started_at")
+            if stage_started_at:
+                try:
+                    stage_started = datetime.fromisoformat(stage_started_at)
+                    stage_duration = (now - stage_started).total_seconds()
+                    status_data["stage_duration_seconds"] = round(stage_duration, 3)
+                    status_data["stage_elapsed_seconds"] = int(stage_duration)
+                except (TypeError, ValueError):
+                    pass
+            for stage_item in status_data.get("stages", []):
+                if final_state == "completed" and stage_item["status"] == "pending":
+                    stage_item["status"] = "skipped"
+                if stage_item["key"] == active_stage and stage_item["status"] == "running":
+                    stage_item["status"] = "completed" if final_state == "completed" else final_state
 
     @staticmethod
     def _summarize_quality_check_results(check_results, expected_count: int) -> Dict[str, Any]:

--- a/backend/apps/udi/manager.py
+++ b/backend/apps/udi/manager.py
@@ -204,22 +204,26 @@ class UDIManager:
             True if initialization successful
         """
         # 1. State check with lock
+        wait_for_existing_init = False
         with self._lock:
             if self._initialized and not force_refresh:
                 logger.debug("UDI Manager already initialized")
                 return True
 
             if self._init_in_progress:
-                logger.debug("UDI Manager initialization already in progress in another thread")
-                return True
+                logger.info("UDI Manager initialization already in progress; waiting for completion")
+                wait_for_existing_init = True
+            else:
+                config = get_dispatcharr_config()
+                if not config.is_configured():
+                    logger.warning("Cannot initialize UDI: Dispatcharr credentials not configured")
+                    self._initialized = True
+                    return False
 
-            config = get_dispatcharr_config()
-            if not config.is_configured():
-                logger.warning("Cannot initialize UDI: Dispatcharr credentials not configured")
-                self._initialized = True
-                return False
+                self._init_in_progress = True
 
-            self._init_in_progress = True
+        if wait_for_existing_init:
+            return self._wait_for_initialization_completion(force_refresh=force_refresh)
 
         # 2. Fetch fresh data from API (OUTSIDE Lock)
         logger.debug("Fetching fresh data from API...")
@@ -235,6 +239,24 @@ class UDIManager:
         finally:
             with self._lock:
                 self._init_in_progress = False
+
+    def _wait_for_initialization_completion(self, *, force_refresh: bool, timeout_seconds: int = 300) -> bool:
+        """Wait for a concurrent initialization instead of reporting success early."""
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            with self._lock:
+                if not self._init_in_progress:
+                    if force_refresh:
+                        return bool(
+                            self._initialized
+                            and self._network_ready
+                            and self._init_progress.get("status") == "completed"
+                        )
+                    return bool(self._initialized)
+            time.sleep(0.25)
+
+        logger.warning("Timed out waiting for concurrent UDI initialization to complete")
+        return False
     
     def _build_indexes(self) -> None:
         """Build index caches for fast lookups."""

--- a/backend/tests/test_udi_initialization_wait.py
+++ b/backend/tests/test_udi_initialization_wait.py
@@ -1,0 +1,54 @@
+import threading
+import time
+
+from apps.udi.manager import UDIManager
+
+
+class _ConfiguredDispatcharr:
+    def is_configured(self):
+        return True
+
+
+def test_initialize_waits_for_concurrent_refresh(monkeypatch):
+    manager = UDIManager()
+
+    monkeypatch.setattr(
+        "apps.udi.manager.get_dispatcharr_config",
+        lambda: _ConfiguredDispatcharr(),
+    )
+
+    def slow_refresh():
+        time.sleep(0.2)
+        manager._update_init_progress(
+            status="completed",
+            percentage=100,
+            message="Initialization complete",
+            current_step="done",
+        )
+        manager._network_ready = True
+        return True
+
+    monkeypatch.setattr(manager, "refresh_all", slow_refresh)
+
+    first_result = []
+    first = threading.Thread(
+        target=lambda: first_result.append(manager.initialize(force_refresh=True))
+    )
+    first.start()
+
+    deadline = time.time() + 2
+    while time.time() < deadline:
+        with manager._lock:
+            if manager._init_in_progress:
+                break
+        time.sleep(0.01)
+
+    started = time.time()
+    second_result = manager.initialize(force_refresh=True)
+    elapsed = time.time() - started
+    first.join(timeout=2)
+
+    assert first_result == [True]
+    assert second_result is True
+    assert elapsed >= 0.15
+    assert manager.is_network_ready() is True

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -104,6 +104,7 @@ function App() {
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/stream-checker" element={<StreamChecker />} />
               <Route path="/stream-monitoring" element={<StreamMonitoring />} />
+              <Route path="/shadow-monitor" element={<ShadowBlankMonitor />} />
               <Route path="/channels" element={<ChannelConfiguration />} />
               <Route path="/settings" element={<AutomationSettings />} />
               <Route path="/automation/profiles/:profileId" element={<AutomationProfileEditor />} />


### PR DESCRIPTION
﻿## Summary
- Restores compatibility between the legacy automation stage/progress helpers and the newer run-status payload so merged `dev` no longer raises `KeyError: 'stages'` or `_finish_run_status` signature errors during automation cycles.
- Makes `UDIManager.initialize(force_refresh=True)` wait for an already-running initialization instead of returning success before the cache is populated.
- Adds the missing `/shadow-monitor` route so the sidebar/deep link reaches the Shadow Monitor page instead of falling back to the dashboard.

## Root Cause
The merged `dev` branch had both legacy and newer automation run-status methods in `AutomatedStreamManager`. The runtime started a new-format status object, then old helpers tried to mutate the old `stages` shape. A similar setup-flow race could happen when saving Dispatcharr config triggered a background UDI refresh and the wizard immediately called the blocking initialize endpoint; the second call returned success while the first refresh was still running.

## Validation
- `python -m compileall backend\apps`
- `python -m pytest backend\tests\test_automation_run_progress.py backend\tests\test_udi_initialization_wait.py backend\tests\test_log_sanitizer.py -q` -> 9 passed
- `npm.cmd test -- --run` -> 2 files / 4 tests passed
- `npm.cmd run build` -> success
- `python scripts/run_ci_checks.py` -> 75 tests OK

Notes: older file-based wizard tests still assume pre-SQL config files and fail against current SQL-backed config behavior; they were not introduced by this change.
