### PR TITLE
V5: Last quality stats API and shadow media detection

### DIFF
--- a/backend/apps/api/scheduling_handlers.py
+++ b/backend/apps/api/scheduling_handlers.py
@@ -252,6 +252,7 @@ def test_auto_create_rule_response(*, payload: Any, get_scheduling_service: Call
             channel_group_ids=schema.channel_group_ids,
             regex_pattern=schema.regex_pattern,
             minutes_before=schema.minutes_before,
+            max_events_per_run=schema.max_events_per_run,
             force_refresh=True,
         )
         return jsonify(result)

--- a/backend/apps/api/schemas.py
+++ b/backend/apps/api/schemas.py
@@ -622,6 +622,7 @@ class AutoCreateRuleTestSchema:
     channel_group_ids: List[Any]
     regex_pattern: str
     minutes_before: int
+    max_events_per_run: Optional[int]
 
     @classmethod
     def from_payload(cls, payload: Any) -> "AutoCreateRuleTestSchema":
@@ -660,12 +661,22 @@ class AutoCreateRuleTestSchema:
         if minutes_before < 0:
             raise ValidationError("minutes_before must be 0 or greater")
 
+        max_events_per_run = None
+        if "max_events_per_run" in data:
+            try:
+                max_events_per_run = int(data.get("max_events_per_run"))
+            except (TypeError, ValueError):
+                raise ValidationError("max_events_per_run must be an integer") from None
+            if max_events_per_run < 1:
+                raise ValidationError("max_events_per_run must be 1 or greater")
+
         return cls(
             channel_id=channel_id,
             channel_ids=channel_ids,
             channel_group_ids=channel_group_ids,
             regex_pattern=str(data["regex_pattern"]),
             minutes_before=minutes_before,
+            max_events_per_run=max_events_per_run,
         )
 
 

--- a/backend/apps/api/stream_checker_handlers.py
+++ b/backend/apps/api/stream_checker_handlers.py
@@ -10,6 +10,7 @@ from apps.stream.queue_start import (
     coerce_channel_id as _coerce_channel_id,
     order_channels_for_queue_start,
 )
+from apps.telemetry.last_quality_stats import get_last_quality_stats
 
 logger = setup_logging(__name__)
 
