### PR TITLE
Fix automation stream matching duration tracking

### DIFF
--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -3734,6 +3734,7 @@ class AutomatedStreamManager:
                 # Group results by channel for easier joining later
                 if not playlists_refreshed:
                     self._update_run_stage("cache_sync", status="skipped", message="Cache sync not needed")
+                matching_started = time.time()
                 self._update_run_stage("matching", message="Validating existing stream assignments")
 
                 # Validate existing streams

--- a/backend/tests/test_automation_run_progress.py
+++ b/backend/tests/test_automation_run_progress.py
@@ -1,3 +1,6 @@
+import ast
+from pathlib import Path
+
 from apps.automation.automated_stream_manager import AutomatedStreamManager
 
 
@@ -38,3 +41,52 @@ def test_skipped_stage_keeps_run_active_until_finish():
     assert status["active"] is False
     assert status["status"] == "completed"
     assert status["message"] == "Done"
+
+
+def test_automation_duration_start_variables_are_defined_before_use():
+    source_path = (
+        Path(__file__).resolve().parents[1]
+        / "apps"
+        / "automation"
+        / "automated_stream_manager.py"
+    )
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    manager_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "AutomatedStreamManager"
+    )
+    run_cycle = next(
+        node
+        for node in manager_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "run_automation_cycle"
+    )
+
+    assignments = {}
+    usages = []
+
+    for node in ast.walk(run_cycle):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id.endswith("_started"):
+                    assignments.setdefault(target.id, []).append(node.lineno)
+        elif isinstance(node, ast.AnnAssign):
+            target = node.target
+            if isinstance(target, ast.Name) and target.id.endswith("_started"):
+                assignments.setdefault(target.id, []).append(node.lineno)
+        elif (
+            isinstance(node, ast.BinOp)
+            and isinstance(node.op, ast.Sub)
+            and isinstance(node.right, ast.Name)
+            and node.right.id.endswith("_started")
+        ):
+            usages.append((node.right.id, node.lineno))
+
+    missing = [
+        f"{name} used at line {line}"
+        for name, line in usages
+        if not any(assigned_line < line for assigned_line in assignments.get(name, []))
+    ]
+
+    assert missing == []


### PR DESCRIPTION
## Summary
- define the automation stream-matching timer before validation and assignment begin
- add a regression test that scans `run_automation_cycle` for every `time.time() - *_started` duration and verifies the matching start variable is assigned earlier in the function

## Root cause
The merged automation progress code records `stream_matching_seconds` after validation and stream assignment, but `matching_started` was never initialized in the stream-matching block. When an automation cycle reached that duration update, Python raised `NameError: name 'matching_started' is not defined` and the cycle aborted.

## Validation
- `python -m py_compile backend/apps/automation/automated_stream_manager.py`
- `python -m pytest backend/tests/test_automation_run_progress.py backend/tests/test_udi_initialization_wait.py -q`
- `python scripts/run_ci_checks.py`