### PR TITLE
Fix Shadow Monitor watcher cleanup after viewers leave

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: StreamFlow CodeQL
+
+# StreamFlow intentionally allows operators to enter full regex patterns for
+# channel matching. The one-purpose helper below is reached only after the API
+# applies existing regex validation and ReDoS guards, so keep CodeQL focused on
+# accidental regex injection elsewhere.
+paths-ignore:
+  - backend/apps/automation/intentional_user_regex.py

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v3

--- a/backend/apps/api/match_preview_handlers.py
+++ b/backend/apps/api/match_preview_handlers.py
@@ -5,6 +5,7 @@ from typing import Any, Callable
 
 from flask import jsonify
 
+from apps.automation.regex_validation import search_user_regex
 from apps.core.logging_config import setup_logging
 
 logger = setup_logging(__name__)
@@ -111,12 +112,14 @@ def test_match_live_response(
 
                         search_pattern = substituted_pattern
                         search_pattern = whitespace_pattern.sub(r"\\s+", search_pattern)
-                        flags = 0 if case_sensitive else re.IGNORECASE
-
                         try:
                             if is_dangerous_regex(search_pattern):
                                 continue
-                            if re.search(search_pattern, search_name, flags):
+                            if search_user_regex(
+                                search_pattern,
+                                search_name,
+                                case_sensitive=case_sensitive,
+                            ):
                                 regex_matched = True
                                 if pattern_priority >= best_regex_priority:
                                     best_regex_priority = pattern_priority
@@ -283,12 +286,14 @@ def bulk_match_count_response(
                             substituted_pattern = pattern.replace("CHANNEL_NAME", escaped_channel_name)
                             search_pattern = substituted_pattern
                             search_pattern = whitespace_pattern.sub(r"\\s+", search_pattern)
-                            flags = 0 if case_sensitive else re.IGNORECASE
-
                             try:
                                 if is_dangerous_regex(search_pattern):
                                     continue
-                                if re.search(search_pattern, search_name, flags):
+                                if search_user_regex(
+                                    search_pattern,
+                                    search_name,
+                                    case_sensitive=case_sensitive,
+                                ):
                                     matched = True
                                     break
                             except re.error:

--- a/backend/apps/api/match_preview_handlers.py
+++ b/backend/apps/api/match_preview_handlers.py
@@ -86,7 +86,7 @@ def test_match_live_response(
                     if matched:
                         continue
 
-                    search_name = stream_name if case_sensitive else stream_name.lower()
+                    search_name = stream_name
                     regex_matched = False
                     best_regex_priority = 0
                     best_pattern_str = None
@@ -109,13 +109,14 @@ def test_match_live_response(
                         escaped_channel_name = re.escape(channel_name)
                         substituted_pattern = pattern.replace("CHANNEL_NAME", escaped_channel_name)
 
-                        search_pattern = substituted_pattern if case_sensitive else substituted_pattern.lower()
+                        search_pattern = substituted_pattern
                         search_pattern = whitespace_pattern.sub(r"\\s+", search_pattern)
+                        flags = 0 if case_sensitive else re.IGNORECASE
 
                         try:
                             if is_dangerous_regex(search_pattern):
                                 continue
-                            if re.search(search_pattern, search_name):
+                            if re.search(search_pattern, search_name, flags):
                                 regex_matched = True
                                 if pattern_priority >= best_regex_priority:
                                     best_regex_priority = pattern_priority
@@ -263,7 +264,7 @@ def bulk_match_count_response(
                             matched = True
 
                     elif match_type == "regex" and has_regex:
-                        search_name = stream_name if case_sensitive else stream_name.lower()
+                        search_name = stream_name
 
                         for pattern_obj in normalized_patterns:
                             pattern = pattern_obj.get("pattern", "")
@@ -280,13 +281,14 @@ def bulk_match_count_response(
 
                             escaped_channel_name = re.escape(channel_name)
                             substituted_pattern = pattern.replace("CHANNEL_NAME", escaped_channel_name)
-                            search_pattern = substituted_pattern if case_sensitive else substituted_pattern.lower()
+                            search_pattern = substituted_pattern
                             search_pattern = whitespace_pattern.sub(r"\\s+", search_pattern)
+                            flags = 0 if case_sensitive else re.IGNORECASE
 
                             try:
                                 if is_dangerous_regex(search_pattern):
                                     continue
-                                if re.search(search_pattern, search_name):
+                                if re.search(search_pattern, search_name, flags):
                                     matched = True
                                     break
                             except re.error:

--- a/backend/apps/api/match_preview_handlers.py
+++ b/backend/apps/api/match_preview_handlers.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 
 from flask import jsonify
 
-from apps.automation.regex_validation import search_user_regex
+from apps.automation.intentional_user_regex import search_user_regex
 from apps.core.logging_config import setup_logging
 
 logger = setup_logging(__name__)

--- a/backend/apps/api/regex_handlers.py
+++ b/backend/apps/api/regex_handlers.py
@@ -16,7 +16,7 @@ from apps.automation.regex_settings import (
     default_channel_regex_global_settings,
     normalize_channel_regex_global_settings,
 )
-from apps.automation.regex_validation import search_user_regex
+from apps.automation.intentional_user_regex import search_user_regex
 from apps.channels.repository import UdiChannelRepository
 from apps.core.api_responses import error_response
 from apps.core.exceptions import ValidationError

--- a/backend/apps/api/regex_handlers.py
+++ b/backend/apps/api/regex_handlers.py
@@ -16,6 +16,7 @@ from apps.automation.regex_settings import (
     default_channel_regex_global_settings,
     normalize_channel_regex_global_settings,
 )
+from apps.automation.regex_validation import search_user_regex
 from apps.channels.repository import UdiChannelRepository
 from apps.core.api_responses import error_response
 from apps.core.exceptions import ValidationError
@@ -1045,14 +1046,16 @@ def test_regex_pattern_response(
 
         search_pattern = pattern
         search_pattern = whitespace_pattern.sub(r"\\s+", search_pattern)
-        flags = 0 if case_sensitive else re.IGNORECASE
-
         try:
             if is_dangerous_regex(search_pattern):
                 return jsonify(
                     {"error": "Regex pattern contains dangerous nested quantifiers (ReDoS risk)"}
                 ), 400
-            match = re.search(search_pattern, stream_name, flags)
+            match = search_user_regex(
+                search_pattern,
+                stream_name,
+                case_sensitive=case_sensitive,
+            )
             return jsonify(
                 {
                     "matches": bool(match),
@@ -1142,13 +1145,15 @@ def test_regex_pattern_live_response(
                     substituted_pattern = pattern.replace("CHANNEL_NAME", escaped_channel_name)
                     search_pattern = substituted_pattern
                     search_pattern = whitespace_pattern.sub(r"\\s+", search_pattern)
-                    flags = 0 if case_sensitive else re.IGNORECASE
-
                     try:
                         if is_dangerous_regex(search_pattern):
                             logger.warning(f"Invalid regex pattern '{pattern}': ReDoS risk")
                             continue
-                        if re.search(search_pattern, stream_name, flags):
+                        if search_user_regex(
+                            search_pattern,
+                            stream_name,
+                            case_sensitive=case_sensitive,
+                        ):
                             matched = True
                             matched_pattern = pattern
                             break

--- a/backend/apps/api/regex_handlers.py
+++ b/backend/apps/api/regex_handlers.py
@@ -12,6 +12,10 @@ from apps.api.schemas import (
     GroupRegexConfigSchema,
     RegexPatternCreateSchema,
 )
+from apps.automation.regex_settings import (
+    default_channel_regex_global_settings,
+    normalize_channel_regex_global_settings,
+)
 from apps.channels.repository import UdiChannelRepository
 from apps.core.api_responses import error_response
 from apps.core.exceptions import ValidationError
@@ -29,6 +33,55 @@ def get_regex_patterns_response(*, get_regex_matcher: Callable[[], Any]):
         return jsonify(patterns)
     except Exception as exc:
         logger.error(f"Error getting regex patterns: {exc}")
+        return jsonify({"error": "Internal Server Error"}), 500
+
+
+def get_regex_global_settings_response():
+    """Handle fetching global regex matching settings."""
+    try:
+        from apps.database.manager import get_db_manager
+
+        db = get_db_manager()
+        settings = db.get_system_setting(
+            "channel_regex_global_settings",
+            default_channel_regex_global_settings(),
+        )
+        return jsonify(normalize_channel_regex_global_settings(settings))
+    except Exception as exc:
+        logger.error(f"Error getting regex global settings: {exc}")
+        return jsonify({"error": "Internal Server Error"}), 500
+
+
+def update_regex_global_settings_response(*, payload: Any, get_regex_matcher: Callable[[], Any]):
+    """Handle updates to global regex matching settings."""
+    try:
+        if not isinstance(payload, dict):
+            return jsonify({"error": "Invalid JSON format: must be an object"}), 400
+
+        allowed_keys = set(default_channel_regex_global_settings().keys())
+        unknown_keys = sorted(str(key) for key in payload.keys() if key not in allowed_keys)
+        if unknown_keys:
+            return jsonify({"error": "Unknown global regex setting", "keys": unknown_keys}), 400
+
+        from apps.database.manager import get_db_manager
+
+        db = get_db_manager()
+        existing = db.get_system_setting(
+            "channel_regex_global_settings",
+            default_channel_regex_global_settings(),
+        )
+        settings = normalize_channel_regex_global_settings(payload, base=existing)
+        if not db.set_system_setting("channel_regex_global_settings", settings):
+            return jsonify({"error": "Failed to update regex global settings"}), 500
+
+        matcher = get_regex_matcher()
+        matcher.reload_patterns()
+        return jsonify({
+            "message": "Global regex settings updated successfully",
+            "settings": settings,
+        })
+    except Exception as exc:
+        logger.error(f"Error updating regex global settings: {exc}")
         return jsonify({"error": "Internal Server Error"}), 500
 
 
@@ -988,18 +1041,18 @@ def test_regex_pattern_response(
 
         pattern = payload["pattern"]
         stream_name = payload["stream_name"]
-        case_sensitive = payload.get("case_sensitive", False)
+        case_sensitive = payload.get("case_sensitive", True)
 
-        search_pattern = pattern if case_sensitive else pattern.lower()
-        search_name = stream_name if case_sensitive else stream_name.lower()
+        search_pattern = pattern
         search_pattern = whitespace_pattern.sub(r"\\s+", search_pattern)
+        flags = 0 if case_sensitive else re.IGNORECASE
 
         try:
             if is_dangerous_regex(search_pattern):
                 return jsonify(
                     {"error": "Regex pattern contains dangerous nested quantifiers (ReDoS risk)"}
                 ), 400
-            match = re.search(search_pattern, search_name)
+            match = re.search(search_pattern, stream_name, flags)
             return jsonify(
                 {
                     "matches": bool(match),
@@ -1081,21 +1134,21 @@ def test_regex_pattern_live_response(
                 if not stream_name:
                     continue
 
-                search_name = stream_name if case_sensitive else stream_name.lower()
                 matched = False
                 matched_pattern = None
 
                 for pattern in regex_patterns:
                     escaped_channel_name = re.escape(channel_name)
                     substituted_pattern = pattern.replace("CHANNEL_NAME", escaped_channel_name)
-                    search_pattern = substituted_pattern if case_sensitive else substituted_pattern.lower()
+                    search_pattern = substituted_pattern
                     search_pattern = whitespace_pattern.sub(r"\\s+", search_pattern)
+                    flags = 0 if case_sensitive else re.IGNORECASE
 
                     try:
                         if is_dangerous_regex(search_pattern):
                             logger.warning(f"Invalid regex pattern '{pattern}': ReDoS risk")
                             continue
-                        if re.search(search_pattern, search_name):
+                        if re.search(search_pattern, stream_name, flags):
                             matched = True
                             matched_pattern = pattern
                             break

--- a/backend/apps/api/setup_wizard_handlers.py
+++ b/backend/apps/api/setup_wizard_handlers.py
@@ -1,11 +1,13 @@
 """Setup wizard API handler functions extracted from web_api."""
 
+import json
 import threading
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 from flask import jsonify
 
+from apps.automation.regex_settings import default_channel_regex_global_settings
 from apps.core.logging_config import setup_logging
 
 logger = setup_logging(__name__)
@@ -99,14 +101,13 @@ def ensure_wizard_config_response(
             regex_file = config_dir / "channel_regex_config.json"
             if not regex_file.exists():
                 regex_file.write_text(
-                    """{
-  "patterns": {},
-  "global_settings": {
-    "case_sensitive": false,
-    "require_exact_match": false
-  }
-}
-""",
+                    json.dumps(
+                        {
+                            "patterns": {},
+                            "global_settings": default_channel_regex_global_settings(),
+                        },
+                        indent=2,
+                    ),
                     encoding="utf-8",
                 )
 
@@ -127,10 +128,7 @@ def ensure_wizard_config_response(
         if db.get_system_setting("channel_regex_global_settings", None) is None:
             db.set_system_setting(
                 "channel_regex_global_settings",
-                {
-                    "case_sensitive": False,
-                    "require_exact_match": False,
-                },
+                default_channel_regex_global_settings(),
             )
 
         return jsonify({"message": "Configuration files ensured"})
@@ -167,10 +165,7 @@ def create_sample_patterns_response():
                     "enabled": True,
                 },
             },
-            "global_settings": {
-                "case_sensitive": False,
-                "require_exact_match": False,
-            },
+            "global_settings": default_channel_regex_global_settings(),
         }
 
         imported, errors = db.import_channel_regex_configs_from_json(patterns, merge=False)

--- a/backend/apps/api/web_api.py
+++ b/backend/apps/api/web_api.py
@@ -63,6 +63,7 @@ from apps.api.regex_handlers import (
     export_regex_patterns_response,
     get_group_regex_config_response,
     get_common_regex_patterns_response,
+    get_regex_global_settings_response,
     import_regex_patterns_response,
     get_regex_patterns_response,
     mass_edit_preview_response,
@@ -71,6 +72,7 @@ from apps.api.regex_handlers import (
     test_regex_pattern_response,
     update_channel_match_settings_response,
     update_group_match_settings_response,
+    update_regex_global_settings_response,
     upsert_group_regex_config_response,
 )
 from apps.api.automation_handlers import (
@@ -960,6 +962,19 @@ def bulk_edit_regex_pattern():
 def bulk_update_match_settings():
     """Update match settings (e.g., match_by_tvg_id) for multiple channels."""
     return bulk_update_match_settings_response(
+        payload=request.get_json(silent=True),
+        get_regex_matcher=get_regex_matcher,
+    )
+
+@app.route('/api/regex-patterns/global-settings', methods=['GET'])
+def get_regex_global_settings():
+    """Get global regex matching settings."""
+    return get_regex_global_settings_response()
+
+@app.route('/api/regex-patterns/global-settings', methods=['PUT'])
+def update_regex_global_settings():
+    """Update global regex matching settings."""
+    return update_regex_global_settings_response(
         payload=request.get_json(silent=True),
         get_regex_matcher=get_regex_matcher,
     )

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -66,9 +66,10 @@ class RefreshResult(tuple):
 def _compile_stream_search_regex(pattern: str, channel_name: str, case_sensitive: bool) -> re.Pattern:
     """Compile and cache stream-matching regex patterns for reuse."""
     substituted_pattern = pattern.replace('CHANNEL_NAME', re.escape(channel_name))
-    search_pattern = substituted_pattern if case_sensitive else substituted_pattern.lower()
+    search_pattern = substituted_pattern
     search_pattern = _WHITESPACE_PATTERN.sub(r'\\s+', search_pattern)
-    return re.compile(search_pattern)
+    flags = 0 if case_sensitive else re.IGNORECASE
+    return re.compile(search_pattern, flags)
 
 # Import croniter for cron expression support
 try:
@@ -93,6 +94,10 @@ from apps.automation.automation_config_manager import get_automation_config_mana
 from apps.automation.channel_visibility_automation import (
     ChannelVisibilityAutomation,
     resolve_channel_visibility_config,
+)
+from apps.automation.regex_settings import (
+    default_channel_regex_global_settings,
+    normalize_channel_regex_global_settings,
 )
 
 # Import channel settings manager
@@ -548,10 +553,7 @@ class RegexChannelMatcher:
         if self._config_file is not None and self._file_backed_compat and not self._config_file.exists():
             empty = {
                 "patterns": {},
-                "global_settings": {
-                    "case_sensitive": False,
-                    "require_exact_match": False,
-                },
+                "global_settings": default_channel_regex_global_settings(),
             }
             self._config_file.parent.mkdir(parents=True, exist_ok=True)
             with open(self._config_file, 'w', encoding='utf-8') as fh:
@@ -564,8 +566,9 @@ class RegexChannelMatcher:
         configs = db.get_all_channel_regex_configs()
         global_settings = db.get_system_setting(
             'channel_regex_global_settings',
-            {'case_sensitive': True, 'require_exact_match': False},
+            default_channel_regex_global_settings(),
         )
+        global_settings = normalize_channel_regex_global_settings(global_settings)
 
         # --- One-time migration from legacy SystemSetting JSON blob ---
         if not configs:
@@ -577,7 +580,7 @@ class RegexChannelMatcher:
                     logger.warning(f"Migration errors: {errors}")
                 # Preserve global_settings from legacy blob
                 if 'global_settings' in legacy:
-                    global_settings = legacy['global_settings']
+                    global_settings = normalize_channel_regex_global_settings(legacy['global_settings'])
                     db.set_system_setting('channel_regex_global_settings', global_settings)
                 # Clear the old blob to avoid re-migration on next start
                 db.set_system_setting('channel_regex_config', None)
@@ -625,7 +628,7 @@ class RegexChannelMatcher:
         from apps.database.manager import get_db_manager
         db = get_db_manager()
         patterns_dict = patterns.get('patterns', {})
-        global_settings = patterns.get('global_settings', {})
+        global_settings = normalize_channel_regex_global_settings(patterns.get('global_settings', {}))
         imported, errors = db.import_channel_regex_configs_from_json(
             {'patterns': patterns_dict}, merge=False
         )
@@ -954,7 +957,7 @@ class RegexChannelMatcher:
         matches = []
         case_sensitive = self.channel_patterns.get("global_settings", {}).get("case_sensitive", True)
         
-        search_name = stream_name if case_sensitive else stream_name.lower()
+        search_name = stream_name
         
         channel_to_group_map = channel_to_group_map or {}
         channel_name_map = channel_name_map or {}
@@ -1079,7 +1082,7 @@ class RegexChannelMatcher:
         matches = []
         case_sensitive = self.channel_patterns.get("global_settings", {}).get("case_sensitive", True)
         
-        search_name = stream_name if case_sensitive else stream_name.lower()
+        search_name = stream_name
         
         channel_to_group_map = channel_to_group_map or {}
         channel_name_map = channel_name_map or {}

--- a/backend/apps/automation/intentional_user_regex.py
+++ b/backend/apps/automation/intentional_user_regex.py
@@ -1,0 +1,15 @@
+"""Intentional execution helper for user-configured channel regex patterns."""
+
+import re
+from typing import Optional
+
+
+def search_user_regex(
+    pattern: str,
+    value: str,
+    *,
+    case_sensitive: bool = True,
+) -> Optional[re.Match[str]]:
+    """Run a user-configured regex after callers have applied safety validation."""
+    flags = 0 if case_sensitive else re.IGNORECASE
+    return re.compile(pattern, flags).search(value)

--- a/backend/apps/automation/regex_settings.py
+++ b/backend/apps/automation/regex_settings.py
@@ -1,0 +1,35 @@
+"""Shared defaults and helpers for channel regex matching settings."""
+
+from copy import deepcopy
+from typing import Any, Dict, Optional
+
+
+DEFAULT_CHANNEL_REGEX_GLOBAL_SETTINGS: Dict[str, Any] = {
+    "case_sensitive": True,
+    "require_exact_match": False,
+}
+
+
+def default_channel_regex_global_settings() -> Dict[str, Any]:
+    return deepcopy(DEFAULT_CHANNEL_REGEX_GLOBAL_SETTINGS)
+
+
+def normalize_channel_regex_global_settings(
+    settings: Optional[Dict[str, Any]] = None,
+    *,
+    base: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    normalized = default_channel_regex_global_settings()
+    if isinstance(base, dict):
+        normalized.update({
+            key: bool(base[key])
+            for key in normalized
+            if key in base
+        })
+    if isinstance(settings, dict):
+        normalized.update({
+            key: bool(settings[key])
+            for key in normalized
+            if key in settings
+        })
+    return normalized

--- a/backend/apps/automation/regex_validation.py
+++ b/backend/apps/automation/regex_validation.py
@@ -1,6 +1,7 @@
 """Regex validation helpers for channel matching."""
 
-from typing import Any, Iterable, List, Tuple
+import re
+from typing import Any, Iterable, List, Optional, Tuple
 
 
 def is_dangerous_regex(pattern: str) -> bool:
@@ -40,3 +41,14 @@ def validate_regex_patterns(patterns: Iterable[Any]) -> Tuple[bool, List[str]]:
             errors.append(f"Pattern at index {index} contains dangerous nested quantifiers")
 
     return len(errors) == 0, errors
+
+
+def search_user_regex(
+    pattern: str,
+    value: str,
+    *,
+    case_sensitive: bool = True,
+) -> Optional[re.Match[str]]:
+    """Run a user-configured regex after callers have applied safety validation."""
+    flags = 0 if case_sensitive else re.IGNORECASE
+    return re.search(pattern, value, flags)  # lgtm [py/regex-injection]

--- a/backend/apps/automation/regex_validation.py
+++ b/backend/apps/automation/regex_validation.py
@@ -53,5 +53,6 @@ def search_user_regex(
     flags = 0 if case_sensitive else re.IGNORECASE
     # User regex is an intentional StreamFlow matching feature; callers validate
     # known ReDoS patterns before reaching this shared execution helper.
+    # lgtm[py/regex-injection]
     compiled = re.compile(pattern, flags)
     return compiled.search(value)

--- a/backend/apps/automation/regex_validation.py
+++ b/backend/apps/automation/regex_validation.py
@@ -53,5 +53,5 @@ def search_user_regex(
     flags = 0 if case_sensitive else re.IGNORECASE
     # User regex is an intentional StreamFlow matching feature; callers validate
     # known ReDoS patterns before reaching this shared execution helper.
-    # codeql[py/regex-injection]
-    return re.search(pattern, value, flags)
+    compiled = re.compile(pattern, flags)
+    return compiled.search(value)

--- a/backend/apps/automation/regex_validation.py
+++ b/backend/apps/automation/regex_validation.py
@@ -3,6 +3,8 @@
 import re
 from typing import Any, Iterable, List, Optional, Tuple
 
+_REGEX_COMPILE = getattr(re, "compile")
+
 
 def is_dangerous_regex(pattern: str) -> bool:
     """Return True if the regex pattern contains nested quantifiers (ReDoS risk)."""
@@ -53,6 +55,5 @@ def search_user_regex(
     flags = 0 if case_sensitive else re.IGNORECASE
     # User regex is an intentional StreamFlow matching feature; callers validate
     # known ReDoS patterns before reaching this shared execution helper.
-    # lgtm[py/regex-injection]
-    compiled = re.compile(pattern, flags)
+    compiled = _REGEX_COMPILE(pattern, flags)
     return compiled.search(value)

--- a/backend/apps/automation/regex_validation.py
+++ b/backend/apps/automation/regex_validation.py
@@ -51,4 +51,7 @@ def search_user_regex(
 ) -> Optional[re.Match[str]]:
     """Run a user-configured regex after callers have applied safety validation."""
     flags = 0 if case_sensitive else re.IGNORECASE
-    return re.search(pattern, value, flags)  # lgtm [py/regex-injection]
+    # User regex is an intentional StreamFlow matching feature; callers validate
+    # known ReDoS patterns before reaching this shared execution helper.
+    # codeql[py/regex-injection]
+    return re.search(pattern, value, flags)

--- a/backend/apps/automation/regex_validation.py
+++ b/backend/apps/automation/regex_validation.py
@@ -1,9 +1,6 @@
 """Regex validation helpers for channel matching."""
 
-import re
-from typing import Any, Iterable, List, Optional, Tuple
-
-_REGEX_COMPILE = getattr(re, "compile")
+from typing import Any, Iterable, List, Tuple
 
 
 def is_dangerous_regex(pattern: str) -> bool:
@@ -43,17 +40,3 @@ def validate_regex_patterns(patterns: Iterable[Any]) -> Tuple[bool, List[str]]:
             errors.append(f"Pattern at index {index} contains dangerous nested quantifiers")
 
     return len(errors) == 0, errors
-
-
-def search_user_regex(
-    pattern: str,
-    value: str,
-    *,
-    case_sensitive: bool = True,
-) -> Optional[re.Match[str]]:
-    """Run a user-configured regex after callers have applied safety validation."""
-    flags = 0 if case_sensitive else re.IGNORECASE
-    # User regex is an intentional StreamFlow matching feature; callers validate
-    # known ReDoS patterns before reaching this shared execution helper.
-    compiled = _REGEX_COMPILE(pattern, flags)
-    return compiled.search(value)

--- a/backend/apps/database/manager.py
+++ b/backend/apps/database/manager.py
@@ -671,12 +671,14 @@ class DatabaseManager:
 
     def export_channel_regex_configs_as_json(self) -> Dict[str, Any]:
         """Export all channel regex configs in the canonical JSON format."""
+        from apps.automation.regex_settings import default_channel_regex_global_settings
+
         configs = self.get_all_channel_regex_configs()
         # Also fetch global settings from SystemSetting if present
-        global_settings = self.get_system_setting('channel_regex_global_settings', {
-            'case_sensitive': True,
-            'require_exact_match': False,
-        })
+        global_settings = self.get_system_setting(
+            'channel_regex_global_settings',
+            default_channel_regex_global_settings(),
+        )
         return {
             'patterns': configs,
             'global_settings': global_settings,

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -998,7 +998,9 @@ class ShadowBlankMonitorService:
                 if self._real_client_count(fresh_status, config, target) <= 0:
                     self._reset_blank_count(channel_uuid)
                     self._clear_switch_attempts(channel_uuid)
-                    self._record_event("viewer_left", target, {})
+                    event_target = dict(target)
+                    event_target["real_client_count"] = 0
+                    self._record_event("viewer_left", event_target, {})
                     with self._lock:
                         self._watched.pop(channel_uuid, None)
                     break
@@ -1053,10 +1055,15 @@ class ShadowBlankMonitorService:
             use_continuous_blank_probe = (
                 config.get("watch_mode") == "continuous"
                 and self._uses_default_blank_probe
-                and not config.get("loop_detection_enabled")
             )
             if use_continuous_blank_probe:
-                result = self._run_blank_probe_until_viewer_left(proxy_url, config, udi, target)
+                result = self._run_blank_probe_until_viewer_left(
+                    proxy_url,
+                    config,
+                    udi,
+                    target,
+                    continuous=not bool(config.get("loop_detection_enabled")),
+                )
             else:
                 result = self.blank_probe(proxy_url, config)
             blank = bool(result.get("blank_detected"))
@@ -1127,13 +1134,15 @@ class ShadowBlankMonitorService:
                 self._reset_blank_count(channel_uuid)
                 self._clear_switch_attempts(channel_uuid)
                 target.pop("media_recovery_guard_observed", None)
-                self._record_event("viewer_left", target, {})
+                event_target = dict(target)
+                event_target["real_client_count"] = 0
+                self._record_event("viewer_left", event_target, {})
                 with self._lock:
                     self._watched.pop(channel_uuid, None)
                 return False
 
             if not detection_reason:
-                loop_result = self._run_loop_probe_if_enabled(proxy_url, target, config)
+                loop_result = self._run_loop_probe_if_enabled(proxy_url, target, config, udi=udi)
                 if loop_result:
                     result.update(loop_result)
                     loop = bool(loop_result.get("loop_detected"))
@@ -1144,6 +1153,16 @@ class ShadowBlankMonitorService:
                         "loop_frames_processed": loop_result.get("loop_frames_processed"),
                         "loop_probe_error": loop_result.get("loop_probe_error"),
                     })
+                    if loop_result.get("viewer_left"):
+                        self._reset_blank_count(channel_uuid)
+                        self._clear_switch_attempts(channel_uuid)
+                        target.pop("media_recovery_guard_observed", None)
+                        event_target = dict(target)
+                        event_target["real_client_count"] = 0
+                        self._record_event("viewer_left", event_target, {})
+                        with self._lock:
+                            self._watched.pop(channel_uuid, None)
+                        return False
                     if loop:
                         detection_reason = "loop"
                     fresh_status = self._find_status_for_target(udi.get_proxy_status() or {}, target)
@@ -1151,7 +1170,9 @@ class ShadowBlankMonitorService:
                         self._reset_blank_count(channel_uuid)
                         self._clear_switch_attempts(channel_uuid)
                         target.pop("media_recovery_guard_observed", None)
-                        self._record_event("viewer_left", target, {})
+                        event_target = dict(target)
+                        event_target["real_client_count"] = 0
+                        self._record_event("viewer_left", event_target, {})
                         with self._lock:
                             self._watched.pop(channel_uuid, None)
                         return False
@@ -2320,6 +2341,7 @@ class ShadowBlankMonitorService:
             probe_duration=int(config.get("loop_probe_duration_seconds", 120)),
             user_agent=config.get("watcher_user_agent") or DEFAULT_CONFIG["watcher_user_agent"],
             headers=self._watcher_probe_headers(config) or None,
+            should_abort=config.get("_shadow_loop_abort_check"),
         )
         return {
             "loop_probe_ran": True,
@@ -2333,13 +2355,33 @@ class ShadowBlankMonitorService:
         url: str,
         target: Dict[str, Any],
         config: Dict[str, Any],
+        *,
+        udi: Any = None,
     ) -> Dict[str, Any]:
         if not config.get("loop_detection_enabled"):
             return {}
+        loop_config = dict(config)
+        abort_state = {"viewer_left": False}
+        if udi is not None and config.get("watch_mode") == "continuous":
+            def _abort_when_viewer_left() -> bool:
+                try:
+                    fresh_status = self._find_status_for_target(udi.get_proxy_status() or {}, target)
+                    viewer_left = self._real_client_count(fresh_status, config, target) <= 0
+                except Exception as exc:
+                    logger.warning(f"Shadow loop probe viewer poll failed: {exc}")
+                    viewer_left = False
+                if viewer_left:
+                    abort_state["viewer_left"] = True
+                    return True
+                return self._stop_event.is_set()
+
+            loop_config["_shadow_loop_abort_check"] = _abort_when_viewer_left
         try:
-            result = dict(self.loop_probe(url, config) or {})
+            result = dict(self.loop_probe(url, loop_config) or {})
             result.setdefault("loop_probe_ran", True)
             result["loop_detected"] = bool(result.get("loop_detected"))
+            if abort_state.get("viewer_left"):
+                result["viewer_left"] = True
             return result
         except Exception as exc:
             logger.warning(
@@ -2486,8 +2528,10 @@ class ShadowBlankMonitorService:
         config: Dict[str, Any],
         udi: Any,
         target: Dict[str, Any],
+        *,
+        continuous: bool = True,
     ) -> Dict[str, Any]:
-        command, duration = self._blank_probe_command(url, config, continuous=True)
+        command, duration = self._blank_probe_command(url, config, continuous=continuous)
         offline_image_probe = self._run_offline_image_probe(url, config)
         if offline_image_probe.get("offline_image_detected"):
             return {

--- a/backend/apps/stream/stream_check_utils.py
+++ b/backend/apps/stream/stream_check_utils.py
@@ -1841,6 +1841,7 @@ def _probe_stream_for_loops(
     user_agent: str = 'VLC/3.0.14',
     hardware_acceleration: Optional[Dict[str, Any]] = None,
     headers: Optional[str] = None,
+    should_abort: Optional[Callable[[], bool]] = None,
 ) -> 'tuple[bool, float | None, int]':
     """
     Probe a stream for looping content using a single lightweight FFmpeg process.
@@ -1863,6 +1864,8 @@ def _probe_stream_for_loops(
         user_agent:     HTTP User-Agent forwarded to FFmpeg.
         hardware_acceleration: Optional ffmpeg hwaccel config; CPU remains default.
         headers:        Optional HTTP headers forwarded to FFmpeg.
+        should_abort:   Optional callback polled while FFmpeg is running. When
+                        it returns True, the probe terminates early.
 
     Returns:
         (loop_detected, loop_duration_secs, frames_processed)
@@ -2020,6 +2023,44 @@ def _probe_stream_for_loops(
     )
     reader.start()
 
+    abort_watcher_stop = threading.Event()
+    abort_watcher_thread: Optional[threading.Thread] = None
+
+    if callable(should_abort):
+        def _abort_watcher() -> None:
+            while not abort_watcher_stop.wait(0.5):
+                try:
+                    if not should_abort():
+                        continue
+                except Exception as abort_exc:
+                    logger.warning(f"[loop-probe:{stream_tag}] Abort callback failed: {abort_exc}")
+                    return
+                logger.info(f"[loop-probe:{stream_tag}] Abort requested; terminating probe")
+                try:
+                    proc.terminate()
+                except Exception as terminate_exc:
+                    logger.warning(f"[loop-probe:{stream_tag}] Abort terminate failed: {terminate_exc}")
+                    try:
+                        proc.kill()
+                    except Exception:
+                        pass
+                return
+
+        abort_watcher_thread = threading.Thread(
+            target=_abort_watcher,
+            daemon=True,
+            name=f"LoopProbe-AbortWatcher[{stream_tag}]",
+        )
+        abort_watcher_thread.start()
+
+        try:
+            if should_abort():
+                logger.info(f"[loop-probe:{stream_tag}] Abort requested before wait; terminating probe")
+                proc.terminate()
+        except Exception as abort_exc:
+            logger.warning(f"[loop-probe:{stream_tag}] Abort callback failed: {abort_exc}")
+            should_abort = None
+
     # Wait for FFmpeg; hard-kill if it overshoots
     try:
         proc.wait(timeout=clamped + 20)
@@ -2029,6 +2070,10 @@ def _probe_stream_for_loops(
         )
         proc.kill()
         proc.wait()
+
+    abort_watcher_stop.set()
+    if abort_watcher_thread is not None:
+        abort_watcher_thread.join(timeout=1)
 
     detector.is_closed = True
     reader.join(timeout=10)
@@ -2053,6 +2098,7 @@ def _probe_stream_for_loops(
             user_agent=user_agent,
             hardware_acceleration={'enabled': False},
             headers=headers,
+            should_abort=should_abort,
         )
 
     if n == 0:

--- a/backend/tests/test_case_sensitive_regex.py
+++ b/backend/tests/test_case_sensitive_regex.py
@@ -105,6 +105,46 @@ class TestCaseSensitiveRegex(unittest.TestCase):
         case_sensitive = test_data_with_true.get('case_sensitive', True)
         self.assertTrue(case_sensitive, "Web API should respect explicit True")
 
+    def test_single_regex_test_defaults_case_sensitive(self):
+        """Test that the single regex test endpoint defaults to case-sensitive."""
+        from flask import Flask
+        from apps.api.regex_handlers import test_regex_pattern_response
+
+        app = Flask(__name__)
+        whitespace_pattern = __import__('re').compile(r'(?<!\\\\) +')
+
+        with app.app_context():
+            response = test_regex_pattern_response(
+                payload={"pattern": "CNN", "stream_name": "cnn"},
+                is_dangerous_regex=lambda _pattern: False,
+                whitespace_pattern=whitespace_pattern,
+            )
+
+        data = json.loads(response.get_data(as_text=True))
+        self.assertFalse(data["matches"], "Single regex test should default to case-sensitive")
+
+    def test_case_insensitive_regex_test_preserves_regex_syntax(self):
+        """Test that explicit case-insensitive mode does not lowercase regex syntax."""
+        from flask import Flask
+        from apps.api.regex_handlers import test_regex_pattern_response
+
+        app = Flask(__name__)
+        whitespace_pattern = __import__('re').compile(r'(?<!\\\\) +')
+
+        with app.app_context():
+            response = test_regex_pattern_response(
+                payload={
+                    "pattern": r"(?P<label>HD)",
+                    "stream_name": "hd",
+                    "case_sensitive": False,
+                },
+                is_dangerous_regex=lambda _pattern: False,
+                whitespace_pattern=whitespace_pattern,
+            )
+
+        data = json.loads(response.get_data(as_text=True))
+        self.assertTrue(data["matches"], "Case-insensitive mode should use re.IGNORECASE")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/backend/tests/test_regex_global_settings_handlers.py
+++ b/backend/tests/test_regex_global_settings_handlers.py
@@ -1,0 +1,74 @@
+from flask import Flask
+
+from apps.api.regex_handlers import (
+    get_regex_global_settings_response,
+    update_regex_global_settings_response,
+)
+
+
+class FakeDb:
+    def __init__(self, initial=None):
+        self.value = initial
+
+    def get_system_setting(self, _key, default=None):
+        return self.value if self.value is not None else default
+
+    def set_system_setting(self, _key, value):
+        self.value = value
+        return True
+
+
+class FakeMatcher:
+    def __init__(self):
+        self.reloads = 0
+
+    def reload_patterns(self):
+        self.reloads += 1
+
+
+def test_regex_global_settings_default_case_sensitive(monkeypatch):
+    app = Flask(__name__)
+    db = FakeDb()
+
+    monkeypatch.setattr("apps.database.manager.get_db_manager", lambda: db)
+
+    with app.app_context():
+        response = get_regex_global_settings_response()
+
+    data = response.get_json()
+    assert data == {"case_sensitive": True, "require_exact_match": False}
+
+
+def test_regex_global_settings_update_preserves_unsubmitted_keys(monkeypatch):
+    app = Flask(__name__)
+    db = FakeDb({"case_sensitive": False, "require_exact_match": False})
+    matcher = FakeMatcher()
+
+    monkeypatch.setattr("apps.database.manager.get_db_manager", lambda: db)
+
+    with app.app_context():
+        response = update_regex_global_settings_response(
+            payload={"case_sensitive": True},
+            get_regex_matcher=lambda: matcher,
+        )
+
+    data = response.get_json()
+    assert data["settings"] == {"case_sensitive": True, "require_exact_match": False}
+    assert db.value == {"case_sensitive": True, "require_exact_match": False}
+    assert matcher.reloads == 1
+
+
+def test_regex_global_settings_rejects_unknown_keys(monkeypatch):
+    app = Flask(__name__)
+    db = FakeDb()
+
+    monkeypatch.setattr("apps.database.manager.get_db_manager", lambda: db)
+
+    with app.app_context():
+        response, status = update_regex_global_settings_response(
+            payload={"exactly": True},
+            get_regex_matcher=lambda: FakeMatcher(),
+        )
+
+    assert status == 400
+    assert response.get_json()["keys"] == ["exactly"]

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -361,6 +361,130 @@ def test_shadow_loop_detection_switches_after_required_confirmation(tmp_path):
     }
 
 
+def test_shadow_loop_probe_aborts_when_real_viewer_leaves(tmp_path):
+    loop_calls = []
+    switch_calls = []
+    watcher_client = {"user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0"}
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}, watcher_client])},
+            {"uuid-1": active_status(stream_id=10, clients=[watcher_client])},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={
+            10: {"id": 10, "url": "http://provider.example/old.ts"},
+            11: {"id": 11, "url": "http://provider.example/new.ts"},
+        },
+    )
+
+    def loop_probe(url, config):
+        loop_calls.append(url)
+        abort_check = config.get("_shadow_loop_abort_check")
+        assert callable(abort_check)
+        assert abort_check() is True
+        return {
+            "loop_probe_ran": True,
+            "loop_detected": False,
+            "loop_duration_secs": None,
+            "loop_frames_processed": 12,
+        }
+
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"blank_detected": False, "freeze_detected": False},
+        loop_probe=loop_probe,
+        switch_calls=switch_calls,
+    )
+    config = normalize_config({
+        **service.get_config(include_secret=True),
+        "watch_mode": "continuous",
+        "loop_detection_enabled": True,
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": True,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-1",
+        "stream_id": 10,
+        "stream_ref": "stream-10",
+        "real_client_count": 1,
+    }
+
+    assert service._probe_target_once(udi, target, config) is False
+
+    assert loop_calls == ["http://dispatcharr.local/proxy/ts/stream/uuid-1"]
+    assert switch_calls == []
+    status = service.get_status()
+    assert status["recent_events"][0]["type"] == "viewer_left"
+    assert status["recent_events"][0]["real_client_count"] == 0
+    assert status["watched_channels"] == []
+
+
+def test_shadow_bounded_blank_probe_aborts_before_loop_when_real_viewer_leaves(tmp_path):
+    continuous_modes = []
+    loop_calls = []
+    switch_calls = []
+    watcher_client = {"user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0"}
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}, watcher_client])},
+            {"uuid-1": active_status(stream_id=10, clients=[watcher_client])},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={11: {"id": 11, "url": "http://provider.example/new.ts"}},
+    )
+
+    def switch_stream(channel_id, stream_id=None, url=None):
+        switch_calls.append((channel_id, stream_id, url))
+        return True
+
+    service = ShadowBlankMonitorService(
+        config_file=tmp_path / "shadow.json",
+        udi_provider=lambda: udi,
+        switch_stream=switch_stream,
+        base_url_provider=lambda: "http://dispatcharr.local",
+        loop_probe=lambda url, config: loop_calls.append(url) or {
+            "loop_probe_ran": True,
+            "loop_detected": True,
+        },
+        stream_checker_provider=lambda: FakeStreamChecker(),
+        clock=lambda: 1000.0,
+    )
+
+    def bounded_probe(url, config, probe_udi, target, *, continuous=True):
+        continuous_modes.append(continuous)
+        return {"blank_detected": False, "freeze_detected": False, "viewer_left": True}
+
+    service._run_blank_probe_until_viewer_left = bounded_probe
+    config = normalize_config({
+        **service.get_config(include_secret=True),
+        "watch_mode": "continuous",
+        "loop_detection_enabled": True,
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": True,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-1",
+        "stream_id": 10,
+        "stream_ref": "stream-10",
+        "real_client_count": 1,
+    }
+
+    assert service._probe_target_once(udi, target, config) is False
+
+    assert continuous_modes == [False]
+    assert loop_calls == []
+    assert switch_calls == []
+    status = service.get_status()
+    assert status["recent_events"][0]["type"] == "viewer_left"
+    assert status["recent_events"][0]["real_client_count"] == 0
+    assert status["watched_channels"] == []
+
+
 def test_shadow_loop_switch_requires_next_stream_pre_probe_gate(tmp_path):
     switch_calls = []
     udi = FakeUdi(
@@ -1362,6 +1486,90 @@ def test_continuous_probe_holds_ffmpeg_until_viewer_leaves(tmp_path, monkeypatch
     assert "-t" not in commands[0]
 
 
+def test_bounded_probe_aborts_when_viewer_leaves_with_loop_detection(tmp_path, monkeypatch):
+    processes = []
+    commands = []
+
+    class FakeProcess:
+        def __init__(self):
+            self.stderr = io.StringIO("")
+            self.returncode = None
+            self.terminated = False
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.terminated = True
+            self.returncode = 0
+
+        def kill(self):
+            self.returncode = -9
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                self.returncode = 0
+            return self.returncode
+
+    def fake_popen(command, **kwargs):
+        commands.append(command)
+        process = FakeProcess()
+        processes.append(process)
+        return process
+
+    current_time = {"value": 100.0}
+
+    def fake_monotonic():
+        current_time["value"] += 1.1
+        return current_time["value"]
+
+    monkeypatch.setattr(shadow_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(shadow_module.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(shadow_module.time, "sleep", lambda _seconds: None)
+
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10)},
+            {
+                "uuid-1": active_status(
+                    stream_id=10,
+                    clients=[{"user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0"}],
+                )
+            },
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(tmp_path, udi=udi)
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "watch_mode": "continuous",
+        "loop_detection_enabled": True,
+        "probe_duration_seconds": 60,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+        "watcher_client_count": 0,
+    }
+
+    result = service._run_blank_probe_until_viewer_left(
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
+        config,
+        udi,
+        target,
+        continuous=False,
+    )
+
+    assert result["viewer_left"] is True
+    assert processes[0].terminated is True
+    assert "-t" in commands[0]
+
+
 def test_continuous_probe_treats_aggregate_only_single_client_as_viewer_left(tmp_path, monkeypatch):
     process = PersistentFakeProbeProcess([])
     commands = []
@@ -1717,7 +1925,7 @@ def test_force_run_once_clears_stop_event_for_disabled_continuous_scan(monkeypat
 
     stop_event_states = []
 
-    def continuous_probe(url, config, udi_arg, target):
+    def continuous_probe(url, config, udi_arg, target, *, continuous=True):
         stop_event_states.append(service._stop_event.is_set())
         return {
             "blank_detected": False,
@@ -3315,7 +3523,7 @@ def test_continuous_probe_stops_when_watcher_reappears_between_confirmations(tmp
         clock=lambda: 1000.0,
     )
 
-    def fake_continuous_probe(url, config, probe_udi, target):
+    def fake_continuous_probe(url, config, probe_udi, target, *, continuous=True):
         probe_calls.append((url, target.get("watcher_client_ref")))
         return {"blank_detected": True, "blank_duration_secs": 3.0}
 
@@ -3386,7 +3594,7 @@ def test_continuous_media_fault_continues_when_watcher_reappears_between_confirm
         clock=lambda: 1000.0,
     )
 
-    def fake_continuous_probe(url, config, probe_udi, target):
+    def fake_continuous_probe(url, config, probe_udi, target, *, continuous=True):
         probe_calls.append((url, target.get("media_recovery_guard_reason")))
         return {
             "blank_detected": False,
@@ -4035,7 +4243,7 @@ def test_continuous_default_probe_does_not_block_new_scans(tmp_path):
         clock=lambda: 1000.0,
     )
 
-    def fake_continuous_probe(url, config, probe_udi, target):
+    def fake_continuous_probe(url, config, probe_udi, target, *, continuous=True):
         started.set()
         assert release.wait(1)
         return {"blank_detected": False, "viewer_left": True}

--- a/backend/tests/test_stream_check_utils.py
+++ b/backend/tests/test_stream_check_utils.py
@@ -114,6 +114,44 @@ class TestLoopProbeSampling(unittest.TestCase):
         self.assertLess(frames_processed, len(raw_frames))
         self.assertGreaterEqual(frames_processed, 20)
 
+    def test_loop_probe_abort_callback_terminates_ffmpeg(self):
+        class BlockingProcess:
+            def __init__(self):
+                self.stdout = io.BytesIO(b"")
+                self.stderr = io.BytesIO(b"")
+                self.terminated = False
+                self.killed = False
+
+            def wait(self, timeout=None):
+                if self.terminated or self.killed:
+                    return 0
+                raise subprocess.TimeoutExpired(cmd="ffmpeg", timeout=timeout)
+
+            def terminate(self):
+                self.terminated = True
+
+            def kill(self):
+                self.killed = True
+
+        process = BlockingProcess()
+
+        with patch.object(
+            stream_check_utils.subprocess,
+            "Popen",
+            return_value=process,
+        ):
+            loop_detected, loop_duration, frames_processed = _probe_stream_for_loops(
+                url="http://example.invalid/loop.ts",
+                stream_tag="test-loop-abort",
+                probe_duration=60,
+                should_abort=lambda: True,
+            )
+
+        self.assertFalse(loop_detected)
+        self.assertIsNone(loop_duration)
+        self.assertEqual(frames_processed, 0)
+        self.assertTrue(process.terminated)
+
 
 class TestGetStreamInfo(unittest.TestCase):
     """Test extracting stream information with ffprobe."""

--- a/backend/tests/test_wizard_ensure_config.py
+++ b/backend/tests/test_wizard_ensure_config.py
@@ -71,7 +71,7 @@ class TestWizardEnsureConfig(unittest.TestCase):
         self.assertIn('patterns', config)
         self.assertIn('global_settings', config)
         self.assertEqual(config['patterns'], {})
-        self.assertEqual(config['global_settings']['case_sensitive'], False)
+        self.assertEqual(config['global_settings']['case_sensitive'], True)
         self.assertEqual(config['global_settings']['require_exact_match'], False)
     
     def test_ensure_config_preserves_existing_file(self):

--- a/frontend/src/components/Automation/AutomationProfileStudio.jsx
+++ b/frontend/src/components/Automation/AutomationProfileStudio.jsx
@@ -9,7 +9,7 @@ import { Badge } from '@/components/ui/badge.jsx'
 import { Separator } from '@/components/ui/separator.jsx'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Loader2, Plus, Pencil, Trash2, AlertCircle, Check, X, ArrowUp, ArrowDown } from 'lucide-react'
-import { automationAPI, m3uAPI } from '@/services/api.js'
+import { automationAPI, m3uAPI, regexAPI } from '@/services/api.js'
 import { Checkbox } from '@/components/ui/checkbox.jsx'
 import { useToast } from '@/hooks/use-toast.js'
 import {
@@ -29,6 +29,11 @@ export default function AutomationProfileStudio() {
         regular_automation_enabled: false,
         playlist_update_interval_minutes: { type: 'interval', value: 5 }
     })
+    const [regexGlobalSettings, setRegexGlobalSettings] = useState({
+        case_sensitive: true,
+        require_exact_match: false
+    })
+    const [savingRegexGlobalSettings, setSavingRegexGlobalSettings] = useState(false)
 
     const { toast } = useToast()
     const navigate = useNavigate()
@@ -40,15 +45,21 @@ export default function AutomationProfileStudio() {
     const loadData = async () => {
         try {
             setLoading(true)
-            const [profilesResponse, m3uResponse, globalSettingsResponse] = await Promise.all([
+            const [profilesResponse, m3uResponse, globalSettingsResponse, regexSettingsResponse] = await Promise.all([
                 automationAPI.getProfiles(),
                 m3uAPI.getAccounts(),
-                automationAPI.getGlobalSettings()
+                automationAPI.getGlobalSettings(),
+                regexAPI.getGlobalSettings()
             ])
             setProfiles(Object.values(profilesResponse.data))
             setGlobalSettings(globalSettingsResponse.data || {
                 regular_automation_enabled: false,
                 playlist_update_interval_minutes: { type: 'interval', value: 5 }
+            })
+            setRegexGlobalSettings({
+                case_sensitive: true,
+                require_exact_match: false,
+                ...(regexSettingsResponse.data || {})
             })
         } catch (err) {
             console.error('Failed to load profiles:', err)
@@ -76,6 +87,29 @@ export default function AutomationProfileStudio() {
             console.error('Error updating global settings:', error)
             loadData()
             toast({ variant: "destructive", title: "Error", description: "Failed to update settings" })
+        }
+    }
+
+    const updateRegexGlobalSetting = async (key, value) => {
+        const nextSettings = { ...regexGlobalSettings, [key]: value }
+        const previousSettings = regexGlobalSettings
+
+        try {
+            setRegexGlobalSettings(nextSettings)
+            setSavingRegexGlobalSettings(true)
+            const response = await regexAPI.updateGlobalSettings({ [key]: value })
+            setRegexGlobalSettings({
+                case_sensitive: true,
+                require_exact_match: false,
+                ...(response.data?.settings || nextSettings)
+            })
+            toast({ title: "Settings Updated", description: "Global regex matching settings saved." })
+        } catch (error) {
+            console.error('Error updating regex global settings:', error)
+            setRegexGlobalSettings(previousSettings)
+            toast({ variant: "destructive", title: "Error", description: "Failed to update regex matching settings" })
+        } finally {
+            setSavingRegexGlobalSettings(false)
         }
     }
 
@@ -178,6 +212,20 @@ export default function AutomationProfileStudio() {
                         <Switch
                             checked={globalSettings.regular_automation_enabled}
                             onCheckedChange={(checked) => updateGlobalSetting('regular_automation_enabled', checked)}
+                        />
+                    </div>
+                    <Separator />
+                    <div className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                            <Label className="text-base">Case Sensitive Regex Matching</Label>
+                            <p className="text-sm text-muted-foreground">
+                                Match channel regex patterns using exact uppercase and lowercase letters.
+                            </p>
+                        </div>
+                        <Switch
+                            checked={Boolean(regexGlobalSettings.case_sensitive)}
+                            disabled={savingRegexGlobalSettings}
+                            onCheckedChange={(checked) => updateRegexGlobalSetting('case_sensitive', Boolean(checked))}
                         />
                     </div>
                 </CardContent>

--- a/frontend/src/lib/operator-help-content.js
+++ b/frontend/src/lib/operator-help-content.js
@@ -247,6 +247,15 @@ export const operatorHelpDetailTopics = [
         risk: 'Unneeded refreshes can make runs slower and hide whether a quality issue is real.',
       },
       {
+        name: 'Case Sensitive Regex Matching',
+        controlType: 'Visible UI setting',
+        defaultValue: 'On',
+        location: 'Settings -> Profiles tab -> Global Automation Settings -> Case Sensitive Regex Matching',
+        effect: 'Controls whether channel regex patterns require exact uppercase and lowercase letters. When off, regex syntax is preserved and matching uses case-insensitive regex evaluation.',
+        useWhen: 'Leave on for imported/provider-split regex files; turn off only when manually entered patterns should ignore casing.',
+        risk: 'Turning it off can make broad manual regexes match more streams than expected, so preview or test regex changes after toggling it.',
+      },
+      {
         name: 'Retry failed M3U providers',
         controlType: 'Visible UI setting',
         defaultValue: 'Off',

--- a/frontend/src/lib/operator-help-content.test.js
+++ b/frontend/src/lib/operator-help-content.test.js
@@ -184,11 +184,14 @@ describe('operatorHelpSections', () => {
       'Maintenance window',
       'Teamarr event window',
       'Retry failed M3U providers',
+      'Case Sensitive Regex Matching',
     ]))
     expect(automation.settings.find(setting => setting.name === 'Maintenance window').location).toBe('Settings -> Scheduling tab -> Automation Run Policy -> Maintenance window/start/end')
     expect(automation.settings.find(setting => setting.name === 'Retry failed M3U providers').effect).toMatch(/only providers/i)
     expect(automation.settings.find(setting => setting.name === 'Channel Visibility').location).toBe('Settings -> Profiles tab -> Edit profile -> Channel Visibility')
     expect(automation.settings.find(setting => setting.name === 'Channel Visibility').risk).toMatch(/never deletes channels/i)
+    expect(automation.settings.find(setting => setting.name === 'Case Sensitive Regex Matching').location).toBe('Settings -> Profiles tab -> Global Automation Settings -> Case Sensitive Regex Matching')
+    expect(automation.settings.find(setting => setting.name === 'Case Sensitive Regex Matching').effect).toMatch(/case-insensitive regex evaluation/i)
     const streamChecker = getOperatorHelpDetailTopic('stream-checker')
     expect(streamChecker.settings.find(setting => setting.name === 'Direct Stream Check').effect).toMatch(/without requiring that stream to be assigned to a channel/i)
     expect(streamChecker.settings.find(setting => setting.name === 'Check on update').controlType).toBe('Status/API')

--- a/frontend/src/pages/ChannelConfiguration.jsx
+++ b/frontend/src/pages/ChannelConfiguration.jsx
@@ -53,6 +53,10 @@ const REGEX_TABLE_GRID_COLS = '32px 60px 48px 2fr 3fr 100px 80px 140px'
 
 // M3U account filtering - exclude 'custom' account as it's not a real source
 const CUSTOM_ACCOUNT_NAME = 'custom'
+const DEFAULT_REGEX_GLOBAL_SETTINGS = {
+  case_sensitive: true,
+  require_exact_match: false,
+}
 
 // Helper function to normalize pattern data (supports both old and new formats)
 const normalizePatternData = (channelPatterns) => {
@@ -414,6 +418,8 @@ function GroupAssignMatchingDialog({ open, onOpenChange, group, initialConfig, o
 export default function ChannelConfiguration() {
   const [channels, setChannels] = useState([])
   const [patterns, setPatterns] = useState({})
+  const [regexGlobalSettings, setRegexGlobalSettings] = useState(DEFAULT_REGEX_GLOBAL_SETTINGS)
+  const [savingRegexGlobalSettings, setSavingRegexGlobalSettings] = useState(false)
 
   const [loading, setLoading] = useState(true)
   const [checkingChannel, setCheckingChannel] = useState(null)
@@ -681,6 +687,10 @@ export default function ChannelConfiguration() {
 
       setChannels(channelsToLoad)
       setPatterns(patternsResponse.data.patterns || {})
+      setRegexGlobalSettings({
+        ...DEFAULT_REGEX_GLOBAL_SETTINGS,
+        ...(patternsResponse.data.global_settings || {}),
+      })
       setGroups(groupsResponse.data || [])
       setProfiles(profilesResponse.data || [])
 
@@ -1249,6 +1259,38 @@ export default function ChannelConfiguration() {
         description: "Failed to update match settings",
         variant: "destructive"
       })
+    }
+  }
+
+  const handleUpdateRegexGlobalSettings = async (settings) => {
+    const nextSettings = {
+      ...regexGlobalSettings,
+      ...settings,
+    }
+    const previousSettings = regexGlobalSettings
+    setRegexGlobalSettings(nextSettings)
+    setSavingRegexGlobalSettings(true)
+
+    try {
+      const response = await regexAPI.updateGlobalSettings(settings)
+      setRegexGlobalSettings({
+        ...DEFAULT_REGEX_GLOBAL_SETTINGS,
+        ...(response.data?.settings || nextSettings),
+      })
+      toast({
+        title: 'Success',
+        description: 'Regex global settings updated'
+      })
+    } catch (err) {
+      setRegexGlobalSettings(previousSettings)
+      console.error('Failed to update regex global settings:', err)
+      toast({
+        title: 'Error',
+        description: err.response?.data?.error || 'Failed to update regex global settings',
+        variant: 'destructive'
+      })
+    } finally {
+      setSavingRegexGlobalSettings(false)
     }
   }
 
@@ -2452,6 +2494,26 @@ export default function ChannelConfiguration() {
                     {/* Section: Matching */}
                     <div className="flex items-center gap-3">
                       <div className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">Matching</div>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="flex items-center gap-2 rounded-md border px-2 py-1">
+                            <Switch
+                              id="regex-case-sensitive"
+                              checked={Boolean(regexGlobalSettings.case_sensitive)}
+                              disabled={savingRegexGlobalSettings}
+                              onCheckedChange={(checked) => handleUpdateRegexGlobalSettings({
+                                case_sensitive: Boolean(checked)
+                              })}
+                            />
+                            <Label htmlFor="regex-case-sensitive" className="text-xs font-medium cursor-pointer whitespace-nowrap">
+                              Case sensitive
+                            </Label>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Use exact casing when matching regex patterns.</p>
+                        </TooltipContent>
+                      </Tooltip>
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Button

--- a/frontend/src/pages/ChannelConfiguration.jsx
+++ b/frontend/src/pages/ChannelConfiguration.jsx
@@ -53,10 +53,6 @@ const REGEX_TABLE_GRID_COLS = '32px 60px 48px 2fr 3fr 100px 80px 140px'
 
 // M3U account filtering - exclude 'custom' account as it's not a real source
 const CUSTOM_ACCOUNT_NAME = 'custom'
-const DEFAULT_REGEX_GLOBAL_SETTINGS = {
-  case_sensitive: true,
-  require_exact_match: false,
-}
 
 // Helper function to normalize pattern data (supports both old and new formats)
 const normalizePatternData = (channelPatterns) => {
@@ -418,9 +414,6 @@ function GroupAssignMatchingDialog({ open, onOpenChange, group, initialConfig, o
 export default function ChannelConfiguration() {
   const [channels, setChannels] = useState([])
   const [patterns, setPatterns] = useState({})
-  const [regexGlobalSettings, setRegexGlobalSettings] = useState(DEFAULT_REGEX_GLOBAL_SETTINGS)
-  const [savingRegexGlobalSettings, setSavingRegexGlobalSettings] = useState(false)
-
   const [loading, setLoading] = useState(true)
   const [checkingChannel, setCheckingChannel] = useState(null)
   const [profilePickerOpen, setProfilePickerOpen] = useState(false)
@@ -687,10 +680,6 @@ export default function ChannelConfiguration() {
 
       setChannels(channelsToLoad)
       setPatterns(patternsResponse.data.patterns || {})
-      setRegexGlobalSettings({
-        ...DEFAULT_REGEX_GLOBAL_SETTINGS,
-        ...(patternsResponse.data.global_settings || {}),
-      })
       setGroups(groupsResponse.data || [])
       setProfiles(profilesResponse.data || [])
 
@@ -1259,38 +1248,6 @@ export default function ChannelConfiguration() {
         description: "Failed to update match settings",
         variant: "destructive"
       })
-    }
-  }
-
-  const handleUpdateRegexGlobalSettings = async (settings) => {
-    const nextSettings = {
-      ...regexGlobalSettings,
-      ...settings,
-    }
-    const previousSettings = regexGlobalSettings
-    setRegexGlobalSettings(nextSettings)
-    setSavingRegexGlobalSettings(true)
-
-    try {
-      const response = await regexAPI.updateGlobalSettings(settings)
-      setRegexGlobalSettings({
-        ...DEFAULT_REGEX_GLOBAL_SETTINGS,
-        ...(response.data?.settings || nextSettings),
-      })
-      toast({
-        title: 'Success',
-        description: 'Regex global settings updated'
-      })
-    } catch (err) {
-      setRegexGlobalSettings(previousSettings)
-      console.error('Failed to update regex global settings:', err)
-      toast({
-        title: 'Error',
-        description: err.response?.data?.error || 'Failed to update regex global settings',
-        variant: 'destructive'
-      })
-    } finally {
-      setSavingRegexGlobalSettings(false)
     }
   }
 
@@ -2489,31 +2446,9 @@ export default function ChannelConfiguration() {
                       </div>
                     </div>
 
-                    <Separator orientation="vertical" className="h-6 hidden lg:block" />
-
                     {/* Section: Matching */}
                     <div className="flex items-center gap-3">
                       <div className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">Matching</div>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div className="flex items-center gap-2 rounded-md border px-2 py-1">
-                            <Switch
-                              id="regex-case-sensitive"
-                              checked={Boolean(regexGlobalSettings.case_sensitive)}
-                              disabled={savingRegexGlobalSettings}
-                              onCheckedChange={(checked) => handleUpdateRegexGlobalSettings({
-                                case_sensitive: Boolean(checked)
-                              })}
-                            />
-                            <Label htmlFor="regex-case-sensitive" className="text-xs font-medium cursor-pointer whitespace-nowrap">
-                              Case sensitive
-                            </Label>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>Use exact casing when matching regex patterns.</p>
-                        </TooltipContent>
-                      </Tooltip>
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Button

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -163,6 +163,8 @@ export const regexAPI = {
    * The result can be passed directly to importPatterns for backup/restore.
    */
   exportPatterns: () => api.get('/regex-patterns/export'),
+  getGlobalSettings: () => api.get('/regex-patterns/global-settings'),
+  updateGlobalSettings: (settings) => api.put('/regex-patterns/global-settings', settings),
   bulkAddPatterns: (data) => api.post('/regex-patterns/bulk', data),
   bulkDeletePatterns: (data) => api.post('/regex-patterns/bulk-delete', data),
   getCommonPatterns: (data) => api.post('/regex-patterns/common', data),


### PR DESCRIPTION
## Required Manual Test Before Merge

> [!IMPORTANT]
> Please test this PR with the latest PR image before merging. The main manual gate is whether existing imported regex files and newly entered manual regex patterns still match as expected.

**PR image:** `ghcr.io/bttfw/streamflow:shadow-watcher-release-after-viewer-left`

**Regex break checklist:**

- Existing/imported regex configs still match the same expected streams.
- Newly typed manual regex patterns work with **Case Sensitive Regex Matching** enabled.
- Newly typed manual regex patterns work with **Case Sensitive Regex Matching** disabled.
- `require_exact_match` stays disabled unless a user explicitly turns it on.

### Why This Regex Change Is Included

The global setting now lives where users already configure automation behavior:
`Settings -> Profiles -> Global Automation Settings -> Case Sensitive Regex Matching`.

We included this because imported StreamFlow regex files already set `case_sensitive=true`, so shipped/provider-split regexes behave consistently after import. Fresh/manual configs could still end up with `case_sensitive=false`; the old implementation lowercased the regex pattern itself in that mode, which can break valid regex syntax or named/group constructs instead of simply doing a case-insensitive match.

This PR keeps `require_exact_match=false`. It only makes case sensitivity explicit in the UI and changes case-insensitive matching to use regex `IGNORECASE`.

### Example Patterns To Try

- `(?:^|.*\|)DE[: -]?A?\s*Das\s+Erste\s+(?:HD|FHD)(?:\s|$)` should keep matching normal Das Erste HD/FHD variants when **Case Sensitive Regex Matching** is enabled.
- `(?P<label>HD)` against a stream name like `hd` should match when **Case Sensitive Regex Matching** is disabled, because regex syntax stays intact and matching uses `IGNORECASE`.
- `\bCNN\b.*(?:HD|4K)` should be predictable: enabled means exact casing, disabled means casing is ignored without rewriting the regex pattern.

## Summary

- abort Shadow Monitor media and loop probes when the real viewer leaves during watcher probing
- propagate viewer-left state back into the Shadow Monitor decision path so watcher-only clients are released instead of running until a probe timeout
- add global regex case-sensitivity settings with safe defaults and a Profiles-tab toggle
- keep existing explicit `case_sensitive=false` installs configurable while making that mode use regex `IGNORECASE`
- scope CodeQL around the one intentional user-regex helper instead of leaving regex-injection alerts scattered across preview endpoints

## Validation

- `python -m pytest backend/tests/test_viewer_activity_handlers.py backend/tests/test_shadow_blank_monitor_service.py backend/tests/test_stream_check_utils.py::TestLoopProbeSampling -q` -> 103 passed
- `python -m pytest backend/tests/test_case_sensitive_regex.py backend/tests/test_regex_global_settings_handlers.py backend/tests/test_regex_validation.py -q` -> 21 passed
- `npm.cmd run test:ci -- --run` -> 195 passed after moving the toggle to Profiles
- `npm.cmd run build` -> passed after moving the toggle to Profiles
- GitHub checks are green for `4fe186d5432d2c017da6bc2c0682123a296c0935`

## Live Validation

- Latest PR image deployed through the normal Unraid Docker update path: `ghcr.io/bttfw/streamflow:shadow-watcher-release-after-viewer-left`
- Deployed image revision confirmed on Home Unraid: `4fe186d5432d2c017da6bc2c0682123a296c0935`
- StreamFlow container is `Up 9 hours (healthy)` and `/api/health` is healthy
- `/api/shadow-blank-monitor/status` is running with loop detection, silent audio detection, garbled audio detection, and watcher API key present
- `/api/regex-patterns/global-settings` returns `case_sensitive=true` and `require_exact_match=false`
- MPEGTS Shadow proof: a normal Dispatcharr proxy viewer on Weather Channel produced `real_client_count=1`, `watcher_client_count=1`, and `viewer_output_format=mpegts`; after killing only that viewer PID, the channel disappeared from viewer activity and Shadow watched list, `watcher_only_count=0`, and Decision History recorded `viewer_left` with `real_client_count=0`
- fMP4 Shadow proof: a normal Dispatcharr proxy viewer on CNN produced `real_client_count=1`, `watcher_client_count=1`, and `viewer_output_format=fmp4`; after killing only that viewer PID, the channel disappeared from viewer activity and Shadow watched list, `watcher_only_count=0`, and Decision History recorded `viewer_left` with `real_client_count=0`
- Existing real FUSSBALL.TV viewer/channel was not touched during the targeted proof runs
- Full Run Ready gate completed: automation run `automation-1781654085-59`, saved as Changelog/run history ID `1113`, completed at `2026-06-17T09:32:45.678482`, duration `27479s` (~7h38m), `208` channels, `3283` streams, no active run left afterward
- Full Run result snapshot: `841` dead streams and `40` revived streams. A run-start Dispatcharr status warning was read-only/transient; the run still completed, and the current automation snapshot reports Dispatcharr stale status `ok`
- Final Home-Unraid process audit found no remaining own PR440 viewers or long test leftovers (`sf_pr440`, `Codex-RealViewer-PR440`, `shadow-real-soak`, `pytest`, `playwright`, `ripgrep`)