@@ -230,6 +231,20 @@ def get_stream_checker_progress_response(*, get_stream_checker_service: Callable
         return jsonify(status.get("progress", {}))
     except Exception as exc:
         logger.error(f"Error getting stream checker progress: {exc}")
+        return jsonify({"error": "Internal Server Error"}), 500
+
+
+def get_stream_last_quality_stats_response(*, stream_id: int, stale_after_hours: Optional[float] = None):
+    """Return the latest persisted quality stats for one stream without probing it."""
+    try:
+        return jsonify(
+            get_last_quality_stats(
+                stream_id,
+                stale_after_hours=stale_after_hours,
+            )
+        )
+    except Exception as exc:
+        logger.error("Error getting last quality stats for stream %s: %s", stream_id, exc, exc_info=True)
         return jsonify({"error": "Internal Server Error"}), 500
 
 

--- a/backend/apps/api/web_api.py
+++ b/backend/apps/api/web_api.py
@@ -138,6 +138,7 @@ from apps.api.stream_checker_handlers import (
     update_stream_checker_config_response,
     get_stream_checker_config_response,
     get_stream_checker_hardware_status_response,
+    get_stream_last_quality_stats_response,
     get_stream_checker_progress_response,
     get_stream_checker_queue_response,
     start_stream_checker_response,
@@ -1292,6 +1293,17 @@ def update_stream_checker_config():
 def get_stream_checker_progress():
     """Get current checking progress."""
     return get_stream_checker_progress_response(get_stream_checker_service=get_stream_checker_service)
+
+
+@app.route('/api/stream-checker/streams/<int:stream_id>/last-quality-stats', methods=['GET'])
+def get_stream_last_quality_stats(stream_id):
+    """Get the latest persisted quality stats for a stream without probing."""
+    stale_after_hours = request.args.get("stale_after_hours", type=float)
+    return get_stream_last_quality_stats_response(
+        stream_id=stream_id,
+        stale_after_hours=stale_after_hours,
+    )
+
 
 @app.route('/api/stream-checker/check-channel', methods=['POST'])
 def check_specific_channel():

--- a/backend/apps/automation/scheduling_service.py
+++ b/backend/apps/automation/scheduling_service.py
@@ -37,6 +37,10 @@ DUPLICATE_DETECTION_WINDOW_SECONDS = 300  # 5 minutes window for detecting dupli
 EXECUTED_EVENTS_RETENTION_DAYS = 7  # Keep executed events history for 7 days
 DEFAULT_UDI_REFRESH_INTERVAL_MINUTES = 240
 AUTO_CREATE_QUEUE_PRIORITY = 90
+AUTO_CREATE_DEFAULT_MAX_EVENTS_PER_RULE_RUN = 10
+AUTO_CREATE_DEFAULT_MAX_EVENTS_PER_POLL = 25
+AUTO_CREATE_MAX_EVENTS_PER_RULE_BOUNDS = (1, 250)
+AUTO_CREATE_MAX_EVENTS_PER_POLL_BOUNDS = (1, 1000)
 
 
 # ── SCH-002 ────────────────────────────────────────────────────────────────
@@ -68,6 +72,14 @@ def _parse_dt(value: str) -> datetime:
     return dt
 
 
+def _coerce_guardrail_int(value: Any, default: int, bounds: tuple[int, int]) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(bounds[0], min(bounds[1], parsed))
+
+
 class SchedulingService:
     """
     Service for managing EPG-based scheduled channel checks.
@@ -87,6 +99,53 @@ class SchedulingService:
         self._config_dir = Path(CONFIG_DIR)
         logger.info("Scheduling service initialized")
 
+    @staticmethod
+    def _normalize_auto_create_guardrails(raw_guardrails: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        guardrails = raw_guardrails if isinstance(raw_guardrails, dict) else {}
+        return {
+            'enabled': bool(guardrails.get('enabled', True)),
+            'max_events_per_rule_run': _coerce_guardrail_int(
+                guardrails.get('max_events_per_rule_run'),
+                AUTO_CREATE_DEFAULT_MAX_EVENTS_PER_RULE_RUN,
+                AUTO_CREATE_MAX_EVENTS_PER_RULE_BOUNDS,
+            ),
+            'max_events_per_poll': _coerce_guardrail_int(
+                guardrails.get('max_events_per_poll'),
+                AUTO_CREATE_DEFAULT_MAX_EVENTS_PER_POLL,
+                AUTO_CREATE_MAX_EVENTS_PER_POLL_BOUNDS,
+            ),
+        }
+
+    def _get_auto_create_guardrails(self) -> Dict[str, Any]:
+        return self._normalize_auto_create_guardrails(self._config.get('auto_create_guardrails'))
+
+    def _normalize_rule_max_events_per_run(self, value: Any = None) -> int:
+        guardrails = self._get_auto_create_guardrails()
+        return _coerce_guardrail_int(
+            value,
+            guardrails['max_events_per_rule_run'],
+            AUTO_CREATE_MAX_EVENTS_PER_RULE_BOUNDS,
+        )
+
+    def _rule_max_events_per_run(self, rule: Dict[str, Any]) -> int:
+        return self._normalize_rule_max_events_per_run(rule.get('max_events_per_run'))
+
+    @staticmethod
+    def _guardrail_block_payload(
+        *,
+        scope: str,
+        limit: int,
+        candidate_count: int,
+        reason: str,
+    ) -> Dict[str, Any]:
+        return {
+            'blocked': True,
+            'scope': scope,
+            'limit': limit,
+            'candidate_count': candidate_count,
+            'reason': reason,
+        }
+
     def _get_regex_matcher(self):
         """Get or create regex matcher instance (singleton pattern)."""
         if self._regex_matcher is None:
@@ -105,6 +164,11 @@ class SchedulingService:
             'epg_schedule': {'type': 'interval', 'value': 60},
             'epg_refresh_interval_minutes': 60,
             'udi_refresh_schedule': {'type': 'interval', 'value': DEFAULT_UDI_REFRESH_INTERVAL_MINUTES},
+            'auto_create_guardrails': {
+                'enabled': True,
+                'max_events_per_rule_run': AUTO_CREATE_DEFAULT_MAX_EVENTS_PER_RULE_RUN,
+                'max_events_per_poll': AUTO_CREATE_DEFAULT_MAX_EVENTS_PER_POLL,
+            },
             'enabled': True
         }
         from apps.database.connection import get_session
@@ -137,6 +201,12 @@ class SchedulingService:
                     config['epg_refresh_interval_minutes'] = int(
                         config.get('epg_schedule', {}).get('value', 60)
                     )
+                normalized_guardrails = self._normalize_auto_create_guardrails(
+                    config.get('auto_create_guardrails')
+                )
+                if config.get('auto_create_guardrails') != normalized_guardrails:
+                    config['auto_create_guardrails'] = normalized_guardrails
+                    needs_save = True
 
                 # Persist only when something actually changed
                 if needs_save:
@@ -151,6 +221,9 @@ class SchedulingService:
             session.rollback()
         finally:
             session.close()
+        default_config['auto_create_guardrails'] = self._normalize_auto_create_guardrails(
+            default_config.get('auto_create_guardrails')
+        )
         return default_config
 
     def _save_config(self) -> bool:
@@ -389,7 +462,14 @@ class SchedulingService:
 
     def update_config(self, config: Dict[str, Any]) -> bool:
         with self._lock:
-            self._config.update(config)
+            next_config = dict(config or {})
+            if 'auto_create_guardrails' in next_config:
+                next_config['auto_create_guardrails'] = self._normalize_auto_create_guardrails(
+                    next_config.get('auto_create_guardrails')
+                )
+            self._config.update(next_config)
+            if 'auto_create_guardrails' not in self._config:
+                self._config['auto_create_guardrails'] = self._normalize_auto_create_guardrails(None)
             return self._save_config()
 
     def get_epg_schedule(self) -> dict:
@@ -1085,6 +1165,7 @@ class SchedulingService:
         target['channel_group_ids'] = channel_group_ids
         target['channel_groups_info'] = channel_groups_info
         target['channels_info'] = channels_info
+        target['max_events_per_run'] = self._rule_max_events_per_run(rule)
 
         if channels_info:
             target['channel_id'] = channels_info[0]['id']
@@ -1152,6 +1233,9 @@ class SchedulingService:
                 'channels_info': channels_info,
                 'regex_pattern': rule_data['regex_pattern'],
                 'minutes_before': rule_data.get('minutes_before', 5),
+                'max_events_per_run': self._normalize_rule_max_events_per_run(
+                    rule_data.get('max_events_per_run')
+                ),
                 'schedule_type': schedule_type,
                 'enable_looping_detection': rule_data.get('enable_looping_detection', True),
                 'enable_logo_detection': rule_data.get('enable_logo_detection', True),
@@ -1232,6 +1316,13 @@ class SchedulingService:
                           'enable_looping_detection', 'enable_logo_detection']:
                 if field in rule_data:
                     rule[field] = rule_data[field]
+
+            if 'max_events_per_run' in rule_data:
+                rule['max_events_per_run'] = self._normalize_rule_max_events_per_run(
+                    rule_data.get('max_events_per_run')
+                )
+            elif 'max_events_per_run' not in rule:
+                rule['max_events_per_run'] = self._normalize_rule_max_events_per_run(None)
 
             self._auto_create_rules[rule_index] = rule
             if not self._save_auto_create_rules():
@@ -1326,6 +1417,7 @@ class SchedulingService:
         channel_group_ids: Optional[List[Any]] = None,
         regex_pattern: str,
         minutes_before: int = 0,
+        max_events_per_run: Optional[int] = None,
         force_refresh: bool = False,
     ) -> Dict[str, Any]:
         """Test an auto-create regex against every selected channel and group channel."""
@@ -1507,10 +1599,30 @@ class SchedulingService:
         )
 
         schedulable_matches = len(matching_programs)
+        guardrails = self._get_auto_create_guardrails()
+        guardrail = {'blocked': False}
+        guardrail_blocked_programs: List[Dict[str, Any]] = []
+        if guardrails.get('enabled', True):
+            rule_limit = self._normalize_rule_max_events_per_run(max_events_per_run)
+            if schedulable_matches > rule_limit:
+                guardrail = self._guardrail_block_payload(
+                    scope='rule',
+                    limit=rule_limit,
+                    candidate_count=schedulable_matches,
+                    reason='max_events_per_rule_run',
+                )
+                guardrail_blocked_programs = matching_programs[:10]
+                matching_programs = []
+                schedulable_matches = 0
+                channels_with_matches = set()
+
         return {
             'matches': schedulable_matches,
             'total_epg_matches': total_epg_matches,
             'schedulable_matches': schedulable_matches,
+            'guardrail': guardrail,
+            'guardrail_blocked_matches': guardrail.get('candidate_count', 0) if guardrail.get('blocked') else 0,
+            'guardrail_blocked_programs': guardrail_blocked_programs,
             'future_matches': future_matches,
             'due_now_matches': due_now_matches,
             'ended_matches': ended_matches,
@@ -1573,6 +1685,9 @@ class SchedulingService:
 
             udi = get_udi_manager()
             programs_by_epg_key: Dict[tuple, List] = {}
+            guardrails = self._get_auto_create_guardrails()
+            guardrail_blocked_count = 0
+            guardrail_blocked_rules: List[Dict[str, Any]] = []
 
             # Build a lookup of existing auto-created events keyed by
             # (channel_id, rule_id, program_start_time) for O(1) deduplication.
@@ -1595,6 +1710,8 @@ class SchedulingService:
                 rule_name = rule.get('name', rule_id)
                 regex_pattern = rule.get('regex_pattern')
                 minutes_before = rule.get('minutes_before', 5)
+                rule_events_start_index = len(events_to_add)
+                created_before_rule = created_count
 
                 # Bug 4: reject empty pattern — it would match every program
                 if not regex_pattern or not regex_pattern.strip():
@@ -1764,6 +1881,49 @@ class SchedulingService:
                         existing_keys[dedup_key] = new_event
                         created_count += 1
 
+                if guardrails.get('enabled', True):
+                    rule_new_count = len(events_to_add) - rule_events_start_index
+                    rule_limit = self._rule_max_events_per_run(rule)
+                    poll_limit = guardrails['max_events_per_poll']
+                    blocked_reason = None
+                    blocked_limit = rule_limit
+                    blocked_scope = 'rule'
+                    if rule_new_count > rule_limit:
+                        blocked_reason = 'max_events_per_rule_run'
+                    elif len(events_to_add) > poll_limit:
+                        blocked_reason = 'max_events_per_poll'
+                        blocked_limit = poll_limit
+                        blocked_scope = 'poll'
+
+                    if blocked_reason:
+                        blocked_events = events_to_add[rule_events_start_index:]
+                        for blocked_event in blocked_events:
+                            existing_keys.pop((
+                                blocked_event.get('channel_id'),
+                                blocked_event.get('auto_create_rule_id'),
+                                blocked_event.get('program_start_time'),
+                            ), None)
+                        del events_to_add[rule_events_start_index:]
+                        created_count = created_before_rule
+                        guardrail_blocked_count += rule_new_count
+                        guardrail_blocked_rules.append({
+                            'rule_id': rule_id,
+                            'rule_name': rule_name,
+                            'scope': blocked_scope,
+                            'reason': blocked_reason,
+                            'limit': blocked_limit,
+                            'candidate_count': rule_new_count,
+                        })
+                        logger.warning(
+                            "Auto-create guardrail blocked rule '%s' (%s): %s "
+                            "candidate events exceeds limit %s (%s)",
+                            rule_name,
+                            rule_id,
+                            rule_new_count,
+                            blocked_limit,
+                            blocked_reason,
+                        )
+
             if events_to_add:
                 self._scheduled_events.extend(events_to_add)
             if events_to_add or updated_count:
@@ -1775,7 +1935,8 @@ class SchedulingService:
             f"({matched_count} matched; {future_match_count} future, "
             f"{due_now_match_count} due now, {ended_match_count} ended, "
             f"{already_checked_count} already checked, "
-            f"{missing_time_count} missing time, {invalid_time_count} invalid time)"
+            f"{missing_time_count} missing time, {invalid_time_count} invalid time, "
+            f"{guardrail_blocked_count} guardrail blocked)"
         )
         return {
             'created': created_count,
@@ -1788,6 +1949,8 @@ class SchedulingService:
             'already_checked_matches': already_checked_count,
             'missing_time_matches': missing_time_count,
             'invalid_time_matches': invalid_time_count,
+            'guardrail_blocked_matches': guardrail_blocked_count,
+            'guardrail_blocked_rules': guardrail_blocked_rules,
         }
 
     def execute_scheduled_check(self, event_id: str, stream_checker_service) -> bool:
@@ -2308,6 +2471,7 @@ class SchedulingService:
                 'channel_group_ids': rule.get('channel_group_ids', []),
                 'regex_pattern': rule.get('regex_pattern'),
                 'minutes_before': rule.get('minutes_before', 5),
+                'max_events_per_run': self._rule_max_events_per_run(rule),
             }
             if len(exported_rule['channel_ids']) == 1 and not exported_rule['channel_group_ids']:
                 exported_rule['channel_id'] = exported_rule['channel_ids'][0]
@@ -2369,6 +2533,9 @@ class SchedulingService:
                                 existing_group_ids == import_group_ids_set):
                             matching_rule['name'] = import_name
                             matching_rule['minutes_before'] = rule_data.get('minutes_before', 5)
+                            matching_rule['max_events_per_run'] = self._normalize_rule_max_events_per_run(
+                                rule_data.get('max_events_per_run')
+                            )
                             if not self._save_auto_create_rules():
                                 raise IOError("Failed to save replaced rule")
                             replaced_count += 1
@@ -2385,6 +2552,9 @@ class SchedulingService:
                                     })
                             matching_rule['channel_ids'] = all_ids
                             matching_rule['channels_info'] = channels_info
+                            matching_rule['max_events_per_run'] = self._normalize_rule_max_events_per_run(
+                                rule_data.get('max_events_per_run')
+                            )
                             if not self._save_auto_create_rules():
                                 raise IOError("Failed to save merged rule")
                             merged_count += 1

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -909,7 +909,8 @@ class ShadowBlankMonitorService:
             excluded_stream_ids=excluded_stream_ids,
         ):
             candidate_ref = _ref("stream", candidate_id)
-            candidate_url = self._stream_url_for_id(udi, target.get("channel_id"), candidate_id)
+            candidate_stream = self._stream_for_id(udi, target.get("channel_id"), candidate_id)
+            candidate_url = self._stream_url(candidate_stream)
             details: Dict[str, Any] = {
                 "enabled": True,
                 "target_stream_ref": candidate_ref,
@@ -921,7 +922,22 @@ class ShadowBlankMonitorService:
                 self._record_event("pre_probe_unavailable", target, {**details, "reason": reason})
                 continue
 
-            probe_result = self._run_next_stream_pre_probe(candidate_url, config)
+            provider_slot = self._acquire_pre_probe_provider_slot(udi, candidate_stream)
+            details.update(provider_slot.get("details") or {})
+            if not provider_slot.get("acquired"):
+                details["result"] = "rejected"
+                details["rejection_reason"] = provider_slot.get("reason") or "provider_capacity"
+                last_details = details
+                self._record_event("pre_probe_rejected", target, {**details, "reason": reason})
+                continue
+
+            try:
+                probe_result = self._run_next_stream_pre_probe(
+                    str(provider_slot.get("url") or candidate_url),
+                    config,
+                )
+            finally:
+                self._release_pre_probe_provider_slot(provider_slot)
             rejection_reason = self._pre_probe_rejection_reason(probe_result)
             details.update({
                 "result": "rejected" if rejection_reason else "ok",
@@ -940,7 +956,7 @@ class ShadowBlankMonitorService:
             return candidate_id, details
         return None, last_details
 
-    def _stream_url_for_id(self, udi: Any, channel_id: Optional[int], stream_id: int) -> Optional[str]:
+    def _stream_for_id(self, udi: Any, channel_id: Optional[int], stream_id: int) -> Optional[Dict[str, Any]]:
         stream: Optional[Dict[str, Any]] = None
         if hasattr(udi, "get_stream_by_id"):
             stream = udi.get_stream_by_id(stream_id)
@@ -954,10 +970,121 @@ class ShadowBlankMonitorService:
                 ),
                 None,
             )
+        return stream if isinstance(stream, dict) else None
+
+    @staticmethod
+    def _stream_url(stream: Optional[Dict[str, Any]]) -> Optional[str]:
         if not isinstance(stream, dict):
             return None
         url = str(stream.get("url") or "").strip()
         return url or None
+
+    @staticmethod
+    def _stream_m3u_account_id(stream: Optional[Dict[str, Any]]) -> Optional[int]:
+        if not isinstance(stream, dict):
+            return None
+        account_id = stream.get("m3u_account_id")
+        if account_id in (None, ""):
+            account_id = stream.get("m3u_account")
+        try:
+            return int(account_id) if account_id not in (None, "") else None
+        except (TypeError, ValueError):
+            return None
+
+    def _acquire_pre_probe_provider_slot(
+        self,
+        udi: Any,
+        stream: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        account_id = self._stream_m3u_account_id(stream)
+        details: Dict[str, Any] = {"provider_limited": account_id is not None}
+        if account_id is not None:
+            details["m3u_account_ref"] = _ref("m3u_account", account_id)
+
+        if account_id is None:
+            return {
+                "acquired": True,
+                "reason": "custom_stream",
+                "url": self._stream_url(stream),
+                "details": details,
+            }
+
+        try:
+            from apps.stream.concurrent_stream_limiter import (
+                get_account_limiter,
+                initialize_account_limits,
+            )
+
+            limiter = get_account_limiter()
+            limiter.udi_manager = udi
+            if hasattr(udi, "get_m3u_accounts"):
+                accounts = udi.get_m3u_accounts() or []
+                if accounts:
+                    initialize_account_limits(accounts)
+
+            acquired, limit_reason = limiter.acquire(account_id, timeout=0)
+            if not acquired:
+                details["provider_limit_reason"] = limit_reason
+                return {
+                    "acquired": False,
+                    "reason": limit_reason or "provider_capacity",
+                    "details": details,
+                }
+
+            profile_acquired = False
+            profile = None
+            try:
+                profile_acquired, profile_reason, profile = limiter.reserve_profile_for_stream(stream or {})
+                if not profile_acquired:
+                    details["provider_limit_reason"] = profile_reason
+                    limiter.release(account_id)
+                    return {
+                        "acquired": False,
+                        "reason": profile_reason or "provider_capacity",
+                        "details": details,
+                    }
+
+                url = self._stream_url(stream)
+                if profile and hasattr(udi, "apply_profile_url_transformation"):
+                    transformed_url = udi.apply_profile_url_transformation(stream or {}, profile=profile)
+                    if transformed_url:
+                        url = str(transformed_url)
+                        details["profile_url_transformed"] = True
+                if profile:
+                    details["m3u_profile_ref"] = _ref("m3u_profile", profile.get("id"))
+                details["provider_slot_acquired"] = True
+                return {
+                    "acquired": True,
+                    "reason": "acquired",
+                    "limiter": limiter,
+                    "account_id": account_id,
+                    "profile": profile,
+                    "url": url,
+                    "details": details,
+                }
+            except Exception:
+                if profile_acquired and profile is not None:
+                    limiter.release_profile(profile)
+                limiter.release(account_id)
+                raise
+        except Exception as exc:
+            logger.warning("Shadow next-stream pre-probe provider limit check failed: %s", exc)
+            details["provider_limit_reason"] = type(exc).__name__
+            return {
+                "acquired": False,
+                "reason": "provider_limit_unavailable",
+                "details": details,
+            }
+
+    @staticmethod
+    def _release_pre_probe_provider_slot(slot: Dict[str, Any]) -> None:
+        limiter = slot.get("limiter")
+        if limiter is None:
+            return
+        try:
+            limiter.release_profile(slot.get("profile"))
+        finally:
+            limiter.release(slot.get("account_id"))
 
     def _run_next_stream_pre_probe(self, url: str, config: Dict[str, Any]) -> Dict[str, Any]:
         pre_probe_config = dict(config)

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -8,6 +8,7 @@ channel should receive only one extra local downstream client during a probe.
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import os
 import queue
@@ -54,6 +55,29 @@ NO_DECODABLE_FRAME_ERROR_PATTERNS = (
     "no frame could be decoded",
 )
 FFMPEG_FRAME_RE = re.compile(r"\bframe=\s*(?P<frames>\d+)")
+SILENCE_START_RE = re.compile(r"silence_start:\s*(?P<start>\d+(?:\.\d+)?)")
+SILENCE_END_RE = re.compile(r"silence_end:\s*(?P<end>\d+(?:\.\d+)?)")
+SILENCE_DURATION_RE = re.compile(r"silence_duration:\s*(?P<duration>\d+(?:\.\d+)?)")
+AUDIO_MISSING_PATTERNS = (
+    "matches no streams",
+    "stream specifier",
+    "no audio stream",
+)
+AUDIO_ERROR_PATTERNS = (
+    "error while decoding stream",
+    "audio decoding failed",
+    "audio decode error",
+    "invalid audio",
+    "corrupt audio",
+)
+AUDIO_DECODER_RE = re.compile(r"^\[(?:aac|ac3|eac3|mp2|mp3float|opus|vorbis|flac|truehd|dca)\s+@")
+AUDIO_DECODER_ERROR_PATTERNS = (
+    "channel element",
+    "error decoding",
+    "decode error",
+    "invalid",
+    "not allocated",
+)
 
 DEFAULT_CONFIG: Dict[str, Any] = {
     "enabled": False,
@@ -71,6 +95,15 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "freeze_ratio_threshold": 0.80,
     "no_decodable_frames_detection_enabled": True,
     "no_decodable_frames_min_duration_seconds": 10.0,
+    "garbled_audio_detection_enabled": False,
+    "garbled_audio_error_threshold": 3,
+    "silent_audio_detection_enabled": False,
+    "silent_audio_min_duration_seconds": 10.0,
+    "silent_audio_noise_db": -50,
+    "offline_image_detection_enabled": False,
+    "offline_image_reference_hashes": [],
+    "offline_image_hash_threshold": 4,
+    "offline_image_capture_offset_seconds": 3,
     "confirmation_count": 2,
     "channel_cooldown_seconds": 300,
     "max_switches_per_hour": 3,
@@ -92,6 +125,10 @@ INT_BOUNDS = {
     "channel_cooldown_seconds": (30, 86400),
     "max_switches_per_hour": (1, 20),
     "max_concurrent_watchers": (1, 10),
+    "garbled_audio_error_threshold": (1, 20),
+    "silent_audio_noise_db": (-90, -20),
+    "offline_image_hash_threshold": (0, 20),
+    "offline_image_capture_offset_seconds": (0, 30),
 }
 
 FLOAT_BOUNDS = {
@@ -102,6 +139,7 @@ FLOAT_BOUNDS = {
     "freeze_noise_threshold": (0.0, 1.0),
     "freeze_ratio_threshold": (0.1, 1.0),
     "no_decodable_frames_min_duration_seconds": (3.0, 60.0),
+    "silent_audio_min_duration_seconds": (2.0, 60.0),
 }
 
 
@@ -152,6 +190,9 @@ def normalize_config(payload: Optional[Dict[str, Any]], current: Optional[Dict[s
     config["dry_run"] = bool(config.get("dry_run"))
     config["freeze_detection_enabled"] = bool(config.get("freeze_detection_enabled"))
     config["no_decodable_frames_detection_enabled"] = bool(config.get("no_decodable_frames_detection_enabled"))
+    config["garbled_audio_detection_enabled"] = bool(config.get("garbled_audio_detection_enabled"))
+    config["silent_audio_detection_enabled"] = bool(config.get("silent_audio_detection_enabled"))
+    config["offline_image_detection_enabled"] = bool(config.get("offline_image_detection_enabled"))
     config["watch_mode"] = str(config.get("watch_mode") or DEFAULT_CONFIG["watch_mode"]).strip().lower()
     if config["watch_mode"] not in WATCH_MODES:
         config["watch_mode"] = DEFAULT_CONFIG["watch_mode"]
@@ -168,6 +209,11 @@ def normalize_config(payload: Optional[Dict[str, Any]], current: Optional[Dict[s
     config["excluded_channel_uuids"] = [
         str(item).strip()
         for item in _coerce_list(config.get("excluded_channel_uuids"))
+        if str(item).strip()
+    ]
+    config["offline_image_reference_hashes"] = [
+        str(item).strip().lower()
+        for item in _coerce_list(config.get("offline_image_reference_hashes"))
         if str(item).strip()
     ]
     return config
@@ -611,10 +657,32 @@ class ShadowBlankMonitorService:
             blank = bool(result.get("blank_detected"))
             freeze = bool(result.get("freeze_detected"))
             no_decodable_frames = bool(result.get("no_decodable_frames_detected"))
-            detection_reason = (
-                "blank"
-                if blank
-                else ("freeze" if freeze else ("no_decodable_frames" if no_decodable_frames else ""))
+            garbled_audio = bool(
+                config.get("garbled_audio_detection_enabled")
+                and result.get("garbled_audio_detected")
+            )
+            silent_audio = bool(
+                config.get("silent_audio_detection_enabled")
+                and result.get("silent_audio_detected")
+            )
+            offline_image = bool(
+                config.get("offline_image_detection_enabled")
+                and result.get("offline_image_detected")
+            )
+            detection_reason = next(
+                (
+                    reason
+                    for reason, detected in (
+                        ("blank", blank),
+                        ("offline_image", offline_image),
+                        ("freeze", freeze),
+                        ("no_decodable_frames", no_decodable_frames),
+                        ("garbled_audio", garbled_audio),
+                        ("silent_audio", silent_audio),
+                    )
+                    if detected
+                ),
+                "",
             )
             target["last_probe"] = {
                 "blank_detected": blank,
@@ -626,6 +694,15 @@ class ShadowBlankMonitorService:
                 "no_decodable_frames_detected": no_decodable_frames,
                 "no_decodable_frames_duration_secs": result.get("no_decodable_frames_duration_secs"),
                 "no_decodable_frames_error": result.get("no_decodable_frames_error"),
+                "garbled_audio_detected": garbled_audio,
+                "garbled_audio_error_count": result.get("garbled_audio_error_count"),
+                "garbled_audio_error": result.get("garbled_audio_error"),
+                "silent_audio_detected": silent_audio,
+                "silent_audio_duration_secs": result.get("silent_audio_duration_secs"),
+                "silent_audio_noise_db": result.get("silent_audio_noise_db"),
+                "offline_image_detected": offline_image,
+                "offline_image_hash": result.get("offline_image_hash"),
+                "offline_image_distance": result.get("offline_image_distance"),
             }
 
             if result.get("viewer_left"):
@@ -779,6 +856,9 @@ class ShadowBlankMonitorService:
             self._blank_counts.pop(self._detection_count_key(channel_uuid, "blank"), None)
             self._blank_counts.pop(self._detection_count_key(channel_uuid, "freeze"), None)
             self._blank_counts.pop(self._detection_count_key(channel_uuid, "no_decodable_frames"), None)
+            self._blank_counts.pop(self._detection_count_key(channel_uuid, "garbled_audio"), None)
+            self._blank_counts.pop(self._detection_count_key(channel_uuid, "silent_audio"), None)
+            self._blank_counts.pop(self._detection_count_key(channel_uuid, "offline_image"), None)
 
     def _reset_detection_state(self, channel_uuid: str) -> None:
         self._reset_blank_count(channel_uuid)
@@ -879,22 +959,215 @@ class ShadowBlankMonitorService:
                 f"freezedetect=n={float(config['freeze_noise_threshold'])}:"
                 f"d={float(config['freeze_min_duration_seconds'])}"
             )
-        command.extend(
-            [
-                "-i",
-                url,
-                "-vf",
-                ",".join(video_filters),
-                "-an",
-                "-f",
-                "null",
-                "-",
-            ]
-        )
+        command.extend(["-i", url, "-vf", ",".join(video_filters)])
+        if config.get("garbled_audio_detection_enabled") or config.get("silent_audio_detection_enabled"):
+            audio_filters: List[str] = []
+            if config.get("silent_audio_detection_enabled"):
+                audio_filters.append(
+                    "silencedetect="
+                    f"n={int(config['silent_audio_noise_db'])}dB:"
+                    f"d={float(config['silent_audio_min_duration_seconds'])}"
+                )
+            audio_filters.append("astats=metadata=1:reset=1")
+            command.extend(["-af", ",".join(audio_filters)])
+        else:
+            command.append("-an")
+        command.extend(["-f", "null", "-"])
         if not continuous:
             input_index = command.index("-vf")
             command[input_index:input_index] = ["-t", str(duration)]
         return command, duration
+
+    @staticmethod
+    def _line_is_missing_audio(line: str) -> bool:
+        lowered = (line or "").lower()
+        return any(pattern in lowered for pattern in AUDIO_MISSING_PATTERNS) and (
+            "audio" in lowered or ":a" in lowered
+        )
+
+    @staticmethod
+    def _line_is_garbled_audio(line: str) -> bool:
+        lowered = (line or "").lower()
+        if not lowered or ShadowBlankMonitorService._line_is_missing_audio(lowered):
+            return False
+        if any(pattern in lowered for pattern in AUDIO_ERROR_PATTERNS):
+            return "audio" in lowered or ":a" in lowered or AUDIO_DECODER_RE.search(lowered) is not None
+        if AUDIO_DECODER_RE.search(lowered) is None:
+            return False
+        return any(pattern in lowered for pattern in AUDIO_DECODER_ERROR_PATTERNS)
+
+    @staticmethod
+    def _parse_audio_detection(
+        output: str,
+        config: Dict[str, Any],
+        *,
+        observed_duration: float,
+    ) -> Dict[str, Any]:
+        result = {
+            "garbled_audio_detected": False,
+            "garbled_audio_error_count": 0,
+            "garbled_audio_error": None,
+            "silent_audio_detected": False,
+            "silent_audio_duration_secs": None,
+            "silent_audio_noise_db": None,
+            "audio_stream_present": None,
+        }
+        if not (
+            config.get("garbled_audio_detection_enabled")
+            or config.get("silent_audio_detection_enabled")
+        ):
+            return result
+
+        output = output or ""
+        audio_missing = False
+        garbled_count = 0
+        first_garbled_line: Optional[str] = None
+        active_silence_start: Optional[float] = None
+        longest_silence = 0.0
+
+        for line in output.splitlines():
+            if ShadowBlankMonitorService._line_is_missing_audio(line):
+                audio_missing = True
+                continue
+            if ShadowBlankMonitorService._line_is_garbled_audio(line):
+                garbled_count += 1
+                first_garbled_line = first_garbled_line or line.strip()[:160]
+
+            silence_start = SILENCE_START_RE.search(line)
+            if silence_start:
+                try:
+                    active_silence_start = max(0.0, float(silence_start.group("start")))
+                except (TypeError, ValueError):
+                    active_silence_start = None
+
+            silence_duration = SILENCE_DURATION_RE.search(line)
+            if silence_duration:
+                try:
+                    longest_silence = max(longest_silence, float(silence_duration.group("duration")))
+                except (TypeError, ValueError):
+                    pass
+                active_silence_start = None
+                continue
+
+            silence_end = SILENCE_END_RE.search(line)
+            if silence_end and active_silence_start is not None:
+                try:
+                    longest_silence = max(
+                        longest_silence,
+                        max(0.0, float(silence_end.group("end")) - active_silence_start),
+                    )
+                except (TypeError, ValueError):
+                    pass
+                active_silence_start = None
+
+        if active_silence_start is not None:
+            longest_silence = max(longest_silence, max(0.0, float(observed_duration or 0.0) - active_silence_start))
+
+        result["audio_stream_present"] = not audio_missing if (audio_missing or garbled_count or longest_silence) else None
+        if audio_missing:
+            return result
+
+        if config.get("garbled_audio_detection_enabled"):
+            threshold = int(config.get("garbled_audio_error_threshold", DEFAULT_CONFIG["garbled_audio_error_threshold"]))
+            result["garbled_audio_error_count"] = garbled_count
+            if garbled_count >= threshold:
+                result["garbled_audio_detected"] = True
+                result["garbled_audio_error"] = first_garbled_line or "audio_decode_errors"
+
+        if config.get("silent_audio_detection_enabled"):
+            min_duration = float(
+                config.get(
+                    "silent_audio_min_duration_seconds",
+                    DEFAULT_CONFIG["silent_audio_min_duration_seconds"],
+                )
+            )
+            result["silent_audio_duration_secs"] = round(longest_silence, 3) if longest_silence else None
+            result["silent_audio_noise_db"] = int(config.get("silent_audio_noise_db", DEFAULT_CONFIG["silent_audio_noise_db"]))
+            if longest_silence >= min_duration:
+                result["silent_audio_detected"] = True
+
+        return result
+
+    @staticmethod
+    def _offline_image_probe_command(url: str, config: Dict[str, Any]) -> List[str]:
+        headers = ""
+        api_key = config.get("watcher_api_key")
+        if api_key:
+            headers = f"X-API-Key: {api_key}\r\nAuthorization: ApiKey {api_key}\r\n"
+        command = [
+            "ffmpeg",
+            "-hide_banner",
+            "-nostdin",
+            "-loglevel",
+            "error",
+            "-user_agent",
+            config.get("watcher_user_agent") or DEFAULT_CONFIG["watcher_user_agent"],
+        ]
+        if headers:
+            command.extend(["-headers", headers])
+        offset = int(config.get("offline_image_capture_offset_seconds", 3))
+        if offset > 0:
+            command.extend(["-ss", str(offset)])
+        command.extend(["-i", url, "-frames:v", "1", "-f", "image2pipe", "-vcodec", "png", "-"])
+        return command
+
+    @staticmethod
+    def _hash_distance(left: str, right: str) -> Optional[int]:
+        try:
+            return bin(int(left, 16) ^ int(right, 16)).count("1")
+        except (TypeError, ValueError):
+            return None
+
+    def _run_offline_image_probe(self, url: str, config: Dict[str, Any]) -> Dict[str, Any]:
+        result = {
+            "offline_image_detected": False,
+            "offline_image_hash": None,
+            "offline_image_distance": None,
+            "offline_image_reference_count": len(config.get("offline_image_reference_hashes") or []),
+        }
+        if not config.get("offline_image_detection_enabled"):
+            return result
+        reference_hashes = list(config.get("offline_image_reference_hashes") or [])
+        if not reference_hashes:
+            return result
+
+        try:
+            from PIL import Image
+            import imagehash
+        except Exception as exc:
+            result["offline_image_error"] = f"image_hash_unavailable:{type(exc).__name__}"
+            return result
+
+        try:
+            completed = subprocess.run(
+                self._offline_image_probe_command(url, config),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=15,
+            )
+            if completed.returncode != 0 or not completed.stdout:
+                result["offline_image_error"] = "frame_capture_failed"
+                return result
+
+            image = Image.open(io.BytesIO(completed.stdout))
+            phash = str(imagehash.phash(image)).lower()
+            result["offline_image_hash"] = phash
+            distances = [
+                distance
+                for distance in (self._hash_distance(phash, candidate) for candidate in reference_hashes)
+                if distance is not None
+            ]
+            if not distances:
+                return result
+            best_distance = min(distances)
+            result["offline_image_distance"] = best_distance
+            if best_distance <= int(config.get("offline_image_hash_threshold", 4)):
+                result["offline_image_detected"] = True
+            return result
+        except Exception as exc:
+            logger.debug("Shadow offline image probe failed: %s", exc)
+            result["offline_image_error"] = type(exc).__name__
+            return result
 
     @staticmethod
     def _parse_no_decodable_frames_detection(
@@ -981,12 +1254,18 @@ class ShadowBlankMonitorService:
                     duration,
                     freeze_ratio_threshold=float(config["freeze_ratio_threshold"]),
                 ))
+            parsed.update(self._parse_audio_detection(
+                output,
+                config,
+                observed_duration=elapsed,
+            ))
             parsed.update(self._parse_no_decodable_frames_detection(
                 output,
                 config,
                 observed_duration=elapsed,
                 returncode=completed.returncode,
             ))
+            parsed.update(self._run_offline_image_probe(url, config))
             parsed["returncode"] = completed.returncode
             return parsed
         except subprocess.TimeoutExpired as exc:
@@ -1002,12 +1281,18 @@ class ShadowBlankMonitorService:
                     duration,
                     freeze_ratio_threshold=float(config["freeze_ratio_threshold"]),
                 ))
+            parsed.update(self._parse_audio_detection(
+                output,
+                config,
+                observed_duration=duration,
+            ))
             parsed.update(self._parse_no_decodable_frames_detection(
                 output,
                 config,
                 observed_duration=duration,
                 returncode=None,
             ))
+            parsed.update(self._run_offline_image_probe(url, config))
             parsed["timeout"] = True
             return parsed
 
@@ -1019,12 +1304,26 @@ class ShadowBlankMonitorService:
         target: Dict[str, Any],
     ) -> Dict[str, Any]:
         command, duration = self._blank_probe_command(url, config, continuous=True)
+        offline_image_probe = self._run_offline_image_probe(url, config)
+        if offline_image_probe.get("offline_image_detected"):
+            return {
+                "blank_detected": False,
+                "freeze_detected": False,
+                "no_decodable_frames_detected": False,
+                "garbled_audio_detected": False,
+                "silent_audio_detected": False,
+                **offline_image_probe,
+            }
         viewer_left = False
         stopped = False
         detected_reason = ""
         detected_duration = 0.0
         no_decodable_error: Optional[str] = None
         no_decodable_first_seen_wall: Optional[float] = None
+        garbled_audio_errors = 0
+        first_garbled_audio_error: Optional[str] = None
+        active_silence_start: Optional[float] = None
+        active_silence_wall: Optional[float] = None
         decoded_frames = 0
         lines: List[str] = []
         line_queue: queue.Queue[str] = queue.Queue()
@@ -1070,6 +1369,18 @@ class ShadowBlankMonitorService:
                 config.get(
                     "no_decodable_frames_min_duration_seconds",
                     DEFAULT_CONFIG["no_decodable_frames_min_duration_seconds"],
+                )
+            )
+            silent_audio_required = float(
+                config.get(
+                    "silent_audio_min_duration_seconds",
+                    DEFAULT_CONFIG["silent_audio_min_duration_seconds"],
+                )
+            )
+            garbled_audio_threshold = int(
+                config.get(
+                    "garbled_audio_error_threshold",
+                    DEFAULT_CONFIG["garbled_audio_error_threshold"],
                 )
             )
             last_media_time = 0.0
@@ -1118,6 +1429,47 @@ class ShadowBlankMonitorService:
                             decoded_frames = max(decoded_frames, int(frame_match.group("frames")))
                         except (TypeError, ValueError):
                             continue
+
+                    if config.get("garbled_audio_detection_enabled") and self._line_is_garbled_audio(line):
+                        garbled_audio_errors += 1
+                        first_garbled_audio_error = first_garbled_audio_error or line.strip()[:160]
+                        if garbled_audio_errors >= garbled_audio_threshold:
+                            if mark_detection("garbled_audio", 0.0):
+                                break
+
+                    if config.get("silent_audio_detection_enabled"):
+                        silence_start = SILENCE_START_RE.search(line)
+                        if silence_start:
+                            try:
+                                active_silence_start = max(0.0, float(silence_start.group("start")))
+                                active_silence_wall = now
+                            except (TypeError, ValueError):
+                                active_silence_start = None
+                                active_silence_wall = None
+
+                        silence_duration = SILENCE_DURATION_RE.search(line)
+                        if silence_duration:
+                            try:
+                                silence_secs = max(0.0, float(silence_duration.group("duration")))
+                            except (TypeError, ValueError):
+                                silence_secs = 0.0
+                            active_silence_start = None
+                            active_silence_wall = None
+                            if silence_secs >= silent_audio_required:
+                                if mark_detection("silent_audio", silence_secs):
+                                    break
+
+                        silence_end = SILENCE_END_RE.search(line)
+                        if silence_end and active_silence_start is not None:
+                            try:
+                                silence_secs = max(0.0, float(silence_end.group("end")) - active_silence_start)
+                            except (TypeError, ValueError):
+                                silence_secs = 0.0
+                            active_silence_start = None
+                            active_silence_wall = None
+                            if silence_secs >= silent_audio_required:
+                                if mark_detection("silent_audio", silence_secs):
+                                    break
 
                     if (
                         config.get("no_decodable_frames_detection_enabled", True)
@@ -1195,6 +1547,14 @@ class ShadowBlankMonitorService:
                                 break
 
                 if detected_reason:
+                    break
+
+                if (
+                    config.get("silent_audio_detection_enabled")
+                    and active_silence_start is not None
+                    and observed_duration(active_silence_start, active_silence_wall) >= silent_audio_required
+                ):
+                    mark_detection("silent_audio", observed_duration(active_silence_start, active_silence_wall))
                     break
 
                 if (
@@ -1312,7 +1672,13 @@ class ShadowBlankMonitorService:
                     observed_probe_duration,
                     freeze_ratio_threshold=float(config["freeze_ratio_threshold"]),
                 ))
+            parsed.update(self._parse_audio_detection(
+                output,
+                config,
+                observed_duration=max(detected_duration, time.monotonic() - probe_started_wall),
+            ))
             parsed.update(no_decodable_parsed)
+            parsed.update(offline_image_probe)
             parsed["returncode"] = process.returncode
             if detected_reason == "blank":
                 parsed["blank_detected"] = True
@@ -1332,6 +1698,18 @@ class ShadowBlankMonitorService:
                     no_decodable_parsed.get("no_decodable_frames_error")
                     or no_decodable_error
                 )
+            elif detected_reason == "garbled_audio":
+                parsed.setdefault("blank_detected", False)
+                parsed.setdefault("freeze_detected", False)
+                parsed["garbled_audio_detected"] = True
+                parsed["garbled_audio_error_count"] = garbled_audio_errors
+                parsed["garbled_audio_error"] = first_garbled_audio_error or "audio_decode_errors"
+            elif detected_reason == "silent_audio":
+                parsed.setdefault("blank_detected", False)
+                parsed.setdefault("freeze_detected", False)
+                parsed["silent_audio_detected"] = True
+                parsed["silent_audio_duration_secs"] = round(detected_duration, 3)
+                parsed["silent_audio_noise_db"] = int(config.get("silent_audio_noise_db", DEFAULT_CONFIG["silent_audio_noise_db"]))
             if viewer_left:
                 parsed["viewer_left"] = True
             if stopped:

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -118,6 +118,11 @@ DEFAULT_CONFIG: Dict[str, Any] = {
 }
 CONFIG_KEYS = set(DEFAULT_CONFIG)
 WATCH_MODES = {"periodic", "continuous"}
+MEDIA_FAULT_RECOVERY_GUARD_BYPASS_REASONS = {
+    "offline_image",
+    "garbled_audio",
+    "silent_audio",
+}
 
 INT_BOUNDS = {
     "poll_interval_seconds": (5, 3600),
@@ -638,6 +643,18 @@ class ShadowBlankMonitorService:
                         self._watcher_absences.pop(channel_uuid, None)
                     self._watched[channel_uuid] = dict(target)
                 if watcher_count > 0:
+                    bypass_details = self._pending_media_recovery_guard_bypass_details(
+                        channel_uuid,
+                        target,
+                        fresh_status,
+                        config,
+                    )
+                    if bypass_details is not None:
+                        target["media_recovery_guard_bypass"] = bypass_details
+                        target["media_recovery_guard_observed"] = bypass_details
+                        self._record_event("watcher_recovery_observed", target, bypass_details)
+                        time.sleep(float(config.get("watch_gap_seconds", 1)))
+                        continue
                     guard_details = {
                         "reason": "active_watcher_between_confirmations",
                         "watcher_client_count": watcher_count,
@@ -653,6 +670,8 @@ class ShadowBlankMonitorService:
     def _probe_target_once(self, udi: Any, target: Dict[str, Any], config: Dict[str, Any]) -> bool:
         channel_uuid = target["channel_uuid"]
         try:
+            target.pop("media_recovery_guard_reason", None)
+            target.pop("media_recovery_guard_bypass", None)
             proxy_url = self._channel_proxy_url(channel_uuid)
             if config.get("watch_mode") == "continuous" and self._uses_default_blank_probe:
                 result = self._run_blank_probe_until_viewer_left(proxy_url, config, udi, target)
@@ -717,6 +736,7 @@ class ShadowBlankMonitorService:
             if result.get("viewer_left") or self._real_client_count(fresh_status, config) <= 0:
                 self._reset_blank_count(channel_uuid)
                 self._clear_switch_attempts(channel_uuid)
+                target.pop("media_recovery_guard_observed", None)
                 self._record_event("viewer_left", target, {})
                 with self._lock:
                     self._watched.pop(channel_uuid, None)
@@ -725,19 +745,50 @@ class ShadowBlankMonitorService:
             if not detection_reason:
                 self._reset_blank_count(channel_uuid)
                 self._clear_switch_attempts(channel_uuid)
+                target.pop("media_recovery_guard_observed", None)
                 self._record_event("probe_ok", target, target["last_probe"])
                 return True
 
-            if self._guard_recent_watcher_recovery(channel_uuid, target, fresh_status, config, reason=detection_reason):
-                return False
+            guard_details = self._watcher_recovery_guard_details(
+                channel_uuid,
+                target,
+                fresh_status,
+                config,
+                reason=detection_reason,
+            )
+            confirmations = self._required_confirmations(config, detection_reason, guard_details)
+            recovery_guard_bypass: Optional[Dict[str, Any]] = None
+            if guard_details is not None:
+                next_count = self._current_detection_count(channel_uuid, detection_reason) + 1
+                recovery_guard_bypass = self._media_recovery_guard_bypass_details(
+                    target,
+                    fresh_status,
+                    config,
+                    reason=detection_reason,
+                    guard_details=guard_details,
+                    confirmed_count=next_count,
+                    required_confirmations=confirmations,
+                    require_confirmed=False,
+                )
+                if recovery_guard_bypass is None:
+                    self._record_watcher_recovery_guard(channel_uuid, target, guard_details)
+                    return False
+                target["media_recovery_guard_reason"] = detection_reason
+                target["media_recovery_guard_bypass"] = recovery_guard_bypass
 
             blank_count = self._increment_blank_count(channel_uuid, detection_reason)
-            confirmations = int(config.get("confirmation_count", 2))
             if blank_count < confirmations:
+                pending_details = {
+                    "confirmations": blank_count,
+                    "required": confirmations,
+                    "reason": detection_reason,
+                }
+                if recovery_guard_bypass:
+                    pending_details["recovery_guard"] = recovery_guard_bypass
                 self._record_event(
                     f"{detection_reason}_pending",
                     target,
-                    {"confirmations": blank_count, "required": confirmations, "reason": detection_reason},
+                    pending_details,
                 )
                 return True
 
@@ -760,8 +811,47 @@ class ShadowBlankMonitorService:
             return
 
         fresh_stream_id = self._extract_stream_id(fresh_status) or target.get("stream_id")
-        if self._guard_recent_watcher_recovery(channel_uuid, target, fresh_status, config, reason=reason):
-            return
+        guard_details = self._watcher_recovery_guard_details(
+            channel_uuid,
+            target,
+            fresh_status,
+            config,
+            reason=reason,
+        )
+        recovery_guard_bypass: Optional[Dict[str, Any]] = None
+        if guard_details is not None:
+            current_count = self._current_detection_count(channel_uuid, reason)
+            required_confirmations = self._required_confirmations(config, reason, guard_details)
+            recovery_guard_bypass = self._media_recovery_guard_bypass_details(
+                target,
+                fresh_status,
+                config,
+                reason=reason,
+                guard_details=guard_details,
+                confirmed_count=current_count,
+                required_confirmations=required_confirmations,
+                require_confirmed=True,
+            )
+            if recovery_guard_bypass is None:
+                self._record_watcher_recovery_guard(channel_uuid, target, guard_details)
+                return
+        else:
+            observed_guard = target.get("media_recovery_guard_observed")
+            if isinstance(observed_guard, dict) and observed_guard.get("reason") == reason:
+                current_count = self._current_detection_count(channel_uuid, reason)
+                required_confirmations = self._required_confirmations(config, reason, observed_guard)
+                recovery_guard_bypass = self._media_recovery_guard_bypass_details(
+                    target,
+                    fresh_status,
+                    config,
+                    reason=reason,
+                    guard_details=observed_guard,
+                    confirmed_count=current_count,
+                    required_confirmations=required_confirmations,
+                    require_confirmed=True,
+                )
+                if recovery_guard_bypass is not None:
+                    recovery_guard_bypass["observed_between_confirmations"] = True
 
         if target.get("stream_id") and fresh_stream_id != target.get("stream_id"):
             self._reset_blank_count(channel_uuid)
@@ -807,6 +897,8 @@ class ShadowBlankMonitorService:
         switch_details = {"target_stream_ref": _ref("stream", alternative), "reason": reason}
         if pre_probe_details:
             switch_details["pre_probe"] = pre_probe_details
+        if recovery_guard_bypass:
+            switch_details["recovery_guard"] = recovery_guard_bypass
 
         if config.get("dry_run"):
             self._set_cooldown(channel_uuid, config)
@@ -1131,7 +1223,23 @@ class ShadowBlankMonitorService:
             self._blank_counts[key] += 1
             return self._blank_counts[key]
 
-    def _guard_recent_watcher_recovery(
+    def _current_detection_count(self, channel_uuid: str, reason: str = "blank") -> int:
+        key = self._detection_count_key(channel_uuid, reason)
+        with self._lock:
+            return int(self._blank_counts.get(key) or 0)
+
+    @staticmethod
+    def _required_confirmations(
+        config: Dict[str, Any],
+        reason: str,
+        guard_details: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        confirmations = int(config.get("confirmation_count", 2))
+        if guard_details is not None and reason in MEDIA_FAULT_RECOVERY_GUARD_BYPASS_REASONS:
+            return max(confirmations, 2)
+        return confirmations
+
+    def _watcher_recovery_guard_details(
         self,
         channel_uuid: str,
         target: Dict[str, Any],
@@ -1139,9 +1247,9 @@ class ShadowBlankMonitorService:
         config: Dict[str, Any],
         *,
         reason: str,
-    ) -> bool:
+    ) -> Optional[Dict[str, Any]]:
         if config.get("watch_mode") != "continuous":
-            return False
+            return None
 
         with self._lock:
             watched = dict(self._watched.get(channel_uuid) or {})
@@ -1169,6 +1277,103 @@ class ShadowBlankMonitorService:
                     "watcher_client_count": fresh_details.get("watcher_client_count"),
                 }
 
+        return guard_details
+
+    def _media_recovery_guard_bypass_details(
+        self,
+        target: Dict[str, Any],
+        fresh_status: Dict[str, Any],
+        config: Dict[str, Any],
+        *,
+        reason: str,
+        guard_details: Dict[str, Any],
+        confirmed_count: int,
+        required_confirmations: int,
+        require_confirmed: bool,
+    ) -> Optional[Dict[str, Any]]:
+        if reason not in MEDIA_FAULT_RECOVERY_GUARD_BYPASS_REASONS:
+            return None
+        if config.get("watch_mode") != "continuous":
+            return None
+        if not config.get("next_stream_pre_probe_enabled"):
+            return None
+        if require_confirmed and confirmed_count < required_confirmations:
+            return None
+        if self._real_client_count(fresh_status, config) <= 0:
+            return None
+
+        target_stream_id = target.get("stream_id")
+        fresh_stream_id = self._extract_stream_id(fresh_status) or target_stream_id
+        if target_stream_id and fresh_stream_id != target_stream_id:
+            return None
+
+        details = dict(guard_details)
+        guard_reason = guard_details.get("reason")
+        details.update({
+            "bypassed": True,
+            "bypass_scope": "confirmed_media_fault",
+            "guard_reason": guard_reason,
+            "reason": reason,
+            "pre_probe_required": True,
+            "confirmations": confirmed_count,
+            "required": required_confirmations,
+            "current_stream_ref": _ref("stream", fresh_stream_id),
+        })
+        return details
+
+    def _pending_media_recovery_guard_bypass_details(
+        self,
+        channel_uuid: str,
+        target: Dict[str, Any],
+        fresh_status: Dict[str, Any],
+        config: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        reason = (
+            target.get("media_recovery_guard_reason")
+            or (target.get("media_recovery_guard_bypass") or {}).get("reason")
+        )
+        if not reason:
+            return None
+
+        current_count = self._current_detection_count(channel_uuid, str(reason))
+        guard_details = {
+            "reason": "active_watcher_between_confirmations",
+            "watcher_client_count": self._watcher_client_count(fresh_status, config),
+        }
+        fresh_details = self._watcher_client_details(fresh_status, config)
+        if fresh_details.get("watcher_client_ref"):
+            guard_details["watcher_client_ref"] = fresh_details.get("watcher_client_ref")
+        required_confirmations = self._required_confirmations(config, str(reason), guard_details)
+        if current_count <= 0 or current_count >= required_confirmations:
+            return None
+
+        return self._media_recovery_guard_bypass_details(
+            target,
+            fresh_status,
+            config,
+            reason=str(reason),
+            guard_details=guard_details,
+            confirmed_count=current_count,
+            required_confirmations=required_confirmations,
+            require_confirmed=False,
+        )
+
+    def _guard_recent_watcher_recovery(
+        self,
+        channel_uuid: str,
+        target: Dict[str, Any],
+        fresh_status: Dict[str, Any],
+        config: Dict[str, Any],
+        *,
+        reason: str,
+    ) -> bool:
+        guard_details = self._watcher_recovery_guard_details(
+            channel_uuid,
+            target,
+            fresh_status,
+            config,
+            reason=reason,
+        )
         if guard_details is None:
             return False
 

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -104,6 +104,8 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "offline_image_reference_hashes": [],
     "offline_image_hash_threshold": 4,
     "offline_image_capture_offset_seconds": 3,
+    "next_stream_pre_probe_enabled": False,
+    "next_stream_pre_probe_duration_seconds": 8,
     "confirmation_count": 2,
     "channel_cooldown_seconds": 300,
     "max_switches_per_hour": 3,
@@ -129,6 +131,7 @@ INT_BOUNDS = {
     "silent_audio_noise_db": (-90, -20),
     "offline_image_hash_threshold": (0, 20),
     "offline_image_capture_offset_seconds": (0, 30),
+    "next_stream_pre_probe_duration_seconds": (3, 60),
 }
 
 FLOAT_BOUNDS = {
@@ -193,6 +196,7 @@ def normalize_config(payload: Optional[Dict[str, Any]], current: Optional[Dict[s
     config["garbled_audio_detection_enabled"] = bool(config.get("garbled_audio_detection_enabled"))
     config["silent_audio_detection_enabled"] = bool(config.get("silent_audio_detection_enabled"))
     config["offline_image_detection_enabled"] = bool(config.get("offline_image_detection_enabled"))
+    config["next_stream_pre_probe_enabled"] = bool(config.get("next_stream_pre_probe_enabled"))
     config["watch_mode"] = str(config.get("watch_mode") or DEFAULT_CONFIG["watch_mode"]).strip().lower()
     if config["watch_mode"] not in WATCH_MODES:
         config["watch_mode"] = DEFAULT_CONFIG["watch_mode"]
@@ -774,24 +778,42 @@ class ShadowBlankMonitorService:
             return
 
         attempted_targets = self._attempted_switch_targets(channel_uuid, fresh_stream_id)
-        alternative = self._choose_alternative_stream(
-            udi,
-            target.get("channel_id"),
-            fresh_stream_id,
-            excluded_stream_ids=attempted_targets,
-        )
+        if config.get("next_stream_pre_probe_enabled"):
+            alternative, pre_probe_details = self._choose_preprobed_alternative_stream(
+                udi,
+                target,
+                config,
+                fresh_stream_id,
+                excluded_stream_ids=attempted_targets,
+                reason=reason,
+            )
+        else:
+            alternative = self._choose_alternative_stream(
+                udi,
+                target.get("channel_id"),
+                fresh_stream_id,
+                excluded_stream_ids=attempted_targets,
+            )
+            pre_probe_details = None
         if not alternative:
             self._set_cooldown(channel_uuid, config)
             self._reset_blank_count(channel_uuid)
-            self._record_event("no_alternative", target, {"reason": reason})
+            details = {"reason": reason}
+            if pre_probe_details:
+                details["pre_probe"] = pre_probe_details
+            self._record_event("no_alternative", target, details)
             return
+
+        switch_details = {"target_stream_ref": _ref("stream", alternative), "reason": reason}
+        if pre_probe_details:
+            switch_details["pre_probe"] = pre_probe_details
 
         if config.get("dry_run"):
             self._set_cooldown(channel_uuid, config)
             self._record_event(
                 "dry_run_switch",
                 target,
-                {"target_stream_ref": _ref("stream", alternative), "reason": reason},
+                switch_details,
             )
             return
 
@@ -807,22 +829,21 @@ class ShadowBlankMonitorService:
             "switch_success" if success else "switch_failed",
             target,
             {
-                "target_stream_ref": _ref("stream", alternative),
-                "reason": reason,
+                **switch_details,
                 "post_switch_verification": bool(success),
             },
         )
 
-    def _choose_alternative_stream(
+    def _ordered_alternative_streams(
         self,
         udi: Any,
         channel_id: Optional[int],
         current_stream_id: Optional[int],
         *,
         excluded_stream_ids: Optional[Iterable[int]] = None,
-    ) -> Optional[int]:
+    ) -> List[int]:
         if channel_id is None:
-            return None
+            return []
         channel = udi.get_channel_by_id(channel_id) if hasattr(udi, "get_channel_by_id") else None
         stream_ids = list((channel or {}).get("streams") or [])
         if not stream_ids and hasattr(udi, "get_channel_streams"):
@@ -833,7 +854,7 @@ class ShadowBlankMonitorService:
             ]
         stream_ids = [int(item) for item in stream_ids if str(item).isdigit()]
         if len(stream_ids) <= 1:
-            return None
+            return []
         excluded = {
             int(item)
             for item in (excluded_stream_ids or [])
@@ -844,7 +865,120 @@ class ShadowBlankMonitorService:
             ordered = stream_ids[index + 1 :] + stream_ids[:index]
         else:
             ordered = stream_ids
-        return next((sid for sid in ordered if sid != current_stream_id and sid not in excluded), None)
+        return [
+            sid
+            for sid in ordered
+            if sid != current_stream_id and sid not in excluded
+        ]
+
+    def _choose_alternative_stream(
+        self,
+        udi: Any,
+        channel_id: Optional[int],
+        current_stream_id: Optional[int],
+        *,
+        excluded_stream_ids: Optional[Iterable[int]] = None,
+    ) -> Optional[int]:
+        return next(
+            iter(
+                self._ordered_alternative_streams(
+                    udi,
+                    channel_id,
+                    current_stream_id,
+                    excluded_stream_ids=excluded_stream_ids,
+                )
+            ),
+            None,
+        )
+
+    def _choose_preprobed_alternative_stream(
+        self,
+        udi: Any,
+        target: Dict[str, Any],
+        config: Dict[str, Any],
+        current_stream_id: Optional[int],
+        *,
+        excluded_stream_ids: Optional[Iterable[int]] = None,
+        reason: str,
+    ) -> tuple[Optional[int], Optional[Dict[str, Any]]]:
+        last_details: Optional[Dict[str, Any]] = None
+        for candidate_id in self._ordered_alternative_streams(
+            udi,
+            target.get("channel_id"),
+            current_stream_id,
+            excluded_stream_ids=excluded_stream_ids,
+        ):
+            candidate_ref = _ref("stream", candidate_id)
+            candidate_url = self._stream_url_for_id(udi, target.get("channel_id"), candidate_id)
+            details: Dict[str, Any] = {
+                "enabled": True,
+                "target_stream_ref": candidate_ref,
+                "duration_seconds": int(config.get("next_stream_pre_probe_duration_seconds", 8)),
+            }
+            if not candidate_url:
+                details["result"] = "missing_url"
+                last_details = details
+                self._record_event("pre_probe_unavailable", target, {**details, "reason": reason})
+                continue
+
+            probe_result = self._run_next_stream_pre_probe(candidate_url, config)
+            rejection_reason = self._pre_probe_rejection_reason(probe_result)
+            details.update({
+                "result": "rejected" if rejection_reason else "ok",
+                "rejection_reason": rejection_reason,
+                "blank_detected": bool(probe_result.get("blank_detected")),
+                "freeze_detected": bool(probe_result.get("freeze_detected")),
+                "no_decodable_frames_detected": bool(probe_result.get("no_decodable_frames_detected")),
+                "garbled_audio_detected": bool(probe_result.get("garbled_audio_detected")),
+                "silent_audio_detected": bool(probe_result.get("silent_audio_detected")),
+                "offline_image_detected": bool(probe_result.get("offline_image_detected")),
+            })
+            last_details = details
+            if rejection_reason:
+                self._record_event("pre_probe_rejected", target, {**details, "reason": reason})
+                continue
+            return candidate_id, details
+        return None, last_details
+
+    def _stream_url_for_id(self, udi: Any, channel_id: Optional[int], stream_id: int) -> Optional[str]:
+        stream: Optional[Dict[str, Any]] = None
+        if hasattr(udi, "get_stream_by_id"):
+            stream = udi.get_stream_by_id(stream_id)
+        if not stream and channel_id is not None and hasattr(udi, "get_channel_streams"):
+            stream_ref = str(stream_id)
+            stream = next(
+                (
+                    candidate
+                    for candidate in (udi.get_channel_streams(channel_id) or [])
+                    if isinstance(candidate, dict) and str(candidate.get("id") or "") == stream_ref
+                ),
+                None,
+            )
+        if not isinstance(stream, dict):
+            return None
+        url = str(stream.get("url") or "").strip()
+        return url or None
+
+    def _run_next_stream_pre_probe(self, url: str, config: Dict[str, Any]) -> Dict[str, Any]:
+        pre_probe_config = dict(config)
+        pre_probe_config["probe_duration_seconds"] = int(
+            config.get("next_stream_pre_probe_duration_seconds", 8)
+        )
+        return self._run_blank_probe(url, pre_probe_config)
+
+    @staticmethod
+    def _pre_probe_rejection_reason(result: Dict[str, Any]) -> Optional[str]:
+        for reason in (
+            "blank",
+            "offline_image",
+            "freeze",
+            "no_decodable_frames",
+            "garbled_audio",
+            "silent_audio",
+        ):
+            if result.get(f"{reason}_detected"):
+                return reason
+        return None
 
     @staticmethod
     def _detection_count_key(channel_uuid: str, reason: str) -> str:

--- a/backend/apps/stream/stream_check_utils.py
+++ b/backend/apps/stream/stream_check_utils.py
@@ -1025,6 +1025,162 @@ def get_stream_info(url: str, timeout: int = 30, user_agent: str = 'VLC/3.0.14')
         return None, None
 
 
+def _parse_ffprobe_rate(rate: Any) -> float:
+    """Parse an ffprobe frame-rate string such as 30000/1001 or 30/1."""
+    if not rate:
+        return 0
+    try:
+        rate_text = str(rate).strip()
+        if '/' in rate_text:
+            numerator, denominator = rate_text.split('/', 1)
+            denominator_value = float(denominator)
+            if denominator_value == 0:
+                return 0
+            return _snap_to_common_fps(float(numerator) / denominator_value)
+        return _snap_to_common_fps(float(rate_text))
+    except (TypeError, ValueError, ZeroDivisionError):
+        return 0
+
+
+def _kbps_from_ffprobe_bit_rate(bit_rate: Any) -> Optional[float]:
+    """Convert ffprobe bit_rate bits/sec values to kbps."""
+    try:
+        if bit_rate in (None, '', 'N/A'):
+            return None
+        kbps = float(bit_rate) / 1000.0
+        return kbps if kbps > MIN_VALID_PROGRESS_BITRATE else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        if value in (None, '', 'N/A'):
+            return None
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _ffprobe_media_fallback(
+    url: str,
+    *,
+    timeout: int,
+    user_agent: str,
+    reason: str,
+) -> Optional[Dict[str, Any]]:
+    """Use ffprobe as a narrow media-presence fallback after ffmpeg is inconclusive.
+
+    This does not forgive truly offline streams: the fallback is accepted only
+    when ffprobe sees a video stream with non-zero dimensions.
+    """
+    command = [
+        'ffprobe',
+        '-user_agent', user_agent,
+        '-v', 'error',
+        '-show_entries',
+        (
+            'stream=codec_name,codec_type,width,height,avg_frame_rate,'
+            'r_frame_rate,bit_rate,pix_fmt,color_space,color_primaries,'
+            'color_transfer,profile,sample_rate,channels,channel_layout:'
+            'format=bit_rate'
+        ),
+        '-of', 'json',
+        url,
+    ]
+
+    start = time.time()
+    try:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=max(5, timeout),
+            text=True,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("  [ffprobe fallback] Timeout while validating media presence")
+        return None
+    except Exception as exc:
+        logger.warning(f"  [ffprobe fallback] Failed to start: {scrub_urls(exc)}")
+        return None
+
+    elapsed = time.time() - start
+    if result.returncode != 0 or not result.stdout:
+        logger.warning(
+            "  [ffprobe fallback] No usable media info returned "
+            f"(exit={result.returncode})"
+        )
+        return None
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        logger.warning(f"  [ffprobe fallback] Invalid JSON: {exc}")
+        return None
+
+    streams = payload.get('streams') or []
+    video = next(
+        (
+            stream for stream in streams
+            if stream.get('codec_type') == 'video'
+            and (_safe_int(stream.get('width')) or 0) > 0
+            and (_safe_int(stream.get('height')) or 0) > 0
+        ),
+        None,
+    )
+    if not video:
+        logger.warning("  [ffprobe fallback] No valid video stream found")
+        return None
+
+    audio = next((stream for stream in streams if stream.get('codec_type') == 'audio'), None)
+    width = _safe_int(video.get('width')) or 0
+    height = _safe_int(video.get('height')) or 0
+    video_codec = _sanitize_codec_name(video.get('codec_name'))
+    audio_codec = _sanitize_codec_name(audio.get('codec_name')) if audio else 'N/A'
+    fps = _parse_ffprobe_rate(video.get('avg_frame_rate')) or _parse_ffprobe_rate(video.get('r_frame_rate'))
+    bitrate_kbps = (
+        _kbps_from_ffprobe_bit_rate(video.get('bit_rate'))
+        or _kbps_from_ffprobe_bit_rate((payload.get('format') or {}).get('bit_rate'))
+    )
+
+    metadata = {
+        'color_transfer': video.get('color_transfer'),
+        'color_primaries': video.get('color_primaries'),
+        'color_space': video.get('color_space'),
+        'pix_fmt': video.get('pix_fmt'),
+        'profile': video.get('profile'),
+    }
+
+    logger.info(
+        "  [ffprobe fallback] Valid media after %s: %sx%s, %.2f FPS, %s/%s",
+        reason,
+        width,
+        height,
+        fps,
+        video_codec,
+        audio_codec,
+    )
+    return {
+        'video_codec': video_codec,
+        'audio_codec': audio_codec,
+        'resolution': f"{width}x{height}",
+        'fps': fps,
+        'bitrate_kbps': bitrate_kbps,
+        'bitrate_source': 'ffprobe_fallback' if bitrate_kbps is not None else 'ffprobe_media_fallback_no_bitrate',
+        'hdr_format': _detect_hdr_format(metadata),
+        'pixel_format': video.get('pix_fmt'),
+        'audio_sample_rate': _safe_int(audio.get('sample_rate')) if audio else None,
+        'audio_channels': _safe_int(audio.get('channels')) if audio else None,
+        'channel_layout': audio.get('channel_layout') if audio else None,
+        'audio_bitrate': _safe_int(_kbps_from_ffprobe_bit_rate(audio.get('bit_rate'))) if audio else None,
+        'status': 'OK',
+        'ffprobe_fallback_ran': True,
+        'ffprobe_fallback_reason': reason,
+        'ffprobe_fallback_elapsed_time': elapsed,
+    }
+
+
 def get_stream_info_and_bitrate(
     url: str,
     duration: int = 30,
@@ -1213,6 +1369,9 @@ def get_stream_info_and_bitrate(
         'freeze_segments': [],
         'preempted': False, 'preempt_reason': None,
         'bitrate_source': None,
+        'ffprobe_fallback_ran': False,
+        'ffprobe_fallback_reason': None,
+        'ffprobe_fallback_elapsed_time': None,
     }
 
     try:
@@ -1482,8 +1641,20 @@ def get_stream_info_and_bitrate(
 
     except subprocess.TimeoutExpired:
         logger.warning(f"Timeout ({actual_timeout}s) while analyzing stream")
-        result_data['status'] = "Timeout"
-        result_data['elapsed_time'] = actual_timeout
+        fallback = _ffprobe_media_fallback(
+            url,
+            timeout=min(max(timeout, 10), 20),
+            user_agent=user_agent,
+            reason='ffmpeg_timeout',
+        )
+        if fallback:
+            result_data.update(fallback)
+            result_data['elapsed_time'] = actual_timeout + float(
+                fallback.get('ffprobe_fallback_elapsed_time') or 0.0
+            )
+        else:
+            result_data['status'] = "Timeout"
+            result_data['elapsed_time'] = actual_timeout
     except StreamProbePreempted:
         logger.info("Stream analysis preempted because viewer capacity is needed")
         result_data['status'] = "PREEMPTED"
@@ -2022,6 +2193,9 @@ def analyze_stream(
         'freeze_segments': [],
         'preempted': False,
         'preempt_reason': None,
+        'ffprobe_fallback_ran': False,
+        'ffprobe_fallback_reason': None,
+        'ffprobe_fallback_elapsed_time': None,
         'quality_reason': 'offline',
         'quality_reason_detail': 'error',
         'quality_reason_context': {},
@@ -2106,6 +2280,9 @@ def analyze_stream(
                     'freeze_segments': result_data.get('freeze_segments', []),
                     'preempted': bool(result_data.get('preempted')),
                     'preempt_reason': result_data.get('preempt_reason'),
+                    'ffprobe_fallback_ran': bool(result_data.get('ffprobe_fallback_ran')),
+                    'ffprobe_fallback_reason': result_data.get('ffprobe_fallback_reason'),
+                    'ffprobe_fallback_elapsed_time': result_data.get('ffprobe_fallback_elapsed_time'),
                 }
                 if result['status'] == 'OK':
                     result['quality_reason'] = 'none'

--- a/backend/apps/telemetry/last_quality_stats.py
+++ b/backend/apps/telemetry/last_quality_stats.py
@@ -1,0 +1,321 @@
+"""Read-only access to the last reusable stream quality measurement."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone, timedelta
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple
+
+from apps.core.stream_stats_utils import (
+    extract_stream_stats,
+    normalize_resolution,
+    parse_bitrate_value,
+    parse_fps_value,
+)
+from apps.database import connection
+from apps.database.models import Run, Stream, StreamTelemetry
+
+
+UNREUSABLE_STATUSES = {
+    "dead",
+    "blank",
+    "freeze",
+    "frozen",
+    "probe_failed",
+    "failed",
+    "error",
+    "offline",
+    "no_decodable_frames",
+}
+
+EMPTY_VALUES = {"", "n/a", "none", "null", "unknown"}
+
+
+def _clean_string(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    if cleaned.lower() in EMPTY_VALUES:
+        return None
+    return cleaned
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    try:
+        if value is None or value == "":
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_json_blob(blob: Any) -> Any:
+    if not blob:
+        return None
+    if isinstance(blob, (dict, list)):
+        return blob
+    if isinstance(blob, str):
+        try:
+            return json.loads(blob)
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _iter_dicts(value: Any) -> Iterable[Dict[str, Any]]:
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _iter_dicts(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_dicts(child)
+
+
+def _stream_payload_matches(payload: Dict[str, Any], stream_id: int) -> bool:
+    for key in ("stream_id", "id"):
+        if _coerce_int(payload.get(key)) == stream_id:
+            return True
+    return False
+
+
+def _find_stream_payload(run: Run, stream_id: int) -> Dict[str, Any]:
+    best_match: Dict[str, Any] = {}
+    for root in (_load_json_blob(run.raw_details), _load_json_blob(run.raw_subentries)):
+        for payload in _iter_dicts(root):
+            if not _stream_payload_matches(payload, stream_id):
+                continue
+            if not best_match:
+                best_match = payload
+            if any(
+                key in payload
+                for key in (
+                    "status",
+                    "dead_reason",
+                    "quality_reason",
+                    "quality_reason_detail",
+                    "resolution",
+                    "stream_stats",
+                )
+            ):
+                return payload
+    return best_match
+
+
+def _extract_resolution(payload: Dict[str, Any]) -> Tuple[Optional[int], Optional[int]]:
+    resolution = normalize_resolution(payload.get("resolution"))
+    if resolution == "N/A":
+        stats = extract_stream_stats(payload)
+        resolution = normalize_resolution(stats.get("resolution"))
+    if resolution == "N/A" or "x" not in resolution:
+        return None, None
+    try:
+        width_raw, height_raw = resolution.lower().split("x", 1)
+        return int(width_raw), int(height_raw)
+    except (TypeError, ValueError):
+        return None, None
+
+
+def _row_or_payload_stats(row: StreamTelemetry, payload: Dict[str, Any]) -> Dict[str, Any]:
+    extracted = extract_stream_stats(payload) if payload else {}
+    width = row.resolution_width
+    height = row.resolution_height
+    if width is None or height is None:
+        width, height = _extract_resolution(payload)
+
+    bitrate = row.bitrate_kbps
+    if bitrate is None:
+        bitrate = parse_bitrate_value(
+            payload.get("bitrate")
+            or payload.get("ffmpeg_output_bitrate")
+            or extracted.get("bitrate_kbps")
+        )
+    bitrate_int = int(bitrate) if bitrate is not None else None
+
+    fps = row.fps if row.fps is not None else parse_fps_value(payload.get("fps") or extracted.get("fps"))
+    codec = (
+        _clean_string(row.codec)
+        or _clean_string(payload.get("video_codec"))
+        or _clean_string(extracted.get("video_codec"))
+    )
+    audio_codec = (
+        _clean_string(row.audio_codec)
+        or _clean_string(payload.get("audio_codec"))
+        or _clean_string(extracted.get("audio_codec"))
+    )
+
+    return {
+        "width": width,
+        "height": height,
+        "fps": fps,
+        "codec": codec.lower() if codec else None,
+        "audio_codec": audio_codec.lower() if audio_codec else None,
+        "bitrate_kbps": bitrate_int,
+        "hdr": bool(row.is_hdr or payload.get("is_hdr") or payload.get("hdr_format")),
+    }
+
+
+def _quality_status(row: StreamTelemetry, payload: Dict[str, Any]) -> Tuple[str, str]:
+    status = _clean_string(payload.get("status"))
+    reason = (
+        _clean_string(payload.get("quality_reason_detail"))
+        or _clean_string(payload.get("quality_reason"))
+        or _clean_string(payload.get("dead_reason"))
+    )
+
+    if payload.get("blank_detected") is True:
+        status = "blank"
+        reason = reason or "blank_detected"
+    elif payload.get("freeze_detected") is True:
+        status = "freeze"
+        reason = reason or "freeze_detected"
+    elif payload.get("no_decodable_frames") is True:
+        status = "no_decodable_frames"
+        reason = reason or "no_decodable_frames"
+
+    if row.is_dead and (not status or status == "completed"):
+        status = "dead"
+        reason = reason or "dead"
+
+    return (status or "completed").lower(), (reason or "none").lower()
+
+
+def _format_timestamp(value: Optional[datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _is_stale(run: Run, stream: Optional[Stream], stale_after_hours: Optional[float]) -> bool:
+    if stream is not None and bool(stream.is_stale):
+        return True
+    if stale_after_hours is None or stale_after_hours <= 0:
+        return False
+    measured_at = run.timestamp
+    if measured_at is None:
+        return False
+    if measured_at.tzinfo is None:
+        measured_at = measured_at.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - measured_at > timedelta(hours=stale_after_hours)
+
+
+def _not_reusable(
+    *,
+    stream_id: int,
+    reason: str,
+    status: str,
+    quality_reason: str,
+    row: StreamTelemetry,
+    run: Run,
+) -> Dict[str, Any]:
+    return {
+        "stream_id": stream_id,
+        "measured": False,
+        "recheck_required": True,
+        "reason": reason,
+        "last_run_id": run.id,
+        "run_type": run.run_type,
+        "channel_id": row.channel_id,
+        "provider_id": row.provider_id,
+        "last_status": status,
+        "quality_reason": quality_reason,
+        "measured_at": _format_timestamp(run.timestamp),
+        "source": "stream_telemetry",
+    }
+
+
+def get_last_quality_stats(
+    stream_id: int,
+    *,
+    session_factory: Optional[Callable[[], Any]] = None,
+    stale_after_hours: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Return the latest stored quality measurement for one stream.
+
+    This is intentionally read-only. It only queries persisted run telemetry and
+    never touches StreamChecker, queues, Dispatcharr, ffmpeg, or any probe path.
+    """
+    session_factory = session_factory or connection.get_session
+    session = session_factory()
+    try:
+        result = (
+            session.query(StreamTelemetry, Run, Stream)
+            .join(Run, StreamTelemetry.run_id == Run.id)
+            .outerjoin(Stream, StreamTelemetry.stream_id == Stream.id)
+            .filter(StreamTelemetry.stream_id == stream_id)
+            .order_by(Run.timestamp.desc(), StreamTelemetry.id.desc())
+            .first()
+        )
+        if result is None:
+            return {
+                "stream_id": stream_id,
+                "measured": False,
+                "recheck_required": True,
+                "reason": "never_measured",
+            }
+
+        row, run, stream = result
+        raw_payload = _find_stream_payload(run, stream_id)
+        stats = _row_or_payload_stats(row, raw_payload)
+        status, quality_reason = _quality_status(row, raw_payload)
+
+        if status in UNREUSABLE_STATUSES or row.is_dead:
+            return _not_reusable(
+                stream_id=stream_id,
+                reason="last_result_not_reusable",
+                status=status,
+                quality_reason=quality_reason,
+                row=row,
+                run=run,
+            )
+
+        width = _coerce_int(stats["width"])
+        height = _coerce_int(stats["height"])
+        if not width or not height or width <= 0 or height <= 0:
+            return _not_reusable(
+                stream_id=stream_id,
+                reason="last_result_not_reusable",
+                status="0x0" if width == 0 or height == 0 else "incomplete_stats",
+                quality_reason=quality_reason,
+                row=row,
+                run=run,
+            )
+
+        fps = parse_fps_value(stats["fps"])
+        codec = _clean_string(stats["codec"])
+        if fps is None or codec is None:
+            return _not_reusable(
+                stream_id=stream_id,
+                reason="last_result_not_reusable",
+                status="incomplete_stats",
+                quality_reason=quality_reason,
+                row=row,
+                run=run,
+            )
+
+        return {
+            "stream_id": stream_id,
+            "measured": True,
+            "recheck_required": False,
+            "last_run_id": run.id,
+            "run_type": run.run_type,
+            "channel_id": row.channel_id,
+            "provider_id": row.provider_id,
+            "resolution": f"{width}x{height}",
+            "width": width,
+            "height": height,
+            "fps": fps,
+            "codec": codec.lower(),
+            "audio_codec": stats["audio_codec"],
+            "bitrate_kbps": stats["bitrate_kbps"],
+            "hdr": bool(stats["hdr"]),
+            "status": status,
+            "quality_reason": quality_reason,
+            "measured_at": _format_timestamp(run.timestamp),
+            "source": "stream_telemetry",
+            "stale": _is_stale(run, stream, stale_after_hours),
+        }
+    finally:
+        session.close()

--- a/backend/tests/test_auto_create_handlers.py
+++ b/backend/tests/test_auto_create_handlers.py
@@ -83,6 +83,7 @@ def test_auto_create_regex_test_uses_rule_wide_preview_for_single_channel():
         channel_group_ids=[],
         regex_pattern="^Live: MLB$",
         minutes_before=0,
+        max_events_per_run=None,
         force_refresh=True,
     )
     service.test_regex_against_epg.assert_not_called()

--- a/backend/tests/test_auto_create_rule_group_preview.py
+++ b/backend/tests/test_auto_create_rule_group_preview.py
@@ -163,6 +163,48 @@ def test_auto_create_preview_reports_due_and_unscheduled_matches(tmp_path, monke
     assert [channel["id"] for channel in result["channels_with_unscheduled_matches"]] == [12, 13]
 
 
+def test_auto_create_preview_guardrail_blocks_massqueue(tmp_path, monkeypatch):
+    service = _make_service(tmp_path, monkeypatch)
+    now = datetime.now(timezone.utc)
+
+    channels = {
+        10: {"id": 10, "name": "Team A", "tvg_id": "team-a"},
+        11: {"id": 11, "name": "Team B", "tvg_id": "team-b"},
+        12: {"id": 12, "name": "Team C", "tvg_id": "team-c"},
+    }
+    udi = Mock()
+    udi.get_channel_group_by_id.return_value = {"id": 50, "name": "Team Channels"}
+    udi.get_channels_by_group.return_value = list(channels.values())
+    udi.get_channel_by_id.side_effect = lambda channel_id: channels.get(int(channel_id))
+    monkeypatch.setattr(scheduling_service, "get_udi_manager", lambda: udi)
+
+    service._epg_cache = [
+        {
+            "title": "Live: Baseball",
+            "start_time": (now + timedelta(minutes=5)).isoformat(),
+            "end_time": (now + timedelta(hours=2)).isoformat(),
+            "tvg_id": tvg_id,
+        }
+        for tvg_id in ["team-a", "team-b", "team-c"]
+    ]
+
+    result = service.test_regex_against_epg_for_rule(
+        channel_group_ids=[50],
+        regex_pattern="^Live:",
+        minutes_before=10,
+        max_events_per_run=2,
+    )
+
+    assert result["total_epg_matches"] == 3
+    assert result["matches"] == 0
+    assert result["guardrail"]["blocked"] is True
+    assert result["guardrail"]["reason"] == "max_events_per_rule_run"
+    assert result["guardrail"]["limit"] == 2
+    assert result["guardrail_blocked_matches"] == 3
+    assert len(result["guardrail_blocked_programs"]) == 3
+    assert result["programs"] == []
+
+
 def test_group_only_auto_create_rule_does_not_persist_group_channels_as_individuals(tmp_path, monkeypatch):
     service = _make_service(tmp_path, monkeypatch)
 
@@ -255,6 +297,49 @@ def test_auto_create_schedules_currently_airing_programs(tmp_path, monkeypatch):
     events = service.get_scheduled_events()
     assert len(events) == 3
     assert {event["channel_id"] for event in events} == {10, 11, 12}
+
+
+def test_auto_create_match_guardrail_blocks_massqueue_events(tmp_path, monkeypatch):
+    service = _make_service(tmp_path, monkeypatch)
+    now = datetime.now(timezone.utc)
+
+    channels = {
+        10: {"id": 10, "name": "Team A", "tvg_id": "team-a"},
+        11: {"id": 11, "name": "Team B", "tvg_id": "team-b"},
+        12: {"id": 12, "name": "Team C", "tvg_id": "team-c"},
+    }
+    udi = Mock()
+    udi.get_channel_group_by_id.return_value = {"id": 50, "name": "Team Channels"}
+    udi.get_channels_by_group.return_value = list(channels.values())
+    udi.get_channel_by_id.side_effect = lambda channel_id: channels.get(int(channel_id))
+    monkeypatch.setattr(scheduling_service, "get_udi_manager", lambda: udi)
+
+    service._auto_create_rules = [{
+        "id": "rule-wide",
+        "name": "Wide live rule",
+        "channel_group_ids": [50],
+        "channel_ids": [],
+        "regex_pattern": "^Live:",
+        "minutes_before": 0,
+        "max_events_per_run": 2,
+    }]
+    service._epg_cache = [
+        {
+            "title": "Live: Baseball",
+            "start_time": (now - timedelta(minutes=5)).isoformat(),
+            "end_time": (now + timedelta(hours=2)).isoformat(),
+            "tvg_id": tvg_id,
+        }
+        for tvg_id in ["team-a", "team-b", "team-c"]
+    ]
+
+    result = service.match_programs_to_rules()
+
+    assert result["matched"] == 3
+    assert result["created"] == 0
+    assert result["guardrail_blocked_matches"] == 3
+    assert result["guardrail_blocked_rules"][0]["rule_id"] == "rule-wide"
+    assert service.get_scheduled_events() == []
 
 
 def test_auto_create_schedules_programs_with_guide_time_aliases(tmp_path, monkeypatch):

--- a/backend/tests/test_last_quality_stats_api.py
+++ b/backend/tests/test_last_quality_stats_api.py
@@ -1,0 +1,246 @@
+from datetime import datetime, timedelta, timezone
+
+from apps.database import connection
+from apps.database.models import Run, Stream, StreamTelemetry
+from apps.telemetry.last_quality_stats import get_last_quality_stats
+
+
+def _add_run(session, *, timestamp, run_type="automation_full_run"):
+    run = Run(
+        timestamp=timestamp,
+        duration_seconds=10.0,
+        total_channels=1,
+        total_streams=1,
+        run_type=run_type,
+    )
+    session.add(run)
+    session.flush()
+    return run
+
+
+def _add_stream(session, stream_id=683989, *, is_stale=False):
+    stream = Stream(
+        id=stream_id,
+        name=f"Stream {stream_id}",
+        url=f"http://example.test/{stream_id}.m3u8",
+        m3u_account_id=21,
+        is_stale=is_stale,
+    )
+    session.add(stream)
+    return stream
+
+
+def test_last_quality_stats_reports_never_measured_without_probe():
+    payload = get_last_quality_stats(683989, session_factory=connection.get_session)
+
+    assert payload == {
+        "stream_id": 683989,
+        "measured": False,
+        "recheck_required": True,
+        "reason": "never_measured",
+    }
+
+
+def test_last_quality_stats_returns_latest_reusable_measurement():
+    session = connection.get_session()
+    try:
+        _add_stream(session)
+        old_run = _add_run(session, timestamp=datetime(2026, 6, 7, 10, 0, tzinfo=timezone.utc))
+        new_run = _add_run(session, timestamp=datetime(2026, 6, 7, 12, 0, tzinfo=timezone.utc))
+        session.add_all(
+            [
+                StreamTelemetry(
+                    run_id=old_run.id,
+                    channel_id=1914,
+                    provider_id=21,
+                    stream_id=683989,
+                    bitrate_kbps=8000,
+                    resolution_width=1920,
+                    resolution_height=1080,
+                    fps=25.0,
+                    codec="h264",
+                    is_hdr=False,
+                ),
+                StreamTelemetry(
+                    run_id=new_run.id,
+                    channel_id=1914,
+                    provider_id=21,
+                    stream_id=683989,
+                    bitrate_kbps=14645,
+                    resolution_width=3840,
+                    resolution_height=2160,
+                    fps=50.0,
+                    codec="hevc",
+                    audio_codec="aac",
+                    is_hdr=True,
+                ),
+            ]
+        )
+        session.commit()
+        new_run_id = new_run.id
+    finally:
+        session.close()
+
+    payload = get_last_quality_stats(683989, session_factory=connection.get_session)
+
+    assert payload["measured"] is True
+    assert payload["recheck_required"] is False
+    assert payload["last_run_id"] == new_run_id
+    assert payload["run_type"] == "automation_full_run"
+    assert payload["channel_id"] == 1914
+    assert payload["provider_id"] == 21
+    assert payload["resolution"] == "3840x2160"
+    assert payload["width"] == 3840
+    assert payload["height"] == 2160
+    assert payload["fps"] == 50.0
+    assert payload["codec"] == "hevc"
+    assert payload["audio_codec"] == "aac"
+    assert payload["bitrate_kbps"] == 14645
+    assert payload["hdr"] is True
+    assert payload["status"] == "completed"
+    assert payload["quality_reason"] == "none"
+    assert payload["source"] == "stream_telemetry"
+    assert payload["stale"] is False
+
+
+def test_last_quality_stats_latest_unusable_result_requires_recheck():
+    session = connection.get_session()
+    try:
+        _add_stream(session)
+        old_run = _add_run(session, timestamp=datetime(2026, 6, 7, 10, 0, tzinfo=timezone.utc))
+        new_run = _add_run(
+            session,
+            timestamp=datetime(2026, 6, 7, 12, 0, tzinfo=timezone.utc),
+            run_type="single_channel_check",
+        )
+        new_run.raw_details = (
+            '{"stream_details":[{"stream_id":683989,"status":"freeze",'
+            '"quality_reason_detail":"freeze_detected"}]}'
+        )
+        session.add_all(
+            [
+                StreamTelemetry(
+                    run_id=old_run.id,
+                    channel_id=1914,
+                    provider_id=21,
+                    stream_id=683989,
+                    bitrate_kbps=14645,
+                    resolution_width=3840,
+                    resolution_height=2160,
+                    fps=50.0,
+                    codec="hevc",
+                    is_dead=False,
+                ),
+                StreamTelemetry(
+                    run_id=new_run.id,
+                    channel_id=1914,
+                    provider_id=21,
+                    stream_id=683989,
+                    is_dead=True,
+                ),
+            ]
+        )
+        session.commit()
+        new_run_id = new_run.id
+    finally:
+        session.close()
+
+    payload = get_last_quality_stats(683989, session_factory=connection.get_session)
+
+    assert payload["measured"] is False
+    assert payload["recheck_required"] is True
+    assert payload["reason"] == "last_result_not_reusable"
+    assert payload["last_run_id"] == new_run_id
+    assert payload["last_status"] == "freeze"
+    assert payload["quality_reason"] == "freeze_detected"
+
+
+def test_last_quality_stats_rejects_zero_resolution():
+    session = connection.get_session()
+    try:
+        _add_stream(session)
+        run = _add_run(session, timestamp=datetime(2026, 6, 7, 12, 0, tzinfo=timezone.utc))
+        session.add(
+            StreamTelemetry(
+                run_id=run.id,
+                channel_id=1914,
+                provider_id=21,
+                stream_id=683989,
+                resolution_width=0,
+                resolution_height=0,
+                fps=50.0,
+                codec="hevc",
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    payload = get_last_quality_stats(683989, session_factory=connection.get_session)
+
+    assert payload["measured"] is False
+    assert payload["recheck_required"] is True
+    assert payload["reason"] == "last_result_not_reusable"
+    assert payload["last_status"] == "0x0"
+
+
+def test_last_quality_stats_marks_current_stream_stale():
+    session = connection.get_session()
+    try:
+        _add_stream(session, is_stale=True)
+        run = _add_run(session, timestamp=datetime(2026, 6, 7, 12, 0, tzinfo=timezone.utc))
+        session.add(
+            StreamTelemetry(
+                run_id=run.id,
+                channel_id=1914,
+                provider_id=21,
+                stream_id=683989,
+                resolution_width=3840,
+                resolution_height=2160,
+                fps=50.0,
+                codec="hevc",
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    payload = get_last_quality_stats(683989, session_factory=connection.get_session)
+
+    assert payload["measured"] is True
+    assert payload["stale"] is True
+
+
+def test_last_quality_stats_route_does_not_touch_stream_checker(monkeypatch):
+    import apps.api.web_api as web_api
+
+    session = connection.get_session()
+    try:
+        _add_stream(session)
+        run = _add_run(session, timestamp=datetime.now(timezone.utc) - timedelta(minutes=5))
+        session.add(
+            StreamTelemetry(
+                run_id=run.id,
+                channel_id=1914,
+                provider_id=21,
+                stream_id=683989,
+                resolution_width=1920,
+                resolution_height=1080,
+                fps=25.0,
+                codec="h264",
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    def fail_if_called():
+        raise AssertionError("last-quality-stats must not probe or touch StreamChecker")
+
+    monkeypatch.setattr(web_api, "get_stream_checker_service", fail_if_called)
+
+    with web_api.app.test_client() as client:
+        response = client.get("/api/stream-checker/streams/683989/last-quality-stats")
+
+    assert response.status_code == 200
+    assert response.get_json()["measured"] is True

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -18,9 +18,10 @@ from apps.stream.shadow_blank_monitor_service import (
 
 
 class FakeUdi:
-    def __init__(self, *, statuses, channels):
+    def __init__(self, *, statuses, channels, streams=None):
         self.statuses = list(statuses)
         self.channels = channels
+        self.streams = streams or {}
         self.status_calls = 0
 
     def get_proxy_status(self):
@@ -36,6 +37,17 @@ class FakeUdi:
             if channel.get("id") == channel_id:
                 return channel
         return None
+
+    def get_stream_by_id(self, stream_id):
+        return self.streams.get(stream_id)
+
+    def get_channel_streams(self, channel_id):
+        channel = self.get_channel_by_id(channel_id)
+        return [
+            self.streams.get(stream_id)
+            for stream_id in (channel or {}).get("streams", [])
+            if self.streams.get(stream_id) is not None
+        ]
 
 
 class FakeStreamChecker:
@@ -106,6 +118,8 @@ def test_watch_mode_controls_scan_delay():
     assert defaults["offline_image_detection_enabled"] is False
     assert defaults["offline_image_reference_hashes"] == []
     assert defaults["offline_image_hash_threshold"] == 4
+    assert defaults["next_stream_pre_probe_enabled"] is False
+    assert defaults["next_stream_pre_probe_duration_seconds"] == 8
     assert defaults["confirmation_count"] == 2
     assert defaults["channel_cooldown_seconds"] == 300
     assert defaults["max_switches_per_hour"] == 3
@@ -643,6 +657,81 @@ def test_confirmed_blank_switches_to_next_stream_when_live(tmp_path):
     assert status["recent_events"][0]["type"] == "switch_success"
     assert status["recent_events"][0]["details"]["post_switch_verification"] is True
     assert status["cooldowns"] == []
+
+
+def test_next_stream_pre_probe_disabled_preserves_direct_switch(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status()}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11, 12]}],
+        streams={11: {"id": 11, "url": "http://candidate.local/bad"}},
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"blank_detected": True},
+        switch_calls=switch_calls,
+    )
+
+    def fail_if_pre_probe_runs(url, config):
+        raise AssertionError("next-stream pre-probe should be disabled")
+
+    service._run_blank_probe = fail_if_pre_probe_runs
+    service.update_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": False,
+    })
+
+    status = service.run_once(force=True)
+
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert status["recent_events"][0]["type"] == "switch_success"
+
+
+def test_next_stream_pre_probe_skips_bad_candidate(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status()}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11, 12]}],
+        streams={
+            11: {"id": 11, "url": "http://candidate.local/bad"},
+            12: {"id": 12, "url": "http://candidate.local/good"},
+        },
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"blank_detected": True},
+        switch_calls=switch_calls,
+    )
+    pre_probe_calls = []
+
+    def pre_probe(url, config):
+        pre_probe_calls.append((url, config["probe_duration_seconds"]))
+        return {"blank_detected": "bad" in url}
+
+    service._run_blank_probe = pre_probe
+    service.update_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": True,
+        "next_stream_pre_probe_duration_seconds": 5,
+    })
+
+    status = service.run_once(force=True)
+
+    assert pre_probe_calls == [
+        ("http://candidate.local/bad", 5),
+        ("http://candidate.local/good", 5),
+    ]
+    assert switch_calls == [("uuid-1", 12, None)]
+    assert status["recent_events"][0]["type"] == "switch_success"
+    assert status["recent_events"][0]["details"]["pre_probe"]["result"] == "ok"
+    assert status["recent_events"][1]["type"] == "pre_probe_rejected"
+    assert status["recent_events"][1]["details"]["rejection_reason"] == "blank"
 
 
 def test_confirmed_freeze_switches_to_next_stream_when_live(tmp_path):

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -1087,6 +1087,132 @@ def test_detection_with_fresh_watcher_client_stops_without_pending_or_switch(tmp
         assert "uuid-1" not in service._switch_attempts
 
 
+def test_continuous_media_fault_recovery_guard_requires_pre_probe(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[
+            {
+                "uuid-1": active_status(
+                    stream_id=10,
+                    clients=[
+                        {"user_agent": "VLC"},
+                        {
+                            "user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0",
+                            "client_id": "raw-recovered-watcher",
+                        },
+                    ],
+                )
+            }
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={11: {"id": 11, "url": "http://candidate.local/good"}},
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {
+            "blank_detected": False,
+            "freeze_detected": False,
+            "silent_audio_detected": True,
+            "silent_audio_duration_secs": 12.0,
+        },
+        switch_calls=switch_calls,
+    )
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "watch_mode": "continuous",
+        "confirmation_count": 2,
+        "silent_audio_detection_enabled": True,
+        "next_stream_pre_probe_enabled": False,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+    }
+    with service._lock:
+        service._blank_counts[service._detection_count_key("uuid-1", "silent_audio")] = 1
+
+    should_continue = service._probe_target_once(udi, target, config)
+    status = service.get_status()
+
+    assert should_continue is False
+    assert switch_calls == []
+    assert status["recent_events"][0]["type"] == "watcher_recovery_guard"
+    assert status["recent_events"][0]["details"]["reason"] == "silent_audio"
+    with service._lock:
+        assert service._blank_counts[service._detection_count_key("uuid-1", "silent_audio")] == 0
+
+
+def test_continuous_media_fault_recovery_guard_needs_second_confirmation(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[
+            {
+                "uuid-1": active_status(
+                    stream_id=10,
+                    clients=[
+                        {"user_agent": "VLC"},
+                        {
+                            "user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0",
+                            "client_id": "raw-recovered-watcher",
+                        },
+                    ],
+                )
+            }
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={11: {"id": 11, "url": "http://candidate.local/good"}},
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {
+            "blank_detected": False,
+            "freeze_detected": False,
+            "silent_audio_detected": True,
+            "silent_audio_duration_secs": 12.0,
+        },
+        switch_calls=switch_calls,
+    )
+    service._run_blank_probe = lambda url, config: {"blank_detected": False, "freeze_detected": False}
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "watch_mode": "continuous",
+        "confirmation_count": 1,
+        "silent_audio_detection_enabled": True,
+        "next_stream_pre_probe_enabled": True,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+    }
+
+    first_result = service._probe_target_once(udi, target, config)
+    second_result = service._probe_target_once(udi, target, config)
+    status = service.get_status()
+
+    assert first_result is True
+    assert second_result is False
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert status["recent_events"][0]["type"] == "switch_success"
+    recovery_guard = status["recent_events"][0]["details"]["recovery_guard"]
+    assert recovery_guard["bypassed"] is True
+    assert recovery_guard["pre_probe_required"] is True
+    assert recovery_guard["confirmations"] == 2
+    assert recovery_guard["required"] == 2
+    assert status["recent_events"][1]["type"] == "silent_audio_pending"
+
+
 def test_continuous_probe_stops_when_watcher_reappears_between_confirmations(tmp_path):
     switch_calls = []
     probe_calls = []
@@ -1150,6 +1276,81 @@ def test_continuous_probe_stops_when_watcher_reappears_between_confirmations(tmp
     assert status["recent_events"][0]["details"]["reason"] == "active_watcher_between_confirmations"
     with service._lock:
         assert service._blank_counts[service._detection_count_key("uuid-1", "blank")] == 0
+
+
+def test_continuous_media_fault_continues_when_watcher_reappears_between_confirmations(tmp_path, monkeypatch):
+    switch_calls = []
+    probe_calls = []
+    monkeypatch.setattr(shadow_module.time, "sleep", lambda _seconds: None)
+    udi = FakeUdi(
+        statuses=[
+            {
+                "uuid-1": active_status(
+                    stream_id=10,
+                    clients=[
+                        {"user_agent": "VLC"},
+                        {
+                            "user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0",
+                            "client_id": "raw-between-confirmations",
+                        },
+                    ],
+                )
+            }
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={11: {"id": 11, "url": "http://candidate.local/good"}},
+    )
+
+    def switch_stream(channel_id, stream_id=None, url=None):
+        switch_calls.append((channel_id, stream_id, url))
+        return True
+
+    service = ShadowBlankMonitorService(
+        config_file=tmp_path / "shadow.json",
+        udi_provider=lambda: udi,
+        switch_stream=switch_stream,
+        base_url_provider=lambda: "http://dispatcharr.local",
+        stream_checker_provider=lambda: FakeStreamChecker(),
+        clock=lambda: 1000.0,
+    )
+
+    def fake_continuous_probe(url, config, probe_udi, target):
+        probe_calls.append((url, target.get("media_recovery_guard_reason")))
+        return {
+            "blank_detected": False,
+            "freeze_detected": False,
+            "silent_audio_detected": True,
+            "silent_audio_duration_secs": 12.0,
+        }
+
+    service._run_blank_probe_until_viewer_left = fake_continuous_probe
+    service._run_blank_probe = lambda url, config: {"blank_detected": False, "freeze_detected": False}
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "watch_mode": "continuous",
+        "confirmation_count": 1,
+        "silent_audio_detection_enabled": True,
+        "next_stream_pre_probe_enabled": True,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+        "watcher_client_count": 0,
+    }
+
+    service._probe_target(udi, target, config)
+    status = service.get_status()
+
+    assert len(probe_calls) == 2
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert status["recent_events"][0]["type"] == "switch_success"
+    assert status["recent_events"][0]["details"]["recovery_guard"]["bypassed"] is True
+    assert "watcher_recovery_observed" in [event["type"] for event in status["recent_events"]]
 
 
 def test_confirmed_blank_rechecks_after_switch_and_skips_attempted_target(tmp_path):

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -98,6 +98,14 @@ def test_watch_mode_controls_scan_delay():
     assert defaults["freeze_detection_enabled"] is True
     assert defaults["no_decodable_frames_detection_enabled"] is True
     assert defaults["no_decodable_frames_min_duration_seconds"] == 10.0
+    assert defaults["garbled_audio_detection_enabled"] is False
+    assert defaults["garbled_audio_error_threshold"] == 3
+    assert defaults["silent_audio_detection_enabled"] is False
+    assert defaults["silent_audio_min_duration_seconds"] == 10.0
+    assert defaults["silent_audio_noise_db"] == -50
+    assert defaults["offline_image_detection_enabled"] is False
+    assert defaults["offline_image_reference_hashes"] == []
+    assert defaults["offline_image_hash_threshold"] == 4
     assert defaults["confirmation_count"] == 2
     assert defaults["channel_cooldown_seconds"] == 300
     assert defaults["max_switches_per_hour"] == 3
@@ -694,6 +702,134 @@ def test_confirmed_no_decodable_frames_switches_to_next_stream_when_live(tmp_pat
     assert status["recent_events"][0]["type"] == "switch_success"
     assert status["recent_events"][0]["details"]["reason"] == "no_decodable_frames"
     assert status["cooldowns"] == []
+
+
+def test_audio_detection_parser_detects_garbled_audio_after_threshold():
+    config = normalize_config({
+        "garbled_audio_detection_enabled": True,
+        "garbled_audio_error_threshold": 2,
+    })
+    output = (
+        "Error while decoding stream #0:1: audio decode error\n"
+        "[aac @ 000] channel element 3.7 is not allocated in audio stream #0:1\n"
+    )
+
+    parsed = ShadowBlankMonitorService._parse_audio_detection(
+        output,
+        config,
+        observed_duration=12,
+    )
+
+    assert parsed["garbled_audio_detected"] is True
+    assert parsed["garbled_audio_error_count"] == 2
+    assert "audio" in parsed["garbled_audio_error"].lower()
+
+
+def test_audio_detection_parser_detects_silent_audio_duration():
+    config = normalize_config({
+        "silent_audio_detection_enabled": True,
+        "silent_audio_min_duration_seconds": 10,
+        "silent_audio_noise_db": -48,
+    })
+    output = (
+        "[silencedetect @ 000] silence_start: 1.5\n"
+        "[silencedetect @ 000] silence_end: 13.0 | silence_duration: 11.5\n"
+    )
+
+    parsed = ShadowBlankMonitorService._parse_audio_detection(
+        output,
+        config,
+        observed_duration=14,
+    )
+
+    assert parsed["silent_audio_detected"] is True
+    assert parsed["silent_audio_duration_secs"] == 11.5
+    assert parsed["silent_audio_noise_db"] == -48
+
+
+def test_media_fault_results_are_ignored_unless_enabled(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status()}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11, 12]}],
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {
+            "garbled_audio_detected": True,
+            "silent_audio_detected": True,
+            "offline_image_detected": True,
+        },
+        switch_calls=switch_calls,
+    )
+    service.update_config({"enabled": False, "dry_run": False, "confirmation_count": 1})
+
+    status = service.run_once(force=True)
+
+    assert switch_calls == []
+    assert status["recent_events"][0]["type"] == "probe_ok"
+
+
+def test_enabled_media_fault_switches_to_next_stream_when_live(tmp_path):
+    scenarios = [
+        (
+            "garbled_audio",
+            "garbled_audio_detection_enabled",
+            {
+                "garbled_audio_detected": True,
+                "garbled_audio_error_count": 3,
+                "garbled_audio_error": "audio decode error",
+            },
+        ),
+        (
+            "silent_audio",
+            "silent_audio_detection_enabled",
+            {
+                "silent_audio_detected": True,
+                "silent_audio_duration_secs": 12.0,
+            },
+        ),
+        (
+            "offline_image",
+            "offline_image_detection_enabled",
+            {
+                "offline_image_detected": True,
+                "offline_image_hash": "ffeeffeeffeeffee",
+                "offline_image_distance": 2,
+            },
+        ),
+    ]
+
+    for reason, enabled_key, probe_result in scenarios:
+        switch_calls = []
+        udi = FakeUdi(
+            statuses=[{"uuid-1": active_status()}],
+            channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11, 12]}],
+        )
+        service = make_service(
+            tmp_path / reason,
+            udi=udi,
+            blank_probe=lambda url, config, probe_result=probe_result: {
+                "blank_detected": False,
+                "freeze_detected": False,
+                **probe_result,
+            },
+            switch_calls=switch_calls,
+        )
+        service.update_config({
+            "enabled": False,
+            "dry_run": False,
+            "confirmation_count": 1,
+            enabled_key: True,
+        })
+
+        status = service.run_once(force=True)
+
+        assert switch_calls == [("uuid-1", 11, None)]
+        assert status["recent_events"][0]["type"] == "switch_success"
+        assert status["recent_events"][0]["details"]["reason"] == reason
+        assert status["cooldowns"] == []
 
 
 def test_watcher_recovery_guard_clears_pending_detection_and_switch_attempts(tmp_path):

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -734,6 +734,64 @@ def test_next_stream_pre_probe_skips_bad_candidate(tmp_path):
     assert status["recent_events"][1]["details"]["rejection_reason"] == "blank"
 
 
+def test_next_stream_pre_probe_respects_provider_capacity(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status()}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11, 12]}],
+        streams={
+            11: {"id": 11, "url": "http://candidate.local/capacity", "m3u_account": 7},
+            12: {"id": 12, "url": "http://candidate.local/good", "m3u_account": 8},
+        },
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"blank_detected": True},
+        switch_calls=switch_calls,
+    )
+    pre_probe_calls = []
+
+    def acquire_slot(_udi, stream):
+        if stream["id"] == 11:
+            return {
+                "acquired": False,
+                "reason": "provider_capacity",
+                "details": {"provider_limited": True},
+            }
+        return {
+            "acquired": True,
+            "reason": "acquired",
+            "url": stream["url"],
+            "details": {"provider_limited": True, "provider_slot_acquired": True},
+        }
+
+    def pre_probe(url, config):
+        pre_probe_calls.append(url)
+        return {"blank_detected": False}
+
+    released = []
+    service._acquire_pre_probe_provider_slot = acquire_slot
+    service._release_pre_probe_provider_slot = lambda slot: released.append(slot)
+    service._run_blank_probe = pre_probe
+    service.update_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": True,
+    })
+
+    status = service.run_once(force=True)
+
+    assert pre_probe_calls == ["http://candidate.local/good"]
+    assert switch_calls == [("uuid-1", 12, None)]
+    assert len(released) == 1
+    assert status["recent_events"][0]["type"] == "switch_success"
+    assert status["recent_events"][0]["details"]["pre_probe"]["provider_slot_acquired"] is True
+    assert status["recent_events"][1]["type"] == "pre_probe_rejected"
+    assert status["recent_events"][1]["details"]["rejection_reason"] == "provider_capacity"
+
+
 def test_confirmed_freeze_switches_to_next_stream_when_live(tmp_path):
     switch_calls = []
     udi = FakeUdi(

--- a/backend/tests/test_stream_check_utils.py
+++ b/backend/tests/test_stream_check_utils.py
@@ -9,6 +9,7 @@ essential quality metrics using ffmpeg/ffprobe.
 import unittest
 from unittest.mock import patch, MagicMock
 import json
+import subprocess
 import sys
 import os
 
@@ -18,6 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from apps.stream.stream_check_utils import (
     check_ffmpeg_installed,
     get_stream_info,
+    get_stream_info_and_bitrate,
     get_stream_bitrate,
     analyze_stream
 )
@@ -129,6 +131,74 @@ class TestGetStreamBitrate(unittest.TestCase):
         
         self.assertIsNone(bitrate)
         self.assertEqual(status, "Timeout")
+
+
+class TestGetStreamInfoAndBitrate(unittest.TestCase):
+    """Test combined ffmpeg analysis with ffprobe safety fallbacks."""
+
+    @patch('subprocess.run')
+    def test_ffprobe_fallback_accepts_valid_media_after_ffmpeg_timeout(self, mock_run):
+        """KPTV-style streams should not be marked dead when ffprobe proves media."""
+        ffprobe_payload = {
+            'programs': [
+                {
+                    'streams': [
+                        {
+                            'index': 0,
+                            'codec_name': 'h264',
+                            'codec_type': 'video',
+                            'width': 1216,
+                            'height': 684,
+                            'r_frame_rate': '30/1',
+                            'avg_frame_rate': '30/1',
+                        },
+                        {
+                            'index': 1,
+                            'codec_name': 'aac',
+                            'codec_type': 'audio',
+                            'bit_rate': '98800',
+                        },
+                    ],
+                },
+            ],
+            'streams': [
+                {
+                    'index': 0,
+                    'codec_name': 'h264',
+                    'codec_type': 'video',
+                    'width': 1216,
+                    'height': 684,
+                    'r_frame_rate': '30/1',
+                    'avg_frame_rate': '30/1',
+                },
+                {
+                    'index': 1,
+                    'codec_name': 'aac',
+                    'codec_type': 'audio',
+                    'bit_rate': '98800',
+                },
+            ],
+        }
+        mock_run.side_effect = [
+            subprocess.TimeoutExpired(cmd='ffmpeg', timeout=70),
+            MagicMock(returncode=0, stdout=json.dumps(ffprobe_payload), stderr=''),
+        ]
+
+        result = get_stream_info_and_bitrate(
+            'http://test.com/kptv-proxy-stream',
+            duration=30,
+            timeout=30,
+            stream_startup_buffer=10,
+        )
+
+        self.assertEqual(result['status'], 'OK')
+        self.assertEqual(result['resolution'], '1216x684')
+        self.assertEqual(result['fps'], 30)
+        self.assertEqual(result['video_codec'], 'h264')
+        self.assertEqual(result['audio_codec'], 'aac')
+        self.assertTrue(result['ffprobe_fallback_ran'])
+        self.assertEqual(result['ffprobe_fallback_reason'], 'ffmpeg_timeout')
+        self.assertEqual(result['bitrate_source'], 'ffprobe_media_fallback_no_bitrate')
 
 
 class TestAnalyzeStream(unittest.TestCase):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.68.0",
-        "react-router-dom": "^6.30.3",
+        "react-router-dom": "^6.30.4",
         "recharts": "^2.8.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
@@ -1649,9 +1649,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -4065,12 +4065,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4080,13 +4080,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.68.0",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^6.30.4",
     "recharts": "^2.8.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/frontend/src/lib/scheduling-auto-create-display.js
+++ b/frontend/src/lib/scheduling-auto-create-display.js
@@ -20,6 +20,7 @@ const getSchedulingBreakdown = (data = {}) => {
   const alreadyCheckedMatches = finiteNumber(data.already_checked_matches)
   const missingTimeMatches = finiteNumber(data.missing_time_matches)
   const invalidTimeMatches = finiteNumber(data.invalid_time_matches)
+  const guardrailBlockedMatches = finiteNumber(data.guardrail_blocked_matches)
   const unscheduledMatches = endedMatches + alreadyCheckedMatches + missingTimeMatches + invalidTimeMatches
 
   return {
@@ -31,6 +32,7 @@ const getSchedulingBreakdown = (data = {}) => {
     alreadyCheckedMatches,
     missingTimeMatches,
     invalidTimeMatches,
+    guardrailBlockedMatches,
     unscheduledMatches,
     hasSchedulingSplit: totalEpgMatches !== matches || dueNowMatches > 0,
   }
@@ -50,6 +52,7 @@ export const getAutoCreateRuleTestToast = ({
     alreadyCheckedMatches,
     missingTimeMatches,
     invalidTimeMatches,
+    guardrailBlockedMatches,
     hasSchedulingSplit,
   } = getSchedulingBreakdown(data)
   const channelsTested = finiteNumber(data.channels_tested, selectedChannelCount)
@@ -66,6 +69,15 @@ export const getAutoCreateRuleTestToast = ({
       description: channelsTested > 1
         ? 'None of the selected channels have a TVG-ID set. EPG matching requires TVG-IDs on the source channels.'
         : 'This channel has no TVG-ID set. EPG matching requires a TVG-ID.',
+      variant: 'destructive',
+    }
+  }
+
+  if (data.guardrail?.blocked || guardrailBlockedMatches > 0) {
+    const limit = data.guardrail?.limit
+    return {
+      title: 'Guardrail Blocked',
+      description: `${guardrailBlockedMatches || totalEpgMatches} schedulable ${plural(guardrailBlockedMatches || totalEpgMatches, 'match', 'matches')} would exceed the configured max${limit ? ` of ${limit}` : ''}. Narrow the regex or raise the rule limit intentionally.`,
       variant: 'destructive',
     }
   }
@@ -148,8 +160,24 @@ export const getAutoCreateRuleTestDiagnostics = (responseData = {}) => {
     alreadyCheckedMatches,
     missingTimeMatches,
     invalidTimeMatches,
+    guardrailBlockedMatches,
   } = getSchedulingBreakdown(data)
   const diagnostics = []
+
+  if (data.guardrail?.blocked || guardrailBlockedMatches > 0) {
+    const blockedPrograms = data.guardrail_blocked_programs || []
+    diagnostics.push({
+      key: 'guardrail_blocked',
+      label: 'Guardrail blocked',
+      count: guardrailBlockedMatches || data.guardrail?.candidate_count || 0,
+      detail: `This rule would create too many checks${data.guardrail?.limit ? ` for the configured limit of ${data.guardrail.limit}` : ''}. Narrow the regex or raise the max checks value deliberately.`,
+      sampleTitles: blockedPrograms.map(program => program.title).filter(Boolean).slice(0, 4),
+      channels: blockedPrograms.map(program => ({
+        id: program.channel_id,
+        name: program.channel_name,
+      })).filter(channel => channel.id || channel.name).slice(0, 5),
+    })
+  }
 
   if (dueNowMatches > 0) {
     diagnostics.push({

--- a/frontend/src/lib/scheduling-auto-create-display.test.js
+++ b/frontend/src/lib/scheduling-auto-create-display.test.js
@@ -103,6 +103,26 @@ describe('getAutoCreateRuleTestToast', () => {
     })
   })
 
+  it('reports guardrail-blocked matches before generic no-schedulable messaging', () => {
+    expect(getAutoCreateRuleTestToast({
+      responseData: {
+        matches: 0,
+        total_epg_matches: 12,
+        guardrail_blocked_matches: 12,
+        guardrail: {
+          blocked: true,
+          limit: 10,
+          reason: 'max_events_per_rule_run',
+        },
+      },
+      selectedChannelCount: 12,
+    })).toEqual({
+      title: 'Guardrail Blocked',
+      description: '12 schedulable matches would exceed the configured max of 10. Narrow the regex or raise the rule limit intentionally.',
+      variant: 'destructive',
+    })
+  })
+
   it('treats null test data as an empty diagnostic snapshot', () => {
     expect(getAutoCreateRuleTestToast({
       responseData: null,
@@ -173,6 +193,32 @@ describe('getAutoCreateRuleTestToast', () => {
         count: 4,
         detail: '3 already ended, 1 missing start/end time',
         channels: [{ id: 9, name: 'No Time' }],
+      },
+    ])
+  })
+
+  it('builds guardrail diagnostics with blocked program examples', () => {
+    expect(getAutoCreateRuleTestDiagnostics({
+      guardrail_blocked_matches: 2,
+      guardrail: {
+        blocked: true,
+        limit: 1,
+      },
+      guardrail_blocked_programs: [
+        { title: 'Live: MLB', channel_id: 10, channel_name: 'Team A' },
+        { title: 'Live: NHL', channel_id: 11, channel_name: 'Team B' },
+      ],
+    })).toEqual([
+      {
+        key: 'guardrail_blocked',
+        label: 'Guardrail blocked',
+        count: 2,
+        detail: 'This rule would create too many checks for the configured limit of 1. Narrow the regex or raise the max checks value deliberately.',
+        sampleTitles: ['Live: MLB', 'Live: NHL'],
+        channels: [
+          { id: 10, name: 'Team A' },
+          { id: 11, name: 'Team B' },
+        ],
       },
     ])
   })

--- a/frontend/src/lib/shadow-monitor-config-fields.js
+++ b/frontend/src/lib/shadow-monitor-config-fields.js
@@ -2,6 +2,7 @@ export const shadowMonitorNumberFields = [
   { key: 'poll_interval_seconds', label: 'Poll Interval', suffix: 'sec', min: 5, max: 3600 },
   { key: 'watch_gap_seconds', label: 'Watch Gap', suffix: 'sec', min: 1, max: 300 },
   { key: 'probe_duration_seconds', label: 'Probe Duration', suffix: 'sec', min: 3, max: 120 },
+  { key: 'next_stream_pre_probe_duration_seconds', label: 'Next Probe Duration', suffix: 'sec', min: 3, max: 60 },
   { key: 'garbled_audio_error_threshold', label: 'Audio Error Threshold', suffix: 'hits', min: 1, max: 20 },
   { key: 'confirmation_count', label: 'Confirmations', suffix: 'hits', min: 1, max: 5 },
   {

--- a/frontend/src/lib/shadow-monitor-config-fields.js
+++ b/frontend/src/lib/shadow-monitor-config-fields.js
@@ -2,6 +2,7 @@ export const shadowMonitorNumberFields = [
   { key: 'poll_interval_seconds', label: 'Poll Interval', suffix: 'sec', min: 5, max: 3600 },
   { key: 'watch_gap_seconds', label: 'Watch Gap', suffix: 'sec', min: 1, max: 300 },
   { key: 'probe_duration_seconds', label: 'Probe Duration', suffix: 'sec', min: 3, max: 120 },
+  { key: 'garbled_audio_error_threshold', label: 'Audio Error Threshold', suffix: 'hits', min: 1, max: 20 },
   { key: 'confirmation_count', label: 'Confirmations', suffix: 'hits', min: 1, max: 5 },
   {
     key: 'channel_cooldown_seconds',
@@ -20,6 +21,9 @@ export const shadowMonitorNumberFields = [
     help: 'Maximum successful stream switches for one channel in a rolling hour.',
   },
   { key: 'max_concurrent_watchers', label: 'Watchers', suffix: 'max', min: 1, max: 10 },
+  { key: 'silent_audio_noise_db', label: 'Silence Level', suffix: 'dB', min: -90, max: -20 },
+  { key: 'offline_image_hash_threshold', label: 'Offline Hash Gap', suffix: 'pHash', min: 0, max: 20 },
+  { key: 'offline_image_capture_offset_seconds', label: 'Offline Capture Offset', suffix: 'sec', min: 0, max: 30 },
 ]
 
 export const shadowMonitorThresholdFields = [
@@ -30,4 +34,5 @@ export const shadowMonitorThresholdFields = [
   { key: 'freeze_noise_threshold', label: 'Freeze Noise', step: '0.001', min: 0, max: 1 },
   { key: 'freeze_ratio_threshold', label: 'Freeze Ratio', step: '0.01', min: 0.1, max: 1 },
   { key: 'no_decodable_frames_min_duration_seconds', label: 'Decoder Stall Duration', step: '0.5', min: 3, max: 60 },
+  { key: 'silent_audio_min_duration_seconds', label: 'Silent Audio Duration', step: '0.5', min: 2, max: 60 },
 ]

--- a/frontend/src/lib/shadow-monitor-config-fields.test.js
+++ b/frontend/src/lib/shadow-monitor-config-fields.test.js
@@ -31,10 +31,14 @@ describe('shadowMonitorNumberFields', () => {
       'poll_interval_seconds',
       'watch_gap_seconds',
       'probe_duration_seconds',
+      'garbled_audio_error_threshold',
       'confirmation_count',
       'channel_cooldown_seconds',
       'max_switches_per_hour',
       'max_concurrent_watchers',
+      'silent_audio_noise_db',
+      'offline_image_hash_threshold',
+      'offline_image_capture_offset_seconds',
     ])
 
     expect(shadowMonitorThresholdFields.map(field => field.key)).toEqual([
@@ -45,6 +49,7 @@ describe('shadowMonitorNumberFields', () => {
       'freeze_noise_threshold',
       'freeze_ratio_threshold',
       'no_decodable_frames_min_duration_seconds',
+      'silent_audio_min_duration_seconds',
     ])
   })
 })

--- a/frontend/src/lib/shadow-monitor-config-fields.test.js
+++ b/frontend/src/lib/shadow-monitor-config-fields.test.js
@@ -31,6 +31,7 @@ describe('shadowMonitorNumberFields', () => {
       'poll_interval_seconds',
       'watch_gap_seconds',
       'probe_duration_seconds',
+      'next_stream_pre_probe_duration_seconds',
       'garbled_audio_error_threshold',
       'confirmation_count',
       'channel_cooldown_seconds',

--- a/frontend/src/pages/Scheduling.jsx
+++ b/frontend/src/pages/Scheduling.jsx
@@ -34,6 +34,7 @@ const SCHEDULE_TYPE_INFO = {
     detailsPlural: 'Creates monitoring sessions for continuous quality tracking'
   }
 }
+const DEFAULT_AUTO_CREATE_MAX_EVENTS_PER_RUN = 10
 
 export default function Scheduling() {
   const [events, setEvents] = useState([])
@@ -66,6 +67,7 @@ export default function Scheduling() {
   const [ruleName, setRuleName] = useState('')
   const [ruleRegexPattern, setRuleRegexPattern] = useState('')
   const [ruleMinutesBefore, setRuleMinutesBefore] = useState(5)
+  const [ruleMaxEventsPerRun, setRuleMaxEventsPerRun] = useState(DEFAULT_AUTO_CREATE_MAX_EVENTS_PER_RUN)
   const [ruleScheduleType, setRuleScheduleType] = useState('check')  // 'check' or 'monitoring'
   const [ruleEnableLoopingDetection, setRuleEnableLoopingDetection] = useState(true)
   const [ruleEnableLogoDetection, setRuleEnableLogoDetection] = useState(true)
@@ -101,6 +103,7 @@ export default function Scheduling() {
     setRuleSelectedChannelGroups([])
     setRuleRegexPattern('')
     setRuleMinutesBefore(5)
+    setRuleMaxEventsPerRun(DEFAULT_AUTO_CREATE_MAX_EVENTS_PER_RUN)
     setRuleScheduleType('check')
     setRuleEnableLoopingDetection(true)
     setRuleEnableLogoDetection(true)
@@ -255,6 +258,11 @@ export default function Scheduling() {
     return !isNaN(minutesValue) && minutesValue >= 0
   }
 
+  const validateMaxEventsPerRun = (value) => {
+    const maxValue = parseInt(value)
+    return !isNaN(maxValue) && maxValue >= 1
+  }
+
   const handleRuleChannelSelect = (channelId) => {
     const channel = channels.find(c => c.id === parseInt(channelId))
     if (!channel) return
@@ -316,6 +324,7 @@ export default function Scheduling() {
         channel_group_ids: selectedGroupIds,
         regex_pattern: ruleRegexPattern,
         minutes_before: parseInt(ruleMinutesBefore) || 0,
+        max_events_per_run: parseInt(ruleMaxEventsPerRun) || DEFAULT_AUTO_CREATE_MAX_EVENTS_PER_RUN,
       })
 
       setRegexMatches(response.data.programs || [])
@@ -377,6 +386,14 @@ export default function Scheduling() {
       })
       return
     }
+    if (!validateMaxEventsPerRun(ruleMaxEventsPerRun)) {
+      toast({
+        title: "Validation Error",
+        description: "Please enter a valid max checks value (1 or greater)",
+        variant: "destructive"
+      })
+      return
+    }
 
     try {
       const ruleData = {
@@ -385,6 +402,7 @@ export default function Scheduling() {
         channel_group_ids: ruleSelectedChannelGroups.map(g => g.id),
         regex_pattern: ruleRegexPattern,
         minutes_before: minutesBeforeValue,
+        max_events_per_run: parseInt(ruleMaxEventsPerRun),
         schedule_type: ruleScheduleType,
         enable_looping_detection: ruleEnableLoopingDetection,
         enable_logo_detection: ruleEnableLogoDetection
@@ -445,6 +463,7 @@ export default function Scheduling() {
     setRuleName(rule.name)
     setRuleRegexPattern(rule.regex_pattern)
     setRuleMinutesBefore(rule.minutes_before)
+    setRuleMaxEventsPerRun(rule.max_events_per_run || DEFAULT_AUTO_CREATE_MAX_EVENTS_PER_RUN)
     setRuleScheduleType(rule.schedule_type || 'check')  // Default to 'check' for backward compatibility
     setRuleEnableLoopingDetection(rule.enable_looping_detection !== false)
     setRuleEnableLogoDetection(rule.enable_logo_detection !== false)
@@ -615,6 +634,7 @@ export default function Scheduling() {
       setRuleName(rule.name || '')
       setRuleRegexPattern(rule.regex_pattern || '')
       setRuleMinutesBefore(rule.minutes_before || 5)
+      setRuleMaxEventsPerRun(rule.max_events_per_run || DEFAULT_AUTO_CREATE_MAX_EVENTS_PER_RUN)
 
       // Handle channel selection
       const channelIds = rule.channel_ids || (rule.channel_id ? [rule.channel_id] : [])
@@ -1562,6 +1582,21 @@ export default function Scheduling() {
                           </p>
                         </div>
 
+                        <div className="space-y-2">
+                          <Label htmlFor="rule-max-events">Max Checks per Rule Run</Label>
+                          <Input
+                            id="rule-max-events"
+                            type="number"
+                            min="1"
+                            max="250"
+                            value={ruleMaxEventsPerRun}
+                            onChange={(e) => setRuleMaxEventsPerRun(e.target.value)}
+                          />
+                          <p className="text-sm text-muted-foreground">
+                            If this rule would create more checks, StreamFlow blocks the rule instead of creating a mass queue.
+                          </p>
+                        </div>
+
                         {/* Schedule Type Selection */}
                         <div className="space-y-2">
                           <Label htmlFor="rule-schedule-type">Schedule Type</Label>
@@ -1671,6 +1706,7 @@ export default function Scheduling() {
                     <TableHead>Channels</TableHead>
                     <TableHead>Regex Pattern</TableHead>
                     <TableHead>Minutes Before</TableHead>
+                    <TableHead>Max Checks</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -1758,6 +1794,7 @@ export default function Scheduling() {
                           <code className="text-xs bg-muted px-2 py-1 rounded">{rule.regex_pattern}</code>
                         </TableCell>
                         <TableCell>{rule.minutes_before} min</TableCell>
+                        <TableCell>{rule.max_events_per_run || DEFAULT_AUTO_CREATE_MAX_EVENTS_PER_RUN}</TableCell>
                         <TableCell className="text-right">
                           <div className="flex items-center justify-end gap-1">
                             <Button

--- a/frontend/src/pages/ShadowBlankMonitor.jsx
+++ b/frontend/src/pages/ShadowBlankMonitor.jsx
@@ -34,6 +34,9 @@ const eventLabels = {
   probe_ok: 'Probe OK',
   blank_pending: 'Blank Pending',
   freeze_pending: 'Freeze Pending',
+  garbled_audio_pending: 'Garbled Audio Pending',
+  silent_audio_pending: 'Silent Audio Pending',
+  offline_image_pending: 'Offline Image Pending',
   dry_run_switch: 'Dry Run Switch',
   switch_success: 'Switch Success',
   switch_failed: 'Switch Failed',
@@ -79,6 +82,7 @@ export default function ShadowBlankMonitor() {
   const [status, setStatus] = useState(null)
   const [excludedIds, setExcludedIds] = useState('')
   const [excludedUuids, setExcludedUuids] = useState('')
+  const [offlineImageHashes, setOfflineImageHashes] = useState('')
   const [loading, setLoading] = useState(true)
   const [actionLoading, setActionLoading] = useState('')
   const { toast } = useToast()
@@ -106,6 +110,7 @@ export default function ShadowBlankMonitor() {
       setEditedConfig(nextConfig)
       setExcludedIds((nextConfig.excluded_channel_ids || []).join(', '))
       setExcludedUuids((nextConfig.excluded_channel_uuids || []).join(', '))
+      setOfflineImageHashes((nextConfig.offline_image_reference_hashes || []).join(', '))
       setStatus(statusResponse.data || {})
     } catch (err) {
       console.error('Failed to load shadow monitor data:', err)
@@ -142,6 +147,7 @@ export default function ShadowBlankMonitor() {
         ...(editedConfig || {}),
         excluded_channel_ids: parseCsv(excludedIds, true),
         excluded_channel_uuids: parseCsv(excludedUuids),
+        offline_image_reference_hashes: parseCsv(offlineImageHashes),
         ...extra,
       }
       const response = await shadowBlankMonitorAPI.updateConfig(payload)
@@ -150,6 +156,7 @@ export default function ShadowBlankMonitor() {
       setEditedConfig(nextConfig)
       setExcludedIds((nextConfig.excluded_channel_ids || []).join(', '))
       setExcludedUuids((nextConfig.excluded_channel_uuids || []).join(', '))
+      setOfflineImageHashes((nextConfig.offline_image_reference_hashes || []).join(', '))
       await loadStatus()
       toast({ title: 'Saved', description: 'Shadow monitor configuration updated' })
     } catch (err) {
@@ -350,6 +357,39 @@ export default function ShadowBlankMonitor() {
                 />
               </div>
 
+              <div className="flex items-center justify-between rounded-md border p-3">
+                <div>
+                  <Label className="text-sm font-medium">Garbled Audio</Label>
+                  <p className="text-xs text-muted-foreground">Treat repeated audio decode errors as a media fault</p>
+                </div>
+                <Switch
+                  checked={Boolean(editedConfig.garbled_audio_detection_enabled)}
+                  onCheckedChange={(value) => updateConfigValue('garbled_audio_detection_enabled', value)}
+                />
+              </div>
+
+              <div className="flex items-center justify-between rounded-md border p-3">
+                <div>
+                  <Label className="text-sm font-medium">Silent Audio</Label>
+                  <p className="text-xs text-muted-foreground">Treat long audio silence as a media fault</p>
+                </div>
+                <Switch
+                  checked={Boolean(editedConfig.silent_audio_detection_enabled)}
+                  onCheckedChange={(value) => updateConfigValue('silent_audio_detection_enabled', value)}
+                />
+              </div>
+
+              <div className="flex items-center justify-between rounded-md border p-3 md:col-span-2">
+                <div>
+                  <Label className="text-sm font-medium">Offline Image</Label>
+                  <p className="text-xs text-muted-foreground">Detect provider offline slates by reference pHash</p>
+                </div>
+                <Switch
+                  checked={Boolean(editedConfig.offline_image_detection_enabled)}
+                  onCheckedChange={(value) => updateConfigValue('offline_image_detection_enabled', value)}
+                />
+              </div>
+
               <div className="rounded-md border p-3 md:col-span-2">
                 <Label className="text-sm font-medium">Watch Mode</Label>
                 <div className="mt-3 grid gap-2 sm:grid-cols-2">
@@ -413,6 +453,21 @@ export default function ShadowBlankMonitor() {
                   />
                 </div>
               ))}
+            </div>
+
+            <Separator />
+
+            <div className="space-y-2">
+              <Label htmlFor="offline_image_reference_hashes">Offline Image Reference pHashes</Label>
+              <Input
+                id="offline_image_reference_hashes"
+                placeholder="comma-separated pHash values"
+                value={offlineImageHashes}
+                onChange={(event) => setOfflineImageHashes(event.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Offline-image switching stays disabled unless at least one reference hash is configured.
+              </p>
             </div>
 
             <Separator />
@@ -529,6 +584,9 @@ export default function ShadowBlankMonitor() {
                           )}
                           {channel.last_probe?.freeze_detected && <Badge variant="outline">Frozen</Badge>}
                           {channel.last_probe?.blank_detected && <Badge variant="outline">Blank</Badge>}
+                          {channel.last_probe?.garbled_audio_detected && <Badge variant="outline">Garbled Audio</Badge>}
+                          {channel.last_probe?.silent_audio_detected && <Badge variant="outline">Silent Audio</Badge>}
+                          {channel.last_probe?.offline_image_detected && <Badge variant="outline">Offline Image</Badge>}
                         </div>
                       </div>
                     )

--- a/frontend/src/pages/ShadowBlankMonitor.jsx
+++ b/frontend/src/pages/ShadowBlankMonitor.jsx
@@ -48,6 +48,8 @@ const eventLabels = {
   quality_check_active: 'Quality Check Active',
   watcher_reconnecting: 'Watcher Reconnecting',
   watcher_recovered: 'Watcher Recovered',
+  pre_probe_unavailable: 'Pre-Probe Unavailable',
+  pre_probe_rejected: 'Pre-Probe Rejected',
 }
 
 const parseCsv = (value, numeric = false) => {
@@ -387,6 +389,17 @@ export default function ShadowBlankMonitor() {
                 <Switch
                   checked={Boolean(editedConfig.offline_image_detection_enabled)}
                   onCheckedChange={(value) => updateConfigValue('offline_image_detection_enabled', value)}
+                />
+              </div>
+
+              <div className="flex items-center justify-between rounded-md border p-3 md:col-span-2">
+                <div>
+                  <Label className="text-sm font-medium">Next Stream Pre-Probe</Label>
+                  <p className="text-xs text-muted-foreground">Validate the next candidate before switching</p>
+                </div>
+                <Switch
+                  checked={Boolean(editedConfig.next_stream_pre_probe_enabled)}
+                  onCheckedChange={(value) => updateConfigValue('next_stream_pre_probe_enabled', value)}
                 />
               </div>
 


### PR DESCRIPTION
## Status

V5 implementation PR for StreamFlow. The requested blocks are implemented on head `bef8b45dc1be8c5b98506c1a1f2bf4af7e7890c9`, CI is green, the updated GHCR image is built, deployed on the live Unraid system through the normal Unraid update path, and the final post-deploy live Full Run completed successfully.

User has explicitly approved moving this PR out of draft for merge readiness. The V5 gates have evidence attached; the actual merge action remains user-controlled.

## Implemented

- Adds read-only Last Quality Stats API:
  - `GET /api/stream-checker/streams/<stream_id>/last-quality-stats`
  - Reuses persisted run/telemetry history only.
  - Does not probe, queue, call Dispatcharr, or touch ffmpeg.
  - Marks never-measured, failed/blank/freeze/probe-failed/offline/no-decodable/0x0/incomplete measurements as `recheck_required`.
- Extends Shadow Monitor media-fault detection:
  - `offline_image`
  - `garbled_audio`
  - `silent_audio`
  - Existing `blank`/`freeze` behavior remains guarded.
- Adds separately configurable Shadow Next Stream Pre-Probe:
  - Default `false`, duration default `8s`, bounded `3..60`.
  - When enabled, candidate stream is checked before switching and rejected on bad media evidence.
  - Pre-probe respects provider/profile capacity and records accepted/rejected/unavailable details.
- Hardens Continuous watcher recovery handling:
  - Only `offline_image`, `garbled_audio`, and `silent_audio` can narrowly bypass a watcher-recovery guard.
  - Requires Continuous mode, active real viewer, unchanged current stream, enabled pre-probe, provider/profile slot, clean target probe, and required confirmations.
  - `blank`, `freeze`, and `no_decodable` stay under the normal watcher-recovery guard.
- Repairs/hardens Auto-Create EPG Regex queue behavior through SchedulingService:
  - Preview covers selected channels/groups.
  - Per-rule max-check guardrail blocks broad rules before events/queue creation.
  - Due EPG matches queue specialized single-channel checks with `source=auto_create` / `is_epg_scheduled=true`.
  - No Full Runs or massqueues are triggered by the EPG rule path.
- Updates `react-router-dom` to `6.30.4` to clear the current frontend audit finding.

## CI / Build Gates

- PR CI on `bef8b45dc1be8c5b98506c1a1f2bf4af7e7890c9`:
  - Tests workflow: success
    - Backend smoke tests: success
    - Frontend build and tests: success
  - CodeQL: success
    - Analyze (python): success
    - Analyze (javascript): success
- Fork GHCR workflow for `bef8b45dc1be8c5b98506c1a1f2bf4af7e7890c9`: success
  - https://github.com/bttfw/streamflow/actions/runs/27172871768
  - amd64 build: success
  - arm64 build: success
  - manifest merge: success
- Live image deployed through normal Unraid DockerMan update path:
  - `ghcr.io/bttfw/streamflow:last-quality-stats-api`
  - live image id `sha256:ed1c5d0e4729e98b2963e3516f59387f7918f4e52b1d5a4c0028dd2e76ca772d`
  - container healthy

## Local Gates

- Focused V5 backend suite: `82 passed`.
- Full Shadow suite after final guard fix: `48 passed`.
- `python -m py_compile backend/apps/stream/shadow_blank_monitor_service.py`: passed.
- Frontend build/tests/audit for touched UI/dependency path: passed, `0 vulnerabilities`.
- Full backend suite was started and collected 1208 tests but exceeded local timeout without a specific failure; CI backend smoke is green.

## Live Gates

- Last Quality Stats API:
  - known measured stream returns cached resolution/fps/codec/bitrate/HDR fields without queue/probe side effects.
  - unknown stream returns `never_measured` / `recheck_required:true`.
- Shadow media detection:
  - Live fixture probes inside the deployed V5 container: normal clean, offline-image detected, silent-audio detected, garbled-audio detected.
  - Real Shadow test gates used Dispatcharr channels/streams and real `/proxy/ts/stream/<uuid>` viewers.
  - Offline-image and garbled-audio Continuous gates produced real non-dry switch success with pre-probe evidence.
  - Provider-limit gate rejected pre-probe when provider/profile slots were unavailable; no switch.
  - Final Full Run observed real viewer activity on `WELT Newsroom`; Shadow raised watcher-recovery guards for `blank`, `garbled_audio`, and `blank`, and made no switch.
- EPG Regex queue trigger:
  - Multi-event rule `^Jetzt live: .* bei .*` matched 4 live Event channels and queued exactly 4 specialized single-channel checks.
  - No Full Run, no massqueue, no Teamarr destabilization.
  - Temporary rule/events were deleted and queue returned clean.
- Teamarr during final Full Run:
  - Multiple live event preflight buckets interleaved on channels 8592-8596.
  - All drained as single-channel checks; Full Run resumed and completed.

## Final Live Full Run

- Run ID: `automation-1780963365-46`
- Started: `2026-06-09T02:02:45` CEST
- Completed: `2026-06-09T09:55:17` CEST
- Duration: `28349.898s` total, `27627.018s` quality checking
- Stages: M3U refresh, cache sync, stream matching, queueing, quality checking, finalizing all completed
- M3U/stream matching:
  - 5 providers refreshed
  - post-refresh streams: 217895
  - stream matching: 217895/217895
- Quality:
  - 212/212 channels checked
  - `quality_failed:0`
  - `quality_incomplete:0`
  - `quality_aborted:0`
  - 3567 total streams, 3570 analyzed
  - 2734 good, 832 dead, 429 blank, 498 freeze, 64 revived
- Shadow during final Full Run:
  - Continuous, dry-run off, next-stream pre-probe on, media detections on
  - 3 watcher-recovery guard events: `blank`, `garbled_audio`, `blank`
  - 0 Shadow `switch_success`, `switch_failed`, `switch_blocked`, or `dry_run_switch`
- Evidence committed in the companion repo:
  - `notes/streamflow-v5-live-implementation-report-20260608.md`
  - `outputs/home/reports/sfv5-final-full-run-20260609-0202.json`
  - `outputs/home/reports/sfv5-final-full-run-monitor-20260609-0202.jsonl`

## Dependency / Image Decision

- No Python, ffmpeg, system package, or image-base update was needed for V5.
- Frontend dependency update was intentionally limited to `react-router-dom` for the audit finding and covered by lockfile/build/test/audit gates.
- Image validation used the existing GHCR workflow and normal Unraid update path, not a special local Docker release path.

## Notes / Non-Blocking Follow-Ups

- Teamarr repeatedly marked the same channel during active preflight windows, but the queue drained and the Full Run completed. Keep as an observation for future debounce/cooldown tuning.
- Event channels used in the EPG multi-match gate queued correctly; actual checks can still fail with existing `no_profile` unless an EPG/Automation profile is assigned for those channels.
- A separate freeze-only guard fixture would be useful regression evidence, but the final Full Run already proved the important conservative watcher-recovery behavior for blank and garbled-audio on a real viewer.