### PR TITLE
Fix automation cache sync duration tracking

### DIFF
--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -3590,6 +3590,7 @@ class AutomatedStreamManager:
             # profiles), the existing cache is used as-is. The background UDI sync
             # in the finally block handles cache accuracy for the next cycle.
             if playlists_refreshed and refresh_success:
+                udi_sync_started = time.time()
                 self._update_run_stage("cache_sync", message="Syncing cache after playlist refresh", total=1)
                 logger.info(
                     "Syncing UDI cache after provider refresh — "
@@ -3691,7 +3692,7 @@ class AutomatedStreamManager:
                         if refresh_success
                         else "Safety gate stopped matching after playlist refresh"
                     ),
-                    stage="udi_sync" if refresh_success else "aborted",
+                    stage="cache_sync" if refresh_success else "aborted",
                     stage_label="Syncing Cache" if refresh_success else "Aborted",
                 )
             


### PR DESCRIPTION
## Summary
- initialize the automation cache-sync duration timer before refreshing UDI after playlist refresh
- keep the automation run-status stage aligned with the existing `cache_sync` stage key

## Root Cause
The merged automation progress status path records `udi_sync_seconds` after a provider playlist refresh, but the refreshed-cache branch never initialized `udi_sync_started`. When the scheduled automation loop entered that branch, Python raised `NameError: name 'udi_sync_started' is not defined` before quality checks could continue.

## Validation
- `python -m py_compile backend/apps/automation/automated_stream_manager.py`
- `python -m pytest backend/tests/test_automation_run_progress.py backend/tests/test_udi_initialization_wait.py -q` -> 3 passed
- `python scripts/run_ci_checks.py` -> 75 tests OK