### PR TITLE
Remove global stream checker dashboard lockout

### DIFF
--- a/frontend/src/lib/dashboard-run-display.js
+++ b/frontend/src/lib/dashboard-run-display.js
@@ -162,3 +162,32 @@ export const getStreamCheckerRunDisplay = ({
     streamQueueActive,
   }
 }
+
+export const getDashboardActionStates = ({
+  actionLoading = '',
+  isStreamCheckerProcessing = false,
+  udiSyncing = false,
+} = {}) => {
+  const actionBusy = actionLoading !== ''
+  const reloadUdiReason = udiSyncing
+    ? 'UDI sync is already running.'
+    : actionBusy
+      ? 'Another dashboard action is running.'
+      : null
+  const runAutomationReason = isStreamCheckerProcessing
+    ? 'Automation cannot start while a stream check is already active.'
+    : actionBusy
+      ? 'Another dashboard action is running.'
+      : null
+
+  return {
+    reloadUdi: {
+      disabled: udiSyncing || actionBusy,
+      reason: reloadUdiReason,
+    },
+    runAutomation: {
+      disabled: isStreamCheckerProcessing || actionBusy,
+      reason: runAutomationReason,
+    },
+  }
+}

--- a/frontend/src/lib/dashboard-run-display.test.js
+++ b/frontend/src/lib/dashboard-run-display.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getDashboardActionStates,
   getAutomationStageCards,
   getRunDurationValue,
   getStreamCheckerRunDisplay,
@@ -107,6 +108,33 @@ describe('dashboard stream checker run display', () => {
       },
     })
 
+    expect(display.streamCheckerElapsedSeconds).toBe(60)
+  })
+
+  it('detects active single-channel checks even when no batch queue is exposed', () => {
+    const display = getStreamCheckerRunDisplay({
+      runState: 'idle',
+      batchTotal: 0,
+      completed: 0,
+      now: Date.parse('2026-05-29T18:05:41Z'),
+      streamCheckerStatus: {
+        checking: true,
+        stream_checking_mode: true,
+        queue: {
+          queue_size: 0,
+          in_progress: 0,
+        },
+        progress: {
+          is_single_channel_check: true,
+          timestamp: '2026-05-29T18:04:41Z',
+          channel_name: 'Single Channel',
+        },
+      },
+    })
+
+    expect(display.isProcessing).toBe(true)
+    expect(display.streamCheckerOnlyActive).toBe(true)
+    expect(display.streamQueueActive).toBe(false)
     expect(display.streamCheckerElapsedSeconds).toBe(60)
   })
 
@@ -221,5 +249,28 @@ describe('dashboard stream checker run display', () => {
     })
 
     expect(value).toBe(0)
+  })
+
+  it('keeps UDI reload available during stream checks but blocks conflicting automation starts', () => {
+    const actions = getDashboardActionStates({
+      actionLoading: '',
+      isStreamCheckerProcessing: true,
+      udiSyncing: false,
+    })
+
+    expect(actions.reloadUdi.disabled).toBe(false)
+    expect(actions.runAutomation.disabled).toBe(true)
+    expect(actions.runAutomation.reason).toMatch(/stream check/i)
+  })
+
+  it('blocks dashboard actions while another action is already running', () => {
+    const actions = getDashboardActionStates({
+      actionLoading: 'udi',
+      isStreamCheckerProcessing: false,
+      udiSyncing: true,
+    })
+
+    expect(actions.reloadUdi.disabled).toBe(true)
+    expect(actions.runAutomation.disabled).toBe(true)
   })
 })

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -11,6 +11,7 @@ import { useToast } from '@/hooks/use-toast.js'
 import { automationAPI, streamCheckerAPI, shadowBlankMonitorAPI, viewerActivityAPI, m3uAPI, dispatcharrAPI, environmentAPI } from '@/services/api.js'
 import { getDashboardRunCounts } from '@/lib/dashboard-run-counts.js'
 import {
+  getDashboardActionStates,
   getAutomationStageCards,
   getRunDurationValue,
   getStreamCheckerRunDisplay,
@@ -21,7 +22,7 @@ import { formatDuration as formatDurationValue, formatLatency as formatLatencyVa
 import {
   PlayCircle, RefreshCw, Activity, CheckCircle2,
   Loader2, ChevronDown, Tv, Radio, Database, WifiOff,
-  Clock3, AlertCircle, ListChecks, Timer, Eye, Users
+  Clock3, AlertCircle, ListChecks, Timer, Eye, Users, StopCircle
 } from 'lucide-react'
 import {
   DropdownMenu,
@@ -336,6 +337,41 @@ export default function Dashboard() {
     }
   }
 
+  const handleStopActiveRun = async () => {
+    try {
+      setActionLoading('stop-run')
+
+      const activeStreamCheck = Boolean(
+        streamCheckerStatus?.stream_checking_mode ||
+        streamCheckerStatus?.checking ||
+        (streamCheckerStatus?.queue?.queue_size || 0) > 0 ||
+        (streamCheckerStatus?.queue?.in_progress || 0) > 0
+      )
+      const activeAutomationRun = Boolean(status?.running || status?.run_status?.active)
+
+      if (activeStreamCheck) {
+        await streamCheckerAPI.clearQueue()
+      }
+      if (activeAutomationRun) {
+        await automationAPI.stop()
+      }
+
+      toast({
+        title: "Stop Requested",
+        description: "Active automation and stream-check work is being stopped.",
+      })
+      await loadStatus()
+    } catch (err) {
+      toast({
+        title: "Error",
+        description: err.response?.data?.error || "Failed to stop the active run",
+        variant: "destructive",
+      })
+    } finally {
+      setActionLoading('')
+    }
+  }
+
   const handleTogglePlaylist = async (playlistId, currentlyEnabled) => {
     try {
       setTogglingPlaylist(playlistId)
@@ -417,25 +453,31 @@ export default function Dashboard() {
   const isProcessing = streamCheckerRunDisplay.isProcessing
   const streamQueueActive = streamCheckerRunDisplay.streamQueueActive
   const streamCheckerOnlyActive = streamCheckerRunDisplay.streamCheckerOnlyActive
+  const streamRunActive = streamCheckerOnlyActive
+  const streamProgress = streamCheckerStatus?.progress || {}
+  const singleStreamRunActive = streamRunActive && !streamQueueActive
   const rawRunProgressPercent = Number(runProgress.percent)
   const runProgressPercent = streamQueueActive
     ? queueProgress
+    : singleStreamRunActive && Number.isFinite(Number(streamProgress.percentage))
+      ? Number(streamProgress.percentage)
     : Number.isFinite(rawRunProgressPercent)
       ? rawRunProgressPercent
       : 0
-  const runProgressCurrent = streamQueueActive ? completed : runProgress.current
-  const runProgressTotal = streamQueueActive ? batchTotal : runProgress.total
+  const runProgressCurrent = streamQueueActive ? completed : (singleStreamRunActive ? null : runProgress.current)
+  const runProgressTotal = streamQueueActive ? batchTotal : (singleStreamRunActive ? null : runProgress.total)
   const hasRunProgressTotal = runProgressTotal !== null && runProgressTotal !== undefined
   const runProgressDetail = hasRunProgressTotal
     ? `${runProgressCurrent ?? 0} of ${runProgressTotal}`
-    : runProgress.message || runStatus.message || 'Waiting for progress'
+    : singleStreamRunActive
+      ? (streamProgress.channel_name || streamProgress.step || 'Single channel check in progress')
+      : runProgress.message || runStatus.message || 'Waiting for progress'
   const showRunProgress = isProcessing || runState !== 'idle' || Object.keys(runProgress).length > 0
-  const streamRunActive = streamQueueActive && streamCheckerOnlyActive
   const displayRunMessage = streamRunActive
     ? 'Running manual quality checks'
     : (runProgress.message || runStatus.message || 'Automation run status')
-  const displayRunStageId = normalizeRunStageKey(streamQueueActive ? 'quality_checking' : runStage)
-  const displayRunStageLabel = streamQueueActive ? 'Quality Checking' : runStageLabel
+  const displayRunStageId = normalizeRunStageKey(streamRunActive ? 'quality_checking' : runStage)
+  const displayRunStageLabel = streamRunActive ? 'Quality Checking' : runStageLabel
   const displayRunningRun = runningRun || streamRunActive
   const runDisplayStageLabel = skippedRun && !streamQueueActive ? 'Waiting for next run' : displayRunStageLabel
   const runDisplayBadgeLabel = streamRunActive
@@ -543,7 +585,12 @@ export default function Dashboard() {
       : displayRunningRun
         ? 'bg-blue-600 text-white border-transparent'
         : ''
-  const shouldDisableActions = isProcessing || actionLoading !== ''
+  const actionStates = getDashboardActionStates({
+    actionLoading,
+    isStreamCheckerProcessing: isProcessing,
+    udiSyncing,
+  })
+  const showStopRunAction = displayRunningRun || isProcessing
   const shadowWatchedCount = shadowMonitorStatus?.watched_count || shadowMonitorStatus?.watched_channels?.length || 0
   const shadowLastEvent = shadowMonitorStatus?.recent_events?.[0]
   const viewerChannels = viewerActivityStatus?.channels || []
@@ -567,22 +614,6 @@ export default function Dashboard() {
         <p className="text-muted-foreground">Monitor and control your stream automation</p>
       </div>
 
-      {/* Active Operations Alert */}
-      {isProcessing && (
-        <Alert className="border-blue-500 bg-blue-50 dark:bg-blue-950">
-          <Loader2 className="h-4 w-4 animate-spin text-blue-600" />
-          <AlertDescription className="text-blue-900 dark:text-blue-100">
-            <div className="font-medium mb-1">Stream checker is actively processing</div>
-            <div className="text-sm">
-              {completed} of {batchTotal} channels completed
-              {inProgress > 0 && ` (${inProgress} in progress, ${queueSize} in queue)`}
-            </div>
-            <Progress value={queueProgress} className="mt-2 h-2" />
-            <div className="text-xs mt-1 text-muted-foreground">Quick actions are temporarily disabled</div>
-          </AlertDescription>
-        </Alert>
-      )}
-
       {showRunProgress && (
         <Card>
           <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -593,13 +624,32 @@ export default function Dashboard() {
               </CardTitle>
               <CardDescription>{displayRunMessage}</CardDescription>
             </div>
-            <Badge variant="outline" className={`w-fit gap-1 ${runBadgeClass}`}>
-              {displayRunningRun && <Loader2 className="h-3 w-3 animate-spin" />}
-              {failedRun && <AlertCircle className="h-3 w-3" />}
-              {abortedRun && <AlertCircle className="h-3 w-3" />}
-              {completedRun && <CheckCircle2 className="h-3 w-3" />}
-              {runDisplayBadgeLabel}
-            </Badge>
+            <div className="flex flex-wrap items-center gap-2">
+              {showStopRunAction && (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleStopActiveRun}
+                  disabled={actionLoading === 'stop-run'}
+                  title="Stop the active automation or stream-check run"
+                >
+                  {actionLoading === 'stop-run' ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <StopCircle className="mr-2 h-4 w-4" />
+                  )}
+                  Stop Run
+                </Button>
+              )}
+              <Badge variant="outline" className={`w-fit gap-1 ${runBadgeClass}`}>
+                {displayRunningRun && <Loader2 className="h-3 w-3 animate-spin" />}
+                {failedRun && <AlertCircle className="h-3 w-3" />}
+                {abortedRun && <AlertCircle className="h-3 w-3" />}
+                {completedRun && <CheckCircle2 className="h-3 w-3" />}
+                {runDisplayBadgeLabel}
+              </Badge>
+            </div>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
@@ -986,8 +1036,9 @@ export default function Dashboard() {
             <div className="flex flex-col justify-center gap-3 sm:min-w-[180px]">
               <Button
                 onClick={handleReloadUDI}
-                disabled={shouldDisableActions || udiSyncing}
+                disabled={actionStates.reloadUdi.disabled}
                 className="w-full"
+                title={actionStates.reloadUdi.reason || 'Reload Dispatcharr cache'}
               >
                 {udiSyncing
                   ? <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -997,7 +1048,13 @@ export default function Dashboard() {
 
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button disabled={shouldDisableActions} variant="outline" className="w-full">
+                  <Button
+                    disabled={actionStates.runAutomation.disabled}
+                    variant="outline"
+                    className="w-full"
+                    aria-describedby={actionStates.runAutomation.reason ? 'run-automation-disabled-reason' : undefined}
+                    title={actionStates.runAutomation.reason || 'Run automation'}
+                  >
                     <PlayCircle className="mr-2 h-4 w-4" />
                     {actionLoading === 'automation' ? 'Running...' : 'Run Automation'}
                     <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
@@ -1022,6 +1079,11 @@ export default function Dashboard() {
                   )}
                 </DropdownMenuContent>
               </DropdownMenu>
+              {actionStates.runAutomation.reason && (
+                <p id="run-automation-disabled-reason" className="text-xs text-muted-foreground">
+                  {actionStates.runAutomation.reason}
+                </p>
+              )}
             </div>
           </div>
         </CardContent>


### PR DESCRIPTION
## Summary

- removes the large dashboard-wide active Stream Checker lockout banner during normal quality checking
- keeps the Automation Run card as the live progress surface for manual and automation-driven checks
- scopes disabled dashboard actions so UDI reload remains available while conflicting automation starts explain why they are blocked locally
- keeps stop/abort discoverable from the active Automation Run card

## Validation Plan

Draft until the validation below is complete:

- frontend unit tests for dashboard run/action display
- frontend production build
- targeted backend smoke where relevant
- self-hosted live validation on the current dev-based image
- final live gate: 5 quality-check channels, one single-channel check with GPU, one single-channel check without GPU/fallback, restore GPU mode, and one small final GPU run

## Changelog / Docs

This is a dashboard behavior polish PR. The PR body and final validation notes will document the behavior and live evidence; no user-guide flow changes are expected beyond the dashboard controls already visible in the UI.