### PR TITLE
Fix Shadow Monitor recovery for proxied live streams

### DIFF
--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -6019,8 +6019,13 @@ class AutomatedStreamManager:
                         ch_revived = c_result.get('revived_streams_count', 0)
                         ch_analyzed = len(c_result.get('checked_streams', []))
                         checked_streams = c_result.get('checked_streams', [])
+                        visibility_result = (
+                            c_result.get('channel_visibility')
+                            if isinstance(c_result.get('channel_visibility'), dict)
+                            else None
+                        )
                         if isinstance(c_result.get('channel_visibility'), dict):
-                            quality_visibility_events.append(c_result.get('channel_visibility'))
+                            quality_visibility_events.append(visibility_result)
                         ch_good = max(
                             int(c_result.get('good_streams_count', 0) or 0),
                             sum(
@@ -6083,6 +6088,14 @@ class AutomatedStreamManager:
                                 'error': c_result.get('error')
                             }
                         })
+
+                        if visibility_result and visibility_result.get('changed'):
+                            visibility_action = visibility_result.get('action')
+                            steps.append({
+                                'step': 'Channel Visibility',
+                                'status': 'warning' if visibility_action == 'hidden' else 'success',
+                                'details': visibility_result,
+                            })
                         
                         # Total streams count for this channel
                         total_streams_count += len(channel.get('streams', []))
@@ -6111,6 +6124,8 @@ class AutomatedStreamManager:
                                or d.get('freeze_streams_count', 0) > 0 or d.get('revived_streams_count', 0) > 0 \
                                or active_checks > 0:
                                 has_impact = True
+                        elif step['step'] == 'Channel Visibility' and step['details'].get('changed'):
+                            has_impact = True
 
                     if steps and has_impact:
                         period_entry['channels'].append({

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -44,6 +44,7 @@ CONFIG_DIR = Path(os.environ.get("CONFIG_DIR", "/app/data"))
 CONFIG_FILE = CONFIG_DIR / "shadow_blank_monitor_config.json"
 MAX_EVENTS = 100
 LOOP_SWITCH_REQUIRES_PRE_PROBE = True
+LOOP_PENDING_PROBE_OK_MISS_TOLERANCE = 1
 AGGREGATE_ONLY_VIEWER_GRACE_SECONDS = 2.0
 WATCHER_API_KEY_REQUIRED_CODE = "watcher_api_key_required"
 WATCHER_API_KEY_REQUIRED_MESSAGE = "Watcher API Key is required before Shadow Monitor can start."
@@ -138,6 +139,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
 CONFIG_KEYS = set(DEFAULT_CONFIG)
 WATCH_MODES = {"periodic", "continuous"}
 MEDIA_FAULT_RECOVERY_GUARD_BYPASS_REASONS = {
+    "blank",
     "freeze",
     "offline_image",
     "garbled_audio",
@@ -419,6 +421,7 @@ class ShadowBlankMonitorService:
         self.config_file = config_file
         self.udi_provider = udi_provider
         self.switch_stream = switch_stream
+        self._uses_default_switch_stream = switch_stream is change_channel_stream
         self.base_url_provider = base_url_provider or (lambda: get_dispatcharr_config().get_base_url())
         self.blank_probe = blank_probe or self._run_blank_probe
         self.loop_probe = loop_probe or self._run_loop_probe
@@ -435,9 +438,12 @@ class ShadowBlankMonitorService:
         self._last_excluded_active_targets: List[Dict[str, Any]] = []
         self._watcher_absences: Dict[str, Dict[str, Any]] = {}
         self._blank_counts: Dict[str, int] = defaultdict(int)
+        self._detection_misses: Dict[str, int] = defaultdict(int)
         self._cooldowns: Dict[str, float] = {}
         self._switch_attempts: Dict[str, Dict[str, Any]] = {}
         self._switch_history: Dict[str, deque[float]] = defaultdict(deque)
+        self._known_channel_ids_by_uuid: Dict[str, int] = {}
+        self._known_channel_ids_by_stream_id: Dict[int, int] = {}
         self._pre_probe_metrics: Dict[str, int] = defaultdict(int)
         self._last_pre_probe: Optional[Dict[str, Any]] = None
         self._active_probes: set[str] = set()
@@ -742,6 +748,7 @@ class ShadowBlankMonitorService:
                 targets[: config["max_concurrent_watchers"]],
                 config,
                 single_pass=force,
+                allow_orphaned_watcher_reprobe=force and bool(include_channel_ids or include_channel_uuids),
             )
             self._last_error = None
         except Exception as exc:
@@ -765,10 +772,16 @@ class ShadowBlankMonitorService:
         proxy_status = udi.get_proxy_status() or {}
         channels = udi.get_channels() if hasattr(udi, "get_channels") else []
         by_uuid, by_id = self._index_channels(channels)
+        self._remember_channel_identities(channels)
         excluded_ids = {int(item) for item in config.get("excluded_channel_ids", [])}
         excluded_uuids = {str(item) for item in config.get("excluded_channel_uuids", [])}
         included_ids = _coerce_int_set(include_channel_ids)
         included_uuids = _coerce_text_set(include_channel_uuids)
+        if len(included_ids) == 1 and len(included_uuids) == 1:
+            self._remember_channel_identity({
+                "id": next(iter(included_ids)),
+                "uuid": next(iter(included_uuids)),
+            })
         limit_to_included = bool(included_ids or included_uuids)
 
         targets: List[Dict[str, Any]] = []
@@ -786,6 +799,7 @@ class ShadowBlankMonitorService:
                 channel_uuid: dict(absence)
                 for channel_uuid, absence in self._watcher_absences.items()
             }
+            active_probe_channels = set(self._active_probes)
         next_absences: Dict[str, Dict[str, Any]] = {}
 
         for key, raw_status in proxy_status.items():
@@ -800,10 +814,6 @@ class ShadowBlankMonitorService:
             if not channel and channel_uuid in by_uuid:
                 channel = by_uuid[channel_uuid]
 
-            numeric_id = self._extract_channel_id(channel, raw_status)
-            if limit_to_included and numeric_id not in included_ids and channel_uuid not in included_uuids:
-                continue
-
             real_clients = self._real_client_count(raw_status, config)
             if real_clients <= 0:
                 continue
@@ -812,6 +822,20 @@ class ShadowBlankMonitorService:
             viewer_output_format = self._real_viewer_output_format(raw_status, config)
 
             stream_id = self._extract_stream_id(raw_status)
+            numeric_id = self._resolve_channel_id(
+                udi,
+                self._extract_channel_id(channel, raw_status),
+                channel_uuid=channel_uuid,
+                channel=channel,
+                status=raw_status,
+                current_stream_id=stream_id,
+                included_ids=included_ids,
+                included_uuids=included_uuids,
+                previous_target=previous_watched.get(channel_uuid),
+            )
+            if limit_to_included and numeric_id not in included_ids and channel_uuid not in included_uuids:
+                continue
+
             current_program = self._current_epg_program(channel, raw_status, numeric_id)
             if numeric_id in excluded_ids or channel_uuid in excluded_uuids:
                 excluded_target = {
@@ -851,6 +875,10 @@ class ShadowBlankMonitorService:
             target.update(watcher_details)
             if continuous_mode:
                 previous_target = previous_watched.get(channel_uuid) or {}
+                probe_running = channel_uuid in active_probe_channels
+                previous_probe_started = previous_target.get("active_probe_started_at")
+                if probe_running and previous_probe_started is not None:
+                    target["active_probe_started_at"] = previous_probe_started
                 previous_absence = previous_absences.get(channel_uuid)
                 previous_watcher_count = int(previous_target.get("watcher_client_count") or 0)
                 previous_watcher_ref = previous_target.get("watcher_client_ref")
@@ -880,6 +908,12 @@ class ShadowBlankMonitorService:
                                 "target_stream_ref": _ref("stream", stream_id),
                                 "observed_stream_ref": _ref("stream", stream_id),
                                 "switch_source": "external",
+                                "switch_actor": "unknown",
+                                "switch_actor_note": (
+                                    "Dispatcharr proxy status does not expose who changed "
+                                    "the active stream."
+                                ),
+                                "stream_change_source": "dispatcharr_proxy_status",
                                 "operator_note": (
                                     "Active stream changed outside the Shadow Monitor switch path. "
                                     "Dispatcharr did not provide actor details."
@@ -888,7 +922,9 @@ class ShadowBlankMonitorService:
                         ))
                 if watcher_clients > 0:
                     target["watcher_state"] = "watching"
-                    if previous_absence:
+                    if probe_running:
+                        next_absences.pop(channel_uuid, None)
+                    elif previous_absence:
                         since = float(previous_absence.get("since") or now)
                         recovered_after = max(0, int(now - since))
                         target["watcher_recovered_after_seconds"] = recovered_after
@@ -948,8 +984,6 @@ class ShadowBlankMonitorService:
             self._last_excluded_active_targets = excluded_active_targets
             self._watcher_absences = next_absences if continuous_mode else {}
         for event_type, event_target, details in continuity_events:
-            if event_type == "watcher_recovered":
-                self._reset_detection_state(event_target["channel_uuid"])
             self._record_event(event_type, event_target, details)
         return targets
 
@@ -960,6 +994,7 @@ class ShadowBlankMonitorService:
         config: Dict[str, Any],
         *,
         single_pass: bool = False,
+        allow_orphaned_watcher_reprobe: bool = False,
     ) -> None:
         targets = list(targets)
         threads: List[threading.Thread] = []
@@ -968,8 +1003,22 @@ class ShadowBlankMonitorService:
         )
         for target in targets:
             channel_uuid = target["channel_uuid"]
-            if int(target.get("watcher_client_count") or 0) > 0:
-                continue
+            watcher_count = int(target.get("watcher_client_count") or 0)
+            if watcher_count > 0:
+                with self._lock:
+                    probe_is_running = channel_uuid in self._active_probes
+                if probe_is_running or not allow_orphaned_watcher_reprobe:
+                    continue
+                target["watcher_state"] = "orphaned"
+                self._record_event(
+                    "watcher_orphaned",
+                    target,
+                    {
+                        "reason": "watcher_without_active_probe",
+                        "watcher_client_count": watcher_count,
+                        "action": "starting_recovery_probe",
+                    },
+                )
             if self._quality_checker_conflicts(target, config):
                 self._record_event("quality_check_active", target, {})
                 continue
@@ -1032,7 +1081,8 @@ class ShadowBlankMonitorService:
                 viewer_output_format = self._real_viewer_output_format(fresh_status, config)
                 if viewer_output_format:
                     target["viewer_output_format"] = viewer_output_format
-                target.update(self._watcher_client_details(fresh_status, config))
+                watcher_details = self._watcher_client_details(fresh_status, config)
+                target.update(watcher_details)
                 watcher_count = int(target.get("watcher_client_count") or 0)
                 target["watcher_state"] = "watching" if watcher_count > 0 else "reconnecting"
                 stream_id = self._extract_stream_id(fresh_status) or target.get("stream_id")
@@ -1043,6 +1093,9 @@ class ShadowBlankMonitorService:
                         self._watcher_absences.pop(channel_uuid, None)
                     self._watched[channel_uuid] = dict(target)
                 if watcher_count > 0:
+                    if self._watcher_status_has_current_probe_client(target, fresh_status, config):
+                        time.sleep(float(config.get("watch_gap_seconds", 1)))
+                        continue
                     bypass_details = self._pending_media_recovery_guard_bypass_details(
                         channel_uuid,
                         target,
@@ -1144,6 +1197,7 @@ class ShadowBlankMonitorService:
                 "loop_duration_secs": result.get("loop_duration_secs"),
                 "loop_frames_processed": result.get("loop_frames_processed"),
                 "loop_probe_error": result.get("loop_probe_error"),
+                "loop_probe_sliced": bool(result.get("loop_probe_sliced")),
             }
             target["last_probe_thresholds"] = self._detection_thresholds(config)
 
@@ -1174,6 +1228,7 @@ class ShadowBlankMonitorService:
                         "loop_duration_secs": loop_result.get("loop_duration_secs"),
                         "loop_frames_processed": loop_result.get("loop_frames_processed"),
                         "loop_probe_error": loop_result.get("loop_probe_error"),
+                        "loop_probe_sliced": bool(loop_result.get("loop_probe_sliced")),
                     })
                     if loop_result.get("viewer_left"):
                         self._reset_blank_count(channel_uuid)
@@ -1200,10 +1255,13 @@ class ShadowBlankMonitorService:
                         return False
 
             if not detection_reason:
-                self._reset_blank_count(channel_uuid)
+                preserved_pending = self._reset_blank_count_after_probe_ok(channel_uuid, config)
                 self._clear_switch_attempts(channel_uuid)
                 target.pop("media_recovery_guard_observed", None)
-                self._record_event("probe_ok", target, target["last_probe"])
+                probe_details = dict(target["last_probe"])
+                if preserved_pending:
+                    probe_details["preserved_pending_detection"] = preserved_pending
+                self._record_event("probe_ok", target, probe_details)
                 return True
 
             cooldown_remaining = self._cooldown_remaining(channel_uuid)
@@ -1365,9 +1423,19 @@ class ShadowBlankMonitorService:
                 reason=reason,
             )
         else:
-            alternative = self._choose_alternative_stream(
+            resolved_channel_id = self._resolve_channel_id(
                 udi,
                 target.get("channel_id"),
+                channel_uuid=target.get("channel_uuid"),
+                current_stream_id=fresh_stream_id,
+                previous_target=target,
+            )
+            if resolved_channel_id is not None and target.get("channel_id") != resolved_channel_id:
+                target["channel_id"] = resolved_channel_id
+                target["channel_ref"] = _ref("channel", resolved_channel_id)
+            alternative = self._choose_alternative_stream(
+                udi,
+                resolved_channel_id,
                 fresh_stream_id,
                 excluded_stream_ids=attempted_targets,
             )
@@ -1402,13 +1470,34 @@ class ShadowBlankMonitorService:
             return
 
         self._record_switch_attempt(channel_uuid, fresh_stream_id, alternative)
-        success = bool(self.switch_stream(channel_uuid, stream_id=alternative))
+        switch_details["switch_channel_ref"] = _ref("channel", channel_uuid)
+        # Dispatcharr's change_stream route is UUID-based even though proxy
+        # status also carries StreamFlow's numeric channel id.
+        switch_channel_id = channel_uuid or target.get("channel_id")
+        api_success = bool(self.switch_stream(switch_channel_id, stream_id=alternative))
+        observed_stream_id: Optional[int] = None
+        verification_details: Dict[str, Any] = {}
+        success = api_success
+        if api_success and self._uses_default_switch_stream:
+            success, observed_stream_id, verification_details = self._verify_active_stream_after_switch(
+                udi,
+                target,
+                alternative,
+                config,
+            )
         self._reset_blank_count(channel_uuid)
         if success:
             with self._lock:
                 self._switch_history[channel_uuid].append(self.clock())
         else:
             self._set_cooldown(channel_uuid, config)
+        switch_details["switch_api_success"] = api_success
+        if observed_stream_id is not None:
+            switch_details["observed_stream_ref"] = _ref("stream", observed_stream_id)
+        if verification_details:
+            verification_details = dict(verification_details)
+            verification_details.pop("accepted", None)
+            switch_details.update(verification_details)
         self._record_event(
             "switch_success" if success else "switch_failed",
             target,
@@ -1417,6 +1506,107 @@ class ShadowBlankMonitorService:
                 "post_switch_verification": bool(success),
             },
         )
+
+    def _verify_active_stream_after_switch(
+        self,
+        udi: Any,
+        target: Dict[str, Any],
+        expected_stream_id: int,
+        config: Dict[str, Any],
+    ) -> tuple[bool, Optional[int], Dict[str, Any]]:
+        deadline = time.monotonic() + 20.0
+        observed_stream_id: Optional[int] = None
+        while time.monotonic() < deadline and not self._stop_event.is_set():
+            try:
+                status = self._find_status_for_target(udi.get_proxy_status() or {}, target)
+            except Exception as exc:
+                logger.warning(f"Shadow blank monitor switch verification status fetch failed: {exc}")
+                status = {}
+            stream_id = self._extract_stream_id(status)
+            if stream_id is not None:
+                observed_stream_id = stream_id
+            try:
+                if stream_id is not None and int(stream_id) == int(expected_stream_id):
+                    return True, observed_stream_id, {
+                        "post_switch_verification_mode": "status_stream_id",
+                    }
+            except (TypeError, ValueError):
+                pass
+            time.sleep(0.5)
+
+        if observed_stream_id is not None:
+            details: Dict[str, Any] = {
+                "post_switch_verification_mode": "status_stream_id",
+                "post_switch_status_mismatch": True,
+                "expected_stream_ref": _ref("stream", expected_stream_id),
+            }
+            probe_details = self._verify_proxy_output_after_switch(target, config)
+            details.update(probe_details)
+            if probe_details.get("accepted"):
+                details["post_switch_verification_mode"] = "status_stream_id+proxy_probe"
+                return True, observed_stream_id, details
+            return False, observed_stream_id, details
+
+        probe_details = self._verify_proxy_output_after_switch(target, config)
+        if probe_details.get("accepted"):
+            return True, observed_stream_id, probe_details
+        return False, observed_stream_id, probe_details
+
+    def _verify_proxy_output_after_switch(
+        self,
+        target: Dict[str, Any],
+        config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        channel_uuid = target.get("channel_uuid")
+        if not channel_uuid:
+            return {
+                "post_switch_verification_mode": "proxy_probe",
+                "post_switch_proxy_probe": {"error": "missing_channel_uuid"},
+            }
+        try:
+            url = self._channel_proxy_url(str(channel_uuid), target.get("viewer_output_format"))
+        except Exception as exc:
+            return {
+                "post_switch_verification_mode": "proxy_probe",
+                "post_switch_proxy_probe": {"error": str(exc)},
+            }
+
+        verify_config = dict(config)
+        verify_config["probe_duration_seconds"] = max(
+            3,
+            min(8, int(config.get("next_stream_pre_probe_duration_seconds", 8))),
+        )
+        verify_config["loop_detection_enabled"] = False
+        try:
+            result = self.blank_probe(url, verify_config)
+        except Exception as exc:
+            return {
+                "post_switch_verification_mode": "proxy_probe",
+                "post_switch_proxy_probe": {"error": str(exc)},
+            }
+
+        rejection_reason = self._pre_probe_rejection_reason(result)
+        summary = {
+            key: result.get(key)
+            for key in (
+                "blank_detected",
+                "freeze_detected",
+                "no_decodable_frames_detected",
+                "garbled_audio_detected",
+                "silent_audio_detected",
+                "offline_image_detected",
+                "timeout",
+            )
+            if key in result
+        }
+        if rejection_reason:
+            summary["rejection_reason"] = rejection_reason
+        return {
+            "post_switch_verification_mode": "proxy_probe",
+            "post_switch_proxy_probe": summary,
+            "post_switch_proxy_probe_accepted": rejection_reason is None,
+            "accepted": rejection_reason is None,
+        }
 
     def _ordered_alternative_streams(
         self,
@@ -1515,14 +1705,24 @@ class ShadowBlankMonitorService:
         reason: str,
     ) -> tuple[Optional[int], Optional[Dict[str, Any]]]:
         last_details: Optional[Dict[str, Any]] = None
-        for candidate_id in self._ordered_alternative_streams(
+        channel_id = self._resolve_channel_id(
             udi,
             target.get("channel_id"),
+            channel_uuid=target.get("channel_uuid"),
+            current_stream_id=current_stream_id,
+            previous_target=target,
+        )
+        if channel_id is not None and target.get("channel_id") != channel_id:
+            target["channel_id"] = channel_id
+            target["channel_ref"] = _ref("channel", channel_id)
+        for candidate_id in self._ordered_alternative_streams(
+            udi,
+            channel_id,
             current_stream_id,
             excluded_stream_ids=excluded_stream_ids,
         ):
             candidate_ref = _ref("stream", candidate_id)
-            candidate_stream = self._stream_for_id(udi, target.get("channel_id"), candidate_id)
+            candidate_stream = self._stream_for_id(udi, channel_id, candidate_id)
             candidate_url = self._stream_url(candidate_stream)
             details: Dict[str, Any] = {
                 "enabled": True,
@@ -1557,6 +1757,7 @@ class ShadowBlankMonitorService:
                 probe_result = self._run_next_stream_pre_probe(
                     str(provider_slot.get("url") or candidate_url),
                     config,
+                    reason=reason,
                 )
             finally:
                 self._release_pre_probe_provider_slot(provider_slot)
@@ -1760,11 +1961,19 @@ class ShadowBlankMonitorService:
             self._pre_probe_metrics[metric] += 1
             self._last_pre_probe = summary
 
-    def _run_next_stream_pre_probe(self, url: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _run_next_stream_pre_probe(
+        self,
+        url: str,
+        config: Dict[str, Any],
+        *,
+        reason: str = "",
+    ) -> Dict[str, Any]:
         pre_probe_config = dict(config)
         pre_probe_config["probe_duration_seconds"] = int(
             config.get("next_stream_pre_probe_duration_seconds", 8)
         )
+        if str(reason or "") != "loop":
+            pre_probe_config["loop_detection_enabled"] = False
         result = self._run_blank_probe(url, pre_probe_config)
         if self._pre_probe_rejection_reason(result):
             return result
@@ -1798,20 +2007,61 @@ class ShadowBlankMonitorService:
             return VIDEO_FAULT_CONFIRMATION_KEY
         return reason or "blank"
 
+    def _clear_detection_counts_locked(self, channel_uuid: str) -> None:
+        self._blank_counts.pop(channel_uuid, None)
+        self._blank_counts.pop(
+            self._detection_count_key(channel_uuid, VIDEO_FAULT_CONFIRMATION_KEY),
+            None,
+        )
+        self._blank_counts.pop(self._detection_count_key(channel_uuid, "blank"), None)
+        self._blank_counts.pop(self._detection_count_key(channel_uuid, "freeze"), None)
+        self._blank_counts.pop(self._detection_count_key(channel_uuid, "no_decodable_frames"), None)
+        self._blank_counts.pop(self._detection_count_key(channel_uuid, "garbled_audio"), None)
+        self._blank_counts.pop(self._detection_count_key(channel_uuid, "silent_audio"), None)
+        self._blank_counts.pop(self._detection_count_key(channel_uuid, "offline_image"), None)
+        self._blank_counts.pop(self._detection_count_key(channel_uuid, "loop"), None)
+        self._detection_misses.pop(channel_uuid, None)
+        self._detection_misses.pop(
+            self._detection_count_key(channel_uuid, VIDEO_FAULT_CONFIRMATION_KEY),
+            None,
+        )
+        self._detection_misses.pop(self._detection_count_key(channel_uuid, "blank"), None)
+        self._detection_misses.pop(self._detection_count_key(channel_uuid, "freeze"), None)
+        self._detection_misses.pop(self._detection_count_key(channel_uuid, "no_decodable_frames"), None)
+        self._detection_misses.pop(self._detection_count_key(channel_uuid, "garbled_audio"), None)
+        self._detection_misses.pop(self._detection_count_key(channel_uuid, "silent_audio"), None)
+        self._detection_misses.pop(self._detection_count_key(channel_uuid, "offline_image"), None)
+        self._detection_misses.pop(self._detection_count_key(channel_uuid, "loop"), None)
+
     def _reset_blank_count(self, channel_uuid: str) -> None:
         with self._lock:
-            self._blank_counts.pop(channel_uuid, None)
-            self._blank_counts.pop(
-                self._detection_count_key(channel_uuid, VIDEO_FAULT_CONFIRMATION_KEY),
-                None,
+            self._clear_detection_counts_locked(channel_uuid)
+
+    def _reset_blank_count_after_probe_ok(
+        self,
+        channel_uuid: str,
+        config: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        loop_key = self._detection_count_key(channel_uuid, "loop")
+        with self._lock:
+            loop_count = int(self._blank_counts.get(loop_key) or 0)
+            loop_misses = int(self._detection_misses.get(loop_key) or 0)
+            preserve_loop = (
+                bool(config.get("loop_detection_enabled"))
+                and loop_count > 0
+                and loop_misses < LOOP_PENDING_PROBE_OK_MISS_TOLERANCE
             )
-            self._blank_counts.pop(self._detection_count_key(channel_uuid, "blank"), None)
-            self._blank_counts.pop(self._detection_count_key(channel_uuid, "freeze"), None)
-            self._blank_counts.pop(self._detection_count_key(channel_uuid, "no_decodable_frames"), None)
-            self._blank_counts.pop(self._detection_count_key(channel_uuid, "garbled_audio"), None)
-            self._blank_counts.pop(self._detection_count_key(channel_uuid, "silent_audio"), None)
-            self._blank_counts.pop(self._detection_count_key(channel_uuid, "offline_image"), None)
-            self._blank_counts.pop(self._detection_count_key(channel_uuid, "loop"), None)
+            self._clear_detection_counts_locked(channel_uuid)
+            if not preserve_loop:
+                return None
+            self._blank_counts[loop_key] = loop_count
+            self._detection_misses[loop_key] = loop_misses + 1
+            return {
+                "reason": "loop",
+                "confirmations": loop_count,
+                "misses": loop_misses + 1,
+                "miss_tolerance": LOOP_PENDING_PROBE_OK_MISS_TOLERANCE,
+            }
 
     def _reset_detection_state(self, channel_uuid: str) -> None:
         self._reset_blank_count(channel_uuid)
@@ -1833,6 +2083,7 @@ class ShadowBlankMonitorService:
                     ),
                 )
             self._blank_counts[key] += 1
+            self._detection_misses[key] = 0
             return self._blank_counts[key]
 
     def _current_detection_count(self, channel_uuid: str, reason: str = "blank") -> int:
@@ -1881,13 +2132,24 @@ class ShadowBlankMonitorService:
         recovery_age = watched.get("watcher_recovered_after_seconds")
         guard_details: Optional[Dict[str, Any]] = None
         if recovery_age is not None:
+            if self._watcher_recovery_matches_current_probe_window(
+                target,
+                watched,
+                config,
+                reason=reason,
+                recovery_age=recovery_age,
+            ):
+                return None
             guard_details = {
                 "reason": reason,
                 "watcher_recovered_after_seconds": recovery_age,
             }
         else:
             fresh_details = self._watcher_client_details(fresh_status, config)
-            if self._watcher_client_started_with_current_probe(target, fresh_details):
+            if (
+                self._watcher_client_started_with_current_probe(target, fresh_details)
+                or self._watcher_status_has_current_probe_client(target, fresh_status, config)
+            ):
                 return None
             target_watcher_ref = target.get("watcher_client_ref")
             fresh_watcher_ref = fresh_details.get("watcher_client_ref")
@@ -1917,6 +2179,67 @@ class ShadowBlankMonitorService:
         except (TypeError, ValueError):
             return False
         return watcher_connected >= probe_started - 0.5
+
+    def _watcher_status_has_current_probe_client(
+        self,
+        target: Dict[str, Any],
+        status: Dict[str, Any],
+        config: Dict[str, Any],
+    ) -> bool:
+        try:
+            probe_started = float(target.get("active_probe_started_at"))
+        except (TypeError, ValueError):
+            return False
+
+        marker = str(config.get("watcher_user_agent") or "").lower()
+        if not marker:
+            return False
+        clients = status.get("clients")
+        if isinstance(clients, dict):
+            clients = list(clients.values())
+        if not isinstance(clients, list):
+            return False
+
+        for client in clients:
+            if marker not in self._client_text(client).lower():
+                continue
+            connected_at = None
+            if isinstance(client, dict):
+                connected_at = client.get("connected_at") or client.get("started_at")
+            try:
+                watcher_connected = float(connected_at)
+            except (TypeError, ValueError):
+                continue
+            if watcher_connected >= probe_started - 0.5:
+                return True
+        return False
+
+    def _watcher_recovery_matches_current_probe_window(
+        self,
+        target: Dict[str, Any],
+        watched: Dict[str, Any],
+        config: Dict[str, Any],
+        *,
+        reason: str,
+        recovery_age: Any,
+    ) -> bool:
+        if reason != "blank" and reason not in MEDIA_FAULT_RECOVERY_GUARD_BYPASS_REASONS:
+            return False
+        try:
+            probe_started = float(target.get("active_probe_started_at"))
+            watched_probe_started = float(watched.get("active_probe_started_at"))
+            age = float(recovery_age)
+        except (TypeError, ValueError):
+            return False
+        if abs(watched_probe_started - probe_started) > 1.0:
+            return False
+        # Bounded Shadow probes intentionally close and reopen the watcher
+        # connection so ffmpeg can flush media-fault lines. Dispatcharr does
+        # not always expose watcher connected_at. Only recoveries attached to
+        # the same active probe window are treated as our own probe rollover;
+        # stale or external watcher recoveries still guard the switch.
+        window = self._probe_analysis_window_seconds(config) + float(config.get("watch_gap_seconds", 1)) + 1.0
+        return 0.0 <= age <= window
 
     def _media_recovery_guard_bypass_details(
         self,
@@ -2087,6 +2410,42 @@ class ShadowBlankMonitorService:
             input_index = command.index("-vf")
             command[input_index:input_index] = ["-t", str(duration)]
         return command, duration
+
+    @staticmethod
+    def _probe_analysis_window_seconds(config: Dict[str, Any]) -> float:
+        """Bound one shadow media analysis window to the enabled fault timers.
+
+        Some Dispatcharr proxy formats only flush blackdetect/freezedetect
+        segment summaries when ffmpeg exits. Keeping the downstream probe open
+        forever makes a real black channel look healthy until the viewer leaves.
+        This cap lets one confirmation window close quickly while preserving the
+        configured per-fault minimum durations.
+        """
+        duration = float(config.get("probe_duration_seconds") or DEFAULT_CONFIG["probe_duration_seconds"])
+        required_windows = [
+            float(config.get("blank_min_duration_seconds", DEFAULT_CONFIG["blank_min_duration_seconds"])),
+        ]
+        if config.get("freeze_detection_enabled"):
+            required_windows.append(float(
+                config.get("freeze_min_duration_seconds", DEFAULT_CONFIG["freeze_min_duration_seconds"])
+            ))
+        if config.get("no_decodable_frames_detection_enabled", True):
+            required_windows.append(float(
+                config.get(
+                    "no_decodable_frames_min_duration_seconds",
+                    DEFAULT_CONFIG["no_decodable_frames_min_duration_seconds"],
+                )
+            ))
+        if config.get("silent_audio_detection_enabled"):
+            required_windows.append(float(
+                config.get(
+                    "silent_audio_min_duration_seconds",
+                    DEFAULT_CONFIG["silent_audio_min_duration_seconds"],
+                )
+            ))
+        # Add a small settle window so ffmpeg can flush final filter lines.
+        analysis_window = max(required_windows or [duration]) + 2.0
+        return max(1.0, min(duration, analysis_window))
 
     @staticmethod
     def _line_is_missing_audio(line: str) -> bool:
@@ -2370,6 +2729,22 @@ class ShadowBlankMonitorService:
             "loop_frames_processed": frames,
         }
 
+    @staticmethod
+    def _continuous_loop_probe_slice_seconds(config: Dict[str, Any]) -> float:
+        """Keep continuous Shadow loop probes from blocking media-fault checks.
+
+        Loop detection still gets enough wall time to satisfy the 10s sidecar
+        loop threshold, but it must yield back to the watcher so black, freeze,
+        silent-audio, and decode-fault checks can run again while a viewer is
+        still active.
+        """
+        configured = float(
+            config.get("loop_probe_duration_seconds")
+            or DEFAULT_CONFIG["loop_probe_duration_seconds"]
+        )
+        analysis_window = ShadowBlankMonitorService._probe_analysis_window_seconds(config)
+        return max(1.0, min(configured, max(15.0, analysis_window + 3.0)))
+
     def _run_loop_probe_if_enabled(
         self,
         url: str,
@@ -2382,7 +2757,12 @@ class ShadowBlankMonitorService:
             return {}
         loop_config = dict(config)
         abort_state = {"viewer_left": False}
+        loop_slice_seconds: Optional[float] = None
+        loop_slice_deadline: Optional[float] = None
         if udi is not None and config.get("watch_mode") == "continuous":
+            loop_slice_seconds = self._continuous_loop_probe_slice_seconds(config)
+            loop_slice_deadline = time.monotonic() + loop_slice_seconds
+
             def _abort_when_viewer_left() -> bool:
                 try:
                     fresh_status = self._find_status_for_target(udi.get_proxy_status() or {}, target)
@@ -2393,6 +2773,9 @@ class ShadowBlankMonitorService:
                 if viewer_left:
                     abort_state["viewer_left"] = True
                     return True
+                if loop_slice_deadline is not None and time.monotonic() >= loop_slice_deadline:
+                    abort_state["time_sliced"] = True
+                    return True
                 return self._stop_event.is_set()
 
             loop_config["_shadow_loop_abort_check"] = _abort_when_viewer_left
@@ -2402,6 +2785,10 @@ class ShadowBlankMonitorService:
             result["loop_detected"] = bool(result.get("loop_detected"))
             if abort_state.get("viewer_left"):
                 result["viewer_left"] = True
+            if abort_state.get("time_sliced") and not result.get("loop_detected"):
+                result["loop_probe_sliced"] = True
+                if loop_slice_seconds is not None:
+                    result["loop_probe_slice_seconds"] = round(loop_slice_seconds, 3)
             return result
         except Exception as exc:
             logger.warning(
@@ -2576,6 +2963,9 @@ class ShadowBlankMonitorService:
         lines: List[str] = []
         line_queue: queue.Queue[str] = queue.Queue()
         probe_started_wall = time.monotonic()
+        analysis_window_seconds = self._probe_analysis_window_seconds(config)
+        analysis_window_elapsed = False
+        analysis_window_duration: Optional[float] = None
         process = subprocess.Popen(
             command,
             stdout=subprocess.DEVNULL,
@@ -2854,6 +3244,13 @@ class ShadowBlankMonitorService:
                 except Exception as exc:
                     logger.warning(f"Shadow blank monitor viewer poll failed: {exc}")
 
+                if now - probe_started_wall >= analysis_window_seconds:
+                    analysis_window_elapsed = True
+                    analysis_window_duration = max(0.0, now - probe_started_wall)
+                    if process.poll() is None:
+                        process.terminate()
+                    break
+
                 time.sleep(0.2)
 
             if self._stop_event.is_set() and process.poll() is None:
@@ -2921,8 +3318,13 @@ class ShadowBlankMonitorService:
                     detected_reason = "no_decodable_frames"
                     detected_duration = float(no_decodable_parsed.get("no_decodable_frames_duration_secs") or 0.0)
 
+            base_probe_duration = (
+                analysis_window_duration
+                if analysis_window_elapsed and analysis_window_duration is not None
+                else float(duration)
+            )
             observed_probe_duration = max(
-                duration,
+                base_probe_duration,
                 int(last_media_time) if last_media_time else 0,
                 int(detected_duration) if detected_duration else 0,
             )
@@ -2937,6 +3339,30 @@ class ShadowBlankMonitorService:
                     observed_probe_duration,
                     freeze_ratio_threshold=float(config["freeze_ratio_threshold"]),
                 ))
+            if not detected_reason and not viewer_left and not stopped:
+                flushed_blank_duration = max(
+                    (
+                        float(segment.get("duration") or 0.0)
+                        for segment in parsed.get("blank_segments") or []
+                        if isinstance(segment, dict)
+                    ),
+                    default=0.0,
+                )
+                if flushed_blank_duration >= blank_required:
+                    detected_reason = "blank"
+                    detected_duration = flushed_blank_duration
+                elif config.get("freeze_detection_enabled"):
+                    flushed_freeze_duration = max(
+                        (
+                            float(segment.get("duration") or 0.0)
+                            for segment in parsed.get("freeze_segments") or []
+                            if isinstance(segment, dict)
+                        ),
+                        default=0.0,
+                    )
+                    if flushed_freeze_duration >= freeze_required:
+                        detected_reason = "freeze"
+                        detected_duration = flushed_freeze_duration
             parsed.update(self._parse_audio_detection(
                 output,
                 config,
@@ -2983,6 +3409,142 @@ class ShadowBlankMonitorService:
         finally:
             if process.poll() is None:
                 process.kill()
+
+    def _remember_channel_identities(self, channels: Iterable[Dict[str, Any]]) -> None:
+        for channel in channels or []:
+            self._remember_channel_identity(channel)
+
+    def _remember_channel_identity(self, channel: Optional[Dict[str, Any]]) -> Optional[int]:
+        if not isinstance(channel, dict):
+            return None
+        channel_id = self._coerce_int((channel or {}).get("id"))
+        if channel_id is None:
+            return None
+        channel_uuid = str(channel.get("uuid") or channel.get("channel_uuid") or "").strip()
+        stream_ids = [
+            stream_id
+            for stream_id in (
+                self._coerce_int(item.get("id") if isinstance(item, dict) else item)
+                for item in (channel.get("streams") or [])
+            )
+            if stream_id is not None
+        ]
+        with self._lock:
+            if channel_uuid:
+                self._known_channel_ids_by_uuid[channel_uuid] = channel_id
+            for stream_id in stream_ids:
+                self._known_channel_ids_by_stream_id[stream_id] = channel_id
+        return channel_id
+
+    def _resolve_channel_id(
+        self,
+        udi: Any,
+        candidate_id: Any,
+        *,
+        channel_uuid: Any = None,
+        channel: Optional[Dict[str, Any]] = None,
+        status: Optional[Dict[str, Any]] = None,
+        current_stream_id: Any = None,
+        included_ids: Optional[Iterable[int]] = None,
+        included_uuids: Optional[Iterable[str]] = None,
+        previous_target: Optional[Dict[str, Any]] = None,
+    ) -> Optional[int]:
+        channel_uuid_text = str(channel_uuid or "").strip()
+        current_stream_id_int = self._coerce_int(current_stream_id)
+
+        if isinstance(channel, dict):
+            if not channel_uuid_text:
+                channel_uuid_text = str(channel.get("uuid") or channel.get("channel_uuid") or "").strip()
+            resolved = self._remember_channel_identity(channel)
+            if resolved is not None:
+                return resolved
+
+        for value in (
+            candidate_id,
+            (status or {}).get("numeric_channel_id") if isinstance(status, dict) else None,
+            (status or {}).get("id") if isinstance(status, dict) else None,
+            (previous_target or {}).get("channel_id") if isinstance(previous_target, dict) else None,
+        ):
+            resolved = self._coerce_int(value)
+            if resolved is not None:
+                self._remember_channel_identity({
+                    "id": resolved,
+                    "uuid": channel_uuid_text,
+                    "streams": [current_stream_id_int] if current_stream_id_int is not None else [],
+                })
+                return resolved
+
+        if channel_uuid_text:
+            with self._lock:
+                resolved = self._known_channel_ids_by_uuid.get(channel_uuid_text)
+            if resolved is not None:
+                return resolved
+
+        if current_stream_id_int is not None:
+            with self._lock:
+                resolved = self._known_channel_ids_by_stream_id.get(current_stream_id_int)
+            if resolved is not None:
+                return resolved
+
+        resolved_channel = self._find_channel_for_identity(
+            udi,
+            channel_uuid=channel_uuid_text,
+            stream_id=current_stream_id_int,
+        )
+        resolved = self._remember_channel_identity(resolved_channel)
+        if resolved is not None:
+            return resolved
+
+        included_id_set = set(included_ids or [])
+        included_uuid_set = {str(item) for item in (included_uuids or [])}
+        if len(included_id_set) == 1 and channel_uuid_text and channel_uuid_text in included_uuid_set:
+            resolved = next(iter(included_id_set))
+            self._remember_channel_identity({
+                "id": resolved,
+                "uuid": channel_uuid_text,
+                "streams": [current_stream_id_int] if current_stream_id_int is not None else [],
+            })
+            return resolved
+
+        return None
+
+    def _find_channel_for_identity(
+        self,
+        udi: Any,
+        *,
+        channel_uuid: str = "",
+        stream_id: Optional[int] = None,
+    ) -> Optional[Dict[str, Any]]:
+        if not hasattr(udi, "get_channels"):
+            return None
+        try:
+            channels = udi.get_channels() or []
+        except Exception:
+            return None
+        for channel in channels:
+            if not isinstance(channel, dict):
+                continue
+            if channel_uuid and str(channel.get("uuid") or channel.get("channel_uuid") or "") == channel_uuid:
+                return channel
+            if stream_id is not None and self._channel_has_stream(channel, stream_id):
+                return channel
+        return None
+
+    @staticmethod
+    def _channel_has_stream(channel: Dict[str, Any], stream_id: int) -> bool:
+        stream_id_text = str(stream_id)
+        for item in (channel or {}).get("streams") or []:
+            value = item.get("id") if isinstance(item, dict) else item
+            if str(value) == stream_id_text:
+                return True
+        return False
+
+    @staticmethod
+    def _coerce_int(value: Any) -> Optional[int]:
+        try:
+            return int(value) if value is not None and str(value) != "" else None
+        except (TypeError, ValueError):
+            return None
 
     @staticmethod
     def _index_channels(channels: Iterable[Dict[str, Any]]) -> tuple[Dict[str, Dict[str, Any]], Dict[int, Dict[str, Any]]]:
@@ -3302,7 +3864,7 @@ class ShadowBlankMonitorService:
             return "probe"
         if event_type == "offline_image_learned":
             return "learn"
-        if event_type in {"viewer_left", "watcher_reconnecting", "watcher_recovered"}:
+        if event_type in {"viewer_left", "watcher_reconnecting", "watcher_recovered", "watcher_orphaned"}:
             return "watcher"
         if event_type == "no_alternative":
             return "skip"

--- a/backend/apps/stream/sidecar_loop_detector.py
+++ b/backend/apps/stream/sidecar_loop_detector.py
@@ -20,6 +20,9 @@ HAMMING_TOLERANCE = 5
 LOOP_DURATION_THRESHOLD = 10.0
 BUFFER_MAXLEN = 300  # ~5 minutes at 1fps
 STALE_THRESHOLD = 10.0
+AVERAGE_HASH_TOLERANCE = 0
+DIFFERENCE_HASH_TOLERANCE = 3
+WAVELET_HASH_TOLERANCE = 2
 
 class SidecarLoopDetector:
     """
@@ -50,6 +53,62 @@ class SidecarLoopDetector:
     def get_loop_duration(self) -> float:
         """Returns the duration of the last detected loop."""
         return self._loop_duration
+
+    def frame_signature(self, img):
+        """Return a multi-hash signature for a decoded video frame."""
+        if not imagehash:
+            return self._simple_hash(img)
+        return {
+            "phash": imagehash.phash(img),
+            "ahash": imagehash.average_hash(img),
+            "dhash": imagehash.dhash(img),
+            "whash": imagehash.whash(img),
+        }
+
+    @staticmethod
+    def _signature_hash(signature, family: str = "phash"):
+        if isinstance(signature, dict):
+            return signature.get(family) or signature.get("phash")
+        return signature
+
+    @classmethod
+    def _signature_distance(cls, left, right, family: str = "phash") -> int:
+        left_hash = cls._signature_hash(left, family)
+        right_hash = cls._signature_hash(right, family)
+        if left_hash is None or right_hash is None:
+            return 999
+        try:
+            return int(left_hash - right_hash)
+        except Exception:
+            return 999
+
+    @classmethod
+    def _phash_sequence_matches(cls, history, recent, tolerance: int) -> bool:
+        return all(
+            cls._signature_distance(history[index], recent[index], "phash") <= tolerance
+            for index in range(SEQUENCE_LENGTH)
+        )
+
+    @classmethod
+    def _stable_compressed_sequence_matches(cls, history, recent) -> bool:
+        """Match loops whose pHash is noisy but shape/brightness stay stable.
+
+        MPEGTS/fMP4 proxy paths can introduce enough codec noise that pHash
+        moves by double digits even though the decoded scene is visually the
+        same. We require agreement from multiple simpler hashes instead of
+        loosening pHash globally.
+        """
+        for index in range(SEQUENCE_LENGTH):
+            ahash_distance = cls._signature_distance(history[index], recent[index], "ahash")
+            dhash_distance = cls._signature_distance(history[index], recent[index], "dhash")
+            whash_distance = cls._signature_distance(history[index], recent[index], "whash")
+            if ahash_distance > AVERAGE_HASH_TOLERANCE:
+                return False
+            if dhash_distance > DIFFERENCE_HASH_TOLERANCE:
+                return False
+            if whash_distance > WAVELET_HASH_TOLERANCE:
+                return False
+        return True
         
     def run(self):
         """
@@ -79,11 +138,8 @@ class SidecarLoopDetector:
                     # Parse PPM frame
                     img = Image.open(io.BytesIO(frame_data))
                     
-                    # Generate pHash
-                    if imagehash:
-                        h = imagehash.phash(img)
-                    else:
-                        h = self._simple_hash(img)
+                    # Generate a compact visual signature for loop matching.
+                    h = self.frame_signature(img)
                     
                     self.buffer.append((timestamp, h))
                     
@@ -144,7 +200,10 @@ class SidecarLoopDetector:
         
         # Static image / Black screen filter
         # If the 3 most recent are nearly identical, it's a static image or black screen
-        if (h0 - h_1 <= tolerance) and (h_1 - h_2 <= tolerance):
+        if (
+            self._signature_distance(h0, h_1, "phash") <= tolerance
+            and self._signature_distance(h_1, h_2, "phash") <= tolerance
+        ):
             return None
 
         # Iterate backward through history (skipping the most recent sequence)
@@ -154,11 +213,13 @@ class SidecarLoopDetector:
         for i in range(len(history) - SEQUENCE_LENGTH + 1):
             # Match recent sequence [H0, H-1, H-2] against [H-t, H-(t+1), H-(t+2)]
             # Note: history[i] is [H-(t+2)], history[i+1] is [H-(t+1)], history[i+2] is [H-t]
-            match_t2 = history[i][1] - h_2 <= tolerance
-            match_t1 = history[i+1][1] - h_1 <= tolerance
-            match_t0 = history[i+2][1] - h0 <= tolerance
-            
-            if match_t2 and match_t1 and match_t0:
+            history_sequence = [history[i][1], history[i + 1][1], history[i + 2][1]]
+            recent_sequence = [h_2, h_1, h0]
+
+            if (
+                self._phash_sequence_matches(history_sequence, recent_sequence, tolerance)
+                or self._stable_compressed_sequence_matches(history_sequence, recent_sequence)
+            ):
                 # Found a matching sequence!
                 t_match = history[i+2][0]
                 duration = t0 - t_match

--- a/backend/apps/stream/stream_check_utils.py
+++ b/backend/apps/stream/stream_check_utils.py
@@ -1878,11 +1878,6 @@ def _probe_stream_for_loops(
         logger.error(f"[loop-probe:{stream_tag}] SidecarLoopDetector unavailable")
         return False, None, 0
 
-    try:
-        import imagehash as _imagehash
-    except ImportError:
-        _imagehash = None
-
     clamped = max(_LOOP_PROBE_DURATION_MIN, min(_LOOP_PROBE_DURATION_MAX, probe_duration))
 
     logger.info(
@@ -1978,13 +1973,14 @@ def _probe_stream_for_loops(
 
                 try:
                     img = Image.open(io.BytesIO(frame_data))
-                    h   = _imagehash.phash(img) if _imagehash else detector._simple_hash(img)
+                    h   = detector.frame_signature(img)
                     detector.buffer.append((ts, h))
                     frames_done[0] += 1
 
+                    display_hash = h.get("phash") if isinstance(h, dict) else h
                     logger.debug(
                         f"[loop-probe:{stream_tag}] "
-                        f"frame={frames_done[0]:4d}  hash={h}  buffer={len(detector.buffer)}"
+                        f"frame={frames_done[0]:4d}  hash={display_hash}  buffer={len(detector.buffer)}"
                     )
 
                     detected = detector.detect_loop(
@@ -1993,6 +1989,9 @@ def _probe_stream_for_loops(
                     if detected:
                         detector._is_looping   = True
                         detector._loop_duration = detected
+                        loop_detected = True
+                        if loop_duration is None or detected > loop_duration:
+                            loop_duration = detected
                         logger.debug(
                             f"[loop-probe:{stream_tag}] Loop signal at "
                             f"frame {frames_done[0]}: period={detected:.1f}s"
@@ -2014,8 +2013,9 @@ def _probe_stream_for_loops(
             except Exception:
                 pass
 
-        loop_detected = detector.is_looping()
-        loop_duration = detector.get_loop_duration() if loop_detected else None
+        if not loop_detected:
+            loop_detected = detector.is_looping()
+            loop_duration = detector.get_loop_duration() if loop_detected else None
 
     reader = threading.Thread(
         target=_reader, daemon=True,

--- a/backend/apps/udi/manager.py
+++ b/backend/apps/udi/manager.py
@@ -517,6 +517,62 @@ class UDIManager:
             )
         return merged, changed
 
+    def _rehydrate_missing_channel_ids(
+        self,
+        channels: List[Dict[str, Any]],
+        expected_ids: Optional[Set[int]],
+        *,
+        reason: str,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Fetch channels that are present in Dispatcharr IDs but absent from the list API.
+
+        Dispatcharr may hide ``hidden_from_output`` channels from normal list
+        responses in some deployments. The /ids/ endpoint with
+        ``visibility_filter=all`` is the broader oracle; when it reports IDs
+        that the list response omitted, fetch those channels individually so
+        StreamFlow can still rematch/check and restore them.
+        """
+        if not expected_ids:
+            return channels, 0
+
+        cached_ids = {
+            channel.get("id")
+            for channel in channels
+            if channel.get("id") is not None
+        }
+        missing_ids = sorted(expected_ids - cached_ids)
+        if not missing_ids:
+            return channels, 0
+
+        rehydrated = self.fetcher.fetch_channels_by_ids(missing_ids)
+        if not rehydrated:
+            logger.warning(
+                "UDI could not rehydrate %s channel(s) omitted by channel list (%s): %s",
+                len(missing_ids),
+                reason,
+                missing_ids[:10],
+            )
+            return channels, 0
+
+        merged, changed = self._merge_channel_list_with_rehydrated(channels, rehydrated)
+        fetched_ids = {channel.get("id") for channel in rehydrated}
+        still_missing = [channel_id for channel_id in missing_ids if channel_id not in fetched_ids]
+        if still_missing:
+            logger.warning(
+                "UDI rehydrated %s channel(s) omitted by channel list (%s); %s still missing: %s",
+                changed,
+                reason,
+                len(still_missing),
+                still_missing[:10],
+            )
+        else:
+            logger.info(
+                "UDI rehydrated %s channel(s) omitted by channel list (%s)",
+                changed,
+                reason,
+            )
+        return merged, changed
+
     @staticmethod
     def _get_stream_m3u_account_id(stream: Dict[str, Any]) -> Optional[Any]:
         """Return a stream's M3U account id across legacy and SQL payloads."""
@@ -1081,7 +1137,7 @@ class UDIManager:
             # Progress advances as each future lands via as_completed so the
             # frontend bar still moves steadily.
             _fetch_tasks = {
-                'pre_counts':   self.fetcher.fetch_entity_counts,
+                'pre_ids':      self.fetcher.fetch_all_ids,
                 'channels':     self.fetcher.fetch_channels,
                 'streams':      self.fetcher.fetch_streams,
                 'groups':       self.fetcher.fetch_channel_groups,
@@ -1106,7 +1162,11 @@ class UDIManager:
                         current_step='fetch',
                     )
 
-            pre_counts      = _fetch_results.get('pre_counts') or {}
+            pre_ids         = _fetch_results.get('pre_ids') or {}
+            pre_counts      = {
+                'channels': len(pre_ids['channels']) if 'channels' in pre_ids else None,
+                'streams': len(pre_ids['streams']) if 'streams' in pre_ids else None,
+            }
             channels_result = _fetch_results.get('channels') or FetchResult()
             streams_result  = _fetch_results.get('streams')  or FetchResult()
             channel_groups  = _fetch_results.get('groups')   or []
@@ -1121,12 +1181,28 @@ class UDIManager:
 
             # Apply /ids/ oracle when the paginated envelope omitted 'count'
             # (can happen with older Dispatcharr builds / custom pagination).
-            if channels_result.expected_count is None and pre_counts.get('channels') is not None:
+            if (
+                pre_counts.get('channels') is not None
+                and (
+                    channels_result.expected_count is None
+                    or pre_counts['channels'] > channels_result.expected_count
+                )
+            ):
                 channels_result.expected_count = pre_counts['channels']
                 logger.info(f"UDI integrity: using /ids/ oracle for channels — expected {channels_result.expected_count}")
             if streams_result.expected_count is None and pre_counts.get('streams') is not None:
                 streams_result.expected_count = pre_counts['streams']
                 logger.info(f"UDI integrity: using /ids/ oracle for streams — expected {streams_result.expected_count}")
+
+            rehydrated_missing_count = 0
+            channels_result.items, rehydrated_missing_count = self._rehydrate_missing_channel_ids(
+                channels_result.items,
+                pre_ids.get('channels') if isinstance(pre_ids, dict) else None,
+                reason="dispatcharr_ids_oracle",
+            )
+            channels_result.items, rehydrated_hidden_count = self._rehydrate_managed_hidden_channels(
+                channels_result.items,
+            )
 
             existing_channel_count = len(self._channels_cache)
             existing_stream_count = len(self._streams_cache)
@@ -1173,6 +1249,10 @@ class UDIManager:
                     'expected': None,  # non-paginated, no oracle available
                 },
             }
+            if rehydrated_missing_count:
+                entity_counts['channels']['rehydrated_missing'] = rehydrated_missing_count
+            if rehydrated_hidden_count:
+                entity_counts['channels']['rehydrated_hidden'] = rehydrated_hidden_count
 
             integrity_ok = channels_ok and streams_ok
             if not integrity_ok:
@@ -1185,10 +1265,9 @@ class UDIManager:
                 )
                 return False
 
-            new_channels, rehydrated_hidden_count = self._rehydrate_managed_hidden_channels(channels_result.items)
-            if rehydrated_hidden_count:
+            new_channels = channels_result.items
+            if rehydrated_missing_count or rehydrated_hidden_count:
                 entity_counts['channels']['received'] = len(new_channels)
-                entity_counts['channels']['rehydrated_hidden'] = rehydrated_hidden_count
 
             self._update_init_progress(percentage=85, message='Building indexes...', current_step='index')
 
@@ -1540,13 +1619,25 @@ class UDIManager:
         logger.info("Refreshing channels...")
         try:
             result = self.fetcher.fetch_channels()
-            channels, rehydrated_hidden_count = self._rehydrate_managed_hidden_channels(result.items)
+            channel_ids: Optional[Set[int]] = None
+            try:
+                current_ids = self.fetcher.fetch_all_ids()
+                channel_ids = current_ids.get('channels') if isinstance(current_ids, dict) else None
+            except Exception as exc:
+                logger.debug("Channel refresh could not fetch channel IDs oracle: %s", exc)
+            channels, rehydrated_missing_count = self._rehydrate_missing_channel_ids(
+                result.items,
+                channel_ids,
+                reason="refresh_channels_ids_oracle",
+            )
+            channels, rehydrated_hidden_count = self._rehydrate_managed_hidden_channels(channels)
             with self._lock:
                 self._channels_cache = channels
                 self._build_indexes()
-            if rehydrated_hidden_count:
+            if rehydrated_missing_count or rehydrated_hidden_count:
                 logger.info(
-                    "Channel refresh retained %s StreamFlow-managed hidden channel(s)",
+                    "Channel refresh retained %s omitted channel(s), including %s StreamFlow-managed hidden channel(s)",
+                    rehydrated_missing_count,
                     rehydrated_hidden_count,
                 )
             self.cache.mark_refreshed('channels')

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -361,6 +361,91 @@ def test_shadow_loop_detection_switches_after_required_confirmation(tmp_path):
     }
 
 
+def test_shadow_loop_confirmation_survives_one_probe_ok_miss(tmp_path):
+    switch_calls = []
+    loop_calls = []
+    active_loop_results = iter([True, False, True])
+    udi = FakeUdi(
+        statuses=[
+            {"/proxy/ts/stream/uuid-1": active_status(10)},
+            {"/proxy/ts/stream/uuid-1": active_status(10)},
+            {"/proxy/ts/stream/uuid-1": active_status(10)},
+            {"/proxy/ts/stream/uuid-1": active_status(10)},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={
+            10: {"id": 10, "url": "http://provider.example/old.ts"},
+            11: {"id": 11, "url": "http://provider.example/new.ts"},
+        },
+    )
+
+    def loop_probe(url, config):
+        loop_calls.append(url)
+        loop_detected = next(active_loop_results) if "/proxy/ts/stream/" in url else False
+        return {
+            "loop_probe_ran": True,
+            "loop_detected": loop_detected,
+            "loop_duration_secs": 12.5 if loop_detected else None,
+            "loop_frames_processed": 26,
+        }
+
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"blank_detected": False, "freeze_detected": False},
+        loop_probe=loop_probe,
+        switch_calls=switch_calls,
+    )
+    config = normalize_config({
+        **service.get_config(include_secret=True),
+        "loop_detection_enabled": True,
+        "loop_probe_duration_seconds": 60,
+        "confirmation_count": 2,
+        "next_stream_pre_probe_enabled": True,
+    })
+    service._run_blank_probe = lambda url, config: {
+        "blank_detected": False,
+        "freeze_detected": False,
+        "no_decodable_frames_detected": False,
+    }
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-1",
+        "stream_id": 10,
+        "stream_ref": "stream-10",
+        "real_client_count": 1,
+    }
+
+    assert service._probe_target_once(udi, target, config) is True
+    assert service.get_status()["recent_events"][0]["type"] == "loop_pending"
+
+    assert service._probe_target_once(udi, target, config) is True
+    probe_ok = service.get_status()["recent_events"][0]
+    assert probe_ok["type"] == "probe_ok"
+    assert probe_ok["details"]["preserved_pending_detection"] == {
+        "reason": "loop",
+        "confirmations": 1,
+        "misses": 1,
+        "miss_tolerance": 1,
+    }
+
+    assert service._probe_target_once(udi, target, config) is False
+
+    assert loop_calls == [
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
+        "http://provider.example/new.ts",
+    ]
+    assert switch_calls == [("uuid-1", 11, None)]
+    event = service.get_status()["recent_events"][0]
+    assert event["type"] == "switch_success"
+    assert event["trigger_reason"] == "loop"
+    assert event["details"]["reason"] == "loop"
+    assert event["details"]["pre_probe"]["result"] == "ok"
+
+
 def test_shadow_loop_probe_aborts_when_real_viewer_leaves(tmp_path):
     loop_calls = []
     switch_calls = []
@@ -420,6 +505,78 @@ def test_shadow_loop_probe_aborts_when_real_viewer_leaves(tmp_path):
     assert status["recent_events"][0]["type"] == "viewer_left"
     assert status["recent_events"][0]["real_client_count"] == 0
     assert status["watched_channels"] == []
+
+
+def test_continuous_shadow_loop_probe_is_time_sliced(tmp_path, monkeypatch):
+    loop_calls = []
+    switch_calls = []
+    now = {"value": 100.0}
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={
+            10: {"id": 10, "url": "http://provider.example/old.ts"},
+            11: {"id": 11, "url": "http://provider.example/new.ts"},
+        },
+    )
+
+    monkeypatch.setattr(shadow_module.time, "monotonic", lambda: now["value"])
+
+    def loop_probe(url, config):
+        loop_calls.append(url)
+        abort_check = config.get("_shadow_loop_abort_check")
+        assert callable(abort_check)
+        assert abort_check() is False
+        now["value"] += 30.0
+        assert abort_check() is True
+        return {
+            "loop_probe_ran": True,
+            "loop_detected": False,
+            "loop_duration_secs": None,
+            "loop_frames_processed": 18,
+        }
+
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"blank_detected": False, "freeze_detected": False},
+        loop_probe=loop_probe,
+        switch_calls=switch_calls,
+    )
+    config = normalize_config({
+        **service.get_config(include_secret=True),
+        "watch_mode": "continuous",
+        "loop_detection_enabled": True,
+        "loop_probe_duration_seconds": 360,
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": True,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-1",
+        "stream_id": 10,
+        "stream_ref": "stream-10",
+        "real_client_count": 1,
+    }
+
+    result = service._run_loop_probe_if_enabled(
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
+        target,
+        config,
+        udi=udi,
+    )
+
+    assert loop_calls == ["http://dispatcharr.local/proxy/ts/stream/uuid-1"]
+    assert result["loop_probe_ran"] is True
+    assert result["loop_detected"] is False
+    assert result["loop_probe_sliced"] is True
+    assert result["loop_probe_slice_seconds"] < 360
+    assert result.get("viewer_left") is not True
+    assert switch_calls == []
 
 
 def test_shadow_bounded_blank_probe_aborts_before_loop_when_real_viewer_leaves(tmp_path):
@@ -667,6 +824,58 @@ def test_shadow_loop_pre_probe_rejects_looping_alternative(tmp_path):
     assert details["rejection_reason"] == "loop"
     assert service.get_status()["recent_events"][0]["type"] == "pre_probe_rejected"
     assert service.get_status()["pre_probe"]["last"]["rejection_reason"] == "loop"
+
+
+def test_shadow_non_loop_pre_probe_skips_candidate_loop_check(tmp_path):
+    loop_calls = []
+    udi = FakeUdi(
+        statuses=[{"/proxy/ts/stream/uuid-1": active_status(10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={
+            10: {"id": 10, "url": "http://provider.example/old.ts"},
+            11: {"id": 11, "url": "http://provider.example/new.ts"},
+        },
+    )
+    service = make_service(tmp_path, udi=udi)
+    service._run_blank_probe = lambda url, config: {
+        "blank_detected": False,
+        "freeze_detected": False,
+        "no_decodable_frames_detected": False,
+    }
+    service.loop_probe = lambda url, config: loop_calls.append(url) or {
+        "loop_probe_ran": True,
+        "loop_detected": True,
+        "loop_duration_secs": 14.0,
+        "loop_frames_processed": 200,
+    }
+    config = normalize_config({
+        **service.get_config(include_secret=True),
+        "loop_detection_enabled": True,
+        "next_stream_pre_probe_enabled": True,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-1",
+        "stream_id": 10,
+        "stream_ref": "stream-10",
+        "real_client_count": 1,
+    }
+
+    alternative, details = service._choose_preprobed_alternative_stream(
+        udi,
+        target,
+        config,
+        10,
+        reason="freeze",
+    )
+
+    assert alternative == 11
+    assert details["result"] == "ok"
+    assert details["rejection_reason"] is None
+    assert details["loop_probe_ran"] is False
+    assert details["loop_detected"] is False
+    assert loop_calls == []
 
 
 def test_shadow_loop_dry_run_records_intended_switch_without_live_change(tmp_path):
@@ -1236,6 +1445,8 @@ def test_continuous_probe_detects_open_blank_after_min_duration(tmp_path, monkey
         "probe_duration_seconds": 60,
         "blank_min_duration_seconds": 2,
         "blank_ratio_threshold": 0.8,
+        "freeze_detection_enabled": False,
+        "no_decodable_frames_detection_enabled": False,
     })
 
     result = service._run_blank_probe_until_viewer_left(
@@ -1252,6 +1463,193 @@ def test_continuous_probe_detects_open_blank_after_min_duration(tmp_path, monkey
     assert processes
     assert result["blank_detected"] is True
     assert result["blank_duration_secs"] < 10
+    assert result["blank_ratio"] < 0.8
+
+
+def test_shadow_probe_flushes_delayed_blackdetect_at_analysis_window(tmp_path, monkeypatch):
+    processes = []
+    commands = []
+
+    class DeferredBlackStderr:
+        def __init__(self):
+            self._released = threading.Event()
+            self._lines = [
+                "[blackdetect @ 000] black_start:0 black_end:4 black_duration:4\n",
+            ]
+            self._index = 0
+
+        def readline(self):
+            self._released.wait(timeout=1.0)
+            if self._index >= len(self._lines):
+                return ""
+            line = self._lines[self._index]
+            self._index += 1
+            return line
+
+        def release(self):
+            self._released.set()
+
+    class FakeProcess:
+        def __init__(self):
+            self.stderr = DeferredBlackStderr()
+            self.returncode = None
+            self.terminated = False
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.terminated = True
+            self.returncode = 0
+            self.stderr.release()
+
+        def kill(self):
+            self.returncode = -9
+            self.stderr.release()
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                self.terminate()
+            return self.returncode
+
+    def fake_popen(command, **kwargs):
+        commands.append(command)
+        process = FakeProcess()
+        processes.append(process)
+        return process
+
+    current_time = {"value": 100.0}
+
+    def fake_monotonic():
+        current_time["value"] += 1.1
+        return current_time["value"]
+
+    monkeypatch.setattr(shadow_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(shadow_module.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(shadow_module.time, "sleep", lambda _seconds: None)
+
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(tmp_path, udi=udi)
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "probe_duration_seconds": 60,
+        "blank_min_duration_seconds": 2,
+        "blank_ratio_threshold": 0.8,
+        "freeze_detection_enabled": False,
+        "no_decodable_frames_detection_enabled": False,
+        "silent_audio_detection_enabled": False,
+    })
+
+    result = service._run_blank_probe_until_viewer_left(
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
+        config,
+        udi,
+        {
+            "channel_uuid": "uuid-1",
+            "channel_id": 1,
+            "stream_id": 10,
+        },
+    )
+
+    assert processes
+    assert processes[0].terminated is True
+    assert "-t" not in commands[0]
+    assert result.get("viewer_left") is not True
+    assert result["blank_detected"] is True
+    assert result["blank_duration_secs"] == 4.0
+    assert result["blank_ratio"] < 0.8
+
+
+def test_shadow_probe_treats_flushed_min_duration_black_segment_as_detection(tmp_path, monkeypatch):
+    processes = []
+
+    class DeferredBlackStderr:
+        def __init__(self):
+            self._released = threading.Event()
+            self._lines = [
+                "[blackdetect @ 000] black_start:0 black_end:2.96 black_duration:2.96\n",
+            ]
+            self._index = 0
+
+        def readline(self):
+            self._released.wait(timeout=1.0)
+            if self._index >= len(self._lines):
+                return ""
+            line = self._lines[self._index]
+            self._index += 1
+            return line
+
+        def release(self):
+            self._released.set()
+
+    class FakeProcess:
+        def __init__(self):
+            self.stderr = DeferredBlackStderr()
+            self.returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.returncode = 0
+            self.stderr.release()
+
+        def kill(self):
+            self.returncode = -9
+            self.stderr.release()
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                self.terminate()
+            return self.returncode
+
+    def fake_popen(command, **kwargs):
+        process = FakeProcess()
+        processes.append(process)
+        return process
+
+    current_time = {"value": 100.0}
+
+    def fake_monotonic():
+        current_time["value"] += 1.1
+        return current_time["value"]
+
+    monkeypatch.setattr(shadow_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(shadow_module.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(shadow_module.time, "sleep", lambda _seconds: None)
+
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(tmp_path, udi=udi)
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "probe_duration_seconds": 60,
+        "blank_min_duration_seconds": 2,
+        "blank_ratio_threshold": 0.8,
+        "freeze_detection_enabled": False,
+        "no_decodable_frames_detection_enabled": False,
+        "silent_audio_detection_enabled": False,
+    })
+
+    result = service._run_blank_probe_until_viewer_left(
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
+        config,
+        udi,
+        {
+            "channel_uuid": "uuid-1",
+            "channel_id": 1,
+            "stream_id": 10,
+        },
+    )
+
+    assert processes
+    assert result["blank_detected"] is True
+    assert result["blank_duration_secs"] == 2.96
     assert result["blank_ratio"] < 0.8
 
 
@@ -3427,6 +3825,68 @@ def test_continuous_freeze_fault_recovery_guard_needs_second_confirmation(tmp_pa
     assert status["recent_events"][1]["type"] == "freeze_pending"
 
 
+def test_continuous_blank_fault_recovery_guard_needs_second_confirmation(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[
+            {
+                "uuid-1": active_status(
+                    stream_id=10,
+                    clients=[
+                        {"user_agent": "VLC"},
+                        {
+                            "user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0",
+                            "client_id": "raw-recovered-watcher",
+                        },
+                    ],
+                )
+            }
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={11: {"id": 11, "url": "http://candidate.local/good"}},
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {
+            "blank_detected": True,
+            "blank_duration_secs": 12.0,
+        },
+        switch_calls=switch_calls,
+    )
+    service._run_blank_probe = lambda url, config: {"blank_detected": False, "freeze_detected": False}
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "watch_mode": "continuous",
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": True,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+    }
+
+    first_result = service._probe_target_once(udi, target, config)
+    second_result = service._probe_target_once(udi, target, config)
+    status = service.get_status()
+
+    assert first_result is True
+    assert second_result is False
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert status["recent_events"][0]["type"] == "switch_success"
+    recovery_guard = status["recent_events"][0]["details"]["recovery_guard"]
+    assert recovery_guard["bypassed"] is True
+    assert recovery_guard["pre_probe_required"] is True
+    assert recovery_guard["confirmations"] == 2
+    assert recovery_guard["required"] == 2
+    assert status["recent_events"][1]["type"] == "blank_pending"
+
+
 def test_continuous_media_fault_recovery_guard_needs_second_confirmation(tmp_path):
     switch_calls = []
     udi = FakeUdi(
@@ -3557,6 +4017,119 @@ def test_continuous_probe_stops_when_watcher_reappears_between_confirmations(tmp
         assert service._blank_counts[service._detection_count_key("uuid-1", "blank")] == 0
 
 
+def test_continuous_probe_continues_with_current_probe_watcher_between_confirmations(tmp_path, monkeypatch):
+    switch_calls = []
+    probe_calls = []
+    monkeypatch.setattr(shadow_module.time, "sleep", lambda _seconds: None)
+    current_probe_watcher = {
+        "user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0",
+        "client_id": "current-probe-watcher",
+        "connected_at": 1000.2,
+    }
+    active_with_current_watcher = active_status(
+        stream_id=10,
+        clients=[
+            {"user_agent": "VLC"},
+            current_probe_watcher,
+        ],
+    )
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_with_current_watcher},
+            {"uuid-1": active_with_current_watcher},
+            {"uuid-1": active_with_current_watcher},
+            {"uuid-1": active_with_current_watcher},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = ShadowBlankMonitorService(
+        config_file=tmp_path / "shadow.json",
+        udi_provider=lambda: udi,
+        switch_stream=lambda *args, **kwargs: switch_calls.append((args, kwargs)) or True,
+        base_url_provider=lambda: "http://dispatcharr.local",
+        stream_checker_provider=lambda: FakeStreamChecker(),
+        clock=lambda: 1000.0,
+    )
+
+    def fake_continuous_probe(url, config, probe_udi, target, *, continuous=True):
+        probe_calls.append((url, target.get("watcher_client_ref")))
+        return {"blank_detected": True, "blank_duration_secs": 3.0}
+
+    service._run_blank_probe_until_viewer_left = fake_continuous_probe
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "watch_mode": "continuous",
+        "confirmation_count": 2,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+        "watcher_client_count": 0,
+    }
+
+    service._probe_target(udi, target, config)
+    status = service.get_status()
+
+    assert len(probe_calls) == 2
+    assert switch_calls == [(("uuid-1",), {"stream_id": 11})]
+    assert status["recent_events"][0]["type"] == "switch_success"
+    assert status["recent_events"][0]["details"]["reason"] == "blank"
+    assert "watcher_recovery_guard" not in [event["type"] for event in status["recent_events"]]
+
+
+def test_continuous_probe_ignores_recent_probe_window_recovery_between_confirmations(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        switch_calls=switch_calls,
+    )
+    service._run_blank_probe_until_viewer_left = lambda url, config, probe_udi, target, *, continuous=True: {
+        "blank_detected": True,
+        "blank_duration_secs": 7.0,
+    }
+    service._uses_default_blank_probe = True
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "watch_mode": "continuous",
+        "confirmation_count": 2,
+        "probe_duration_seconds": 8,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+    }
+
+    first_result = service._probe_target_once(udi, target, config)
+    with service._lock:
+        service._watched["uuid-1"] = {
+            "active_probe_started_at": target["active_probe_started_at"],
+            "watcher_recovered_after_seconds": 1,
+        }
+    second_result = service._probe_target_once(udi, target, config)
+    status = service.get_status()
+
+    assert first_result is True
+    assert second_result is False
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert status["recent_events"][0]["type"] == "switch_success"
+    assert "watcher_recovery_guard" not in [event["type"] for event in status["recent_events"]]
+
+
 def test_continuous_media_fault_continues_when_watcher_reappears_between_confirmations(tmp_path, monkeypatch):
     switch_calls = []
     probe_calls = []
@@ -3654,6 +4227,418 @@ def test_confirmed_blank_rechecks_after_switch_and_skips_attempted_target(tmp_pa
     assert second_status["cooldowns"] == []
     assert second_status["recent_events"][0]["type"] == "switch_success"
     assert second_status["recent_events"][0]["details"]["target_stream_ref"].startswith("stream-")
+
+
+def test_default_switch_requires_active_stream_verification(tmp_path, monkeypatch):
+    switch_calls = []
+    current_time = {"value": 100.0}
+
+    def fake_monotonic():
+        current_time["value"] += 1.0
+        return current_time["value"]
+
+    monkeypatch.setattr(shadow_module.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(shadow_module.time, "sleep", lambda _seconds: None)
+
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+
+    def switch_stream(channel_id, stream_id=None, url=None):
+        switch_calls.append((channel_id, stream_id, url))
+        return True
+
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"blank_detected": True},
+        switch_calls=switch_calls,
+    )
+    service.switch_stream = switch_stream
+    service._uses_default_switch_stream = True
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+    }
+
+    should_continue = service._probe_target_once(udi, target, config)
+    status = service.get_status()
+
+    assert should_continue is False
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert status["recent_events"][0]["type"] == "switch_failed"
+    assert status["recent_events"][0]["details"]["switch_api_success"] is True
+    assert status["recent_events"][0]["details"]["post_switch_verification"] is False
+    assert status["recent_events"][0]["details"]["post_switch_verification_mode"] == "proxy_probe"
+    assert status["recent_events"][0]["details"]["post_switch_status_mismatch"] is True
+    assert status["recent_events"][0]["details"]["observed_stream_ref"].startswith("stream-")
+
+
+def test_default_switch_accepts_proxy_probe_when_status_lacks_stream_id(tmp_path, monkeypatch):
+    switch_calls = []
+    probe_urls = []
+    probe_results = iter([
+        {"blank_detected": True},
+        {"blank_detected": False, "freeze_detected": False},
+    ])
+    current_time = {"value": 100.0}
+
+    def fake_monotonic():
+        current_time["value"] += 1.0
+        return current_time["value"]
+
+    def blank_probe(url, config):
+        probe_urls.append(url)
+        return next(probe_results)
+
+    monkeypatch.setattr(shadow_module.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(shadow_module.time, "sleep", lambda _seconds: None)
+
+    udi = FakeUdi(
+        statuses=[{"uuid-1": {"state": "active", "channel_id": "uuid-1", "clients": [{"user_agent": "VLC"}]}}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+
+    def switch_stream(channel_id, stream_id=None, url=None):
+        switch_calls.append((channel_id, stream_id, url))
+        return True
+
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=blank_probe,
+        switch_calls=switch_calls,
+    )
+    service.switch_stream = switch_stream
+    service._uses_default_switch_stream = True
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+        "viewer_output_format": "fmp4",
+    }
+
+    should_continue = service._probe_target_once(udi, target, config)
+    status = service.get_status()
+    event = status["recent_events"][0]
+
+    assert should_continue is False
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert probe_urls[-1] == "http://dispatcharr.local/proxy/ts/stream/uuid-1?output_format=fmp4"
+    assert event["type"] == "switch_success"
+    assert event["details"]["switch_api_success"] is True
+    assert event["details"]["post_switch_verification"] is True
+    assert event["details"]["post_switch_verification_mode"] == "proxy_probe"
+    assert event["details"]["post_switch_proxy_probe_accepted"] is True
+    assert "observed_stream_ref" not in event["details"]
+    assert status["cooldowns"] == []
+
+
+def test_default_switch_accepts_proxy_probe_when_status_reports_stale_stream(tmp_path, monkeypatch):
+    switch_calls = []
+    probe_urls = []
+    probe_results = iter([
+        {"blank_detected": True},
+        {"blank_detected": False, "freeze_detected": False},
+    ])
+    current_time = {"value": 100.0}
+
+    def fake_monotonic():
+        current_time["value"] += 1.0
+        return current_time["value"]
+
+    def blank_probe(url, config):
+        probe_urls.append(url)
+        return next(probe_results)
+
+    monkeypatch.setattr(shadow_module.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(shadow_module.time, "sleep", lambda _seconds: None)
+
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+
+    def switch_stream(channel_id, stream_id=None, url=None):
+        switch_calls.append((channel_id, stream_id, url))
+        return True
+
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=blank_probe,
+        switch_calls=switch_calls,
+    )
+    service.switch_stream = switch_stream
+    service._uses_default_switch_stream = True
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+        "viewer_output_format": "fmp4",
+    }
+
+    should_continue = service._probe_target_once(udi, target, config)
+    status = service.get_status()
+    event = status["recent_events"][0]
+
+    assert should_continue is False
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert probe_urls == [
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1?output_format=fmp4",
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1?output_format=fmp4",
+    ]
+    assert event["type"] == "switch_success"
+    assert event["details"]["switch_api_success"] is True
+    assert event["details"]["post_switch_verification"] is True
+    assert event["details"]["post_switch_verification_mode"] == "status_stream_id+proxy_probe"
+    assert event["details"]["post_switch_status_mismatch"] is True
+    assert event["details"]["post_switch_proxy_probe_accepted"] is True
+    assert event["details"]["observed_stream_ref"].startswith("stream-")
+    assert event["details"]["expected_stream_ref"].startswith("stream-")
+    assert status["cooldowns"] == []
+
+
+def test_default_switch_rejects_proxy_probe_when_output_still_bad(tmp_path, monkeypatch):
+    switch_calls = []
+    probe_urls = []
+    probe_results = iter([
+        {"blank_detected": True},
+        {"blank_detected": True},
+    ])
+    current_time = {"value": 100.0}
+
+    def fake_monotonic():
+        current_time["value"] += 1.0
+        return current_time["value"]
+
+    def blank_probe(url, config):
+        probe_urls.append(url)
+        return next(probe_results)
+
+    monkeypatch.setattr(shadow_module.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(shadow_module.time, "sleep", lambda _seconds: None)
+
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+
+    def switch_stream(channel_id, stream_id=None, url=None):
+        switch_calls.append((channel_id, stream_id, url))
+        return True
+
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=blank_probe,
+        switch_calls=switch_calls,
+    )
+    service.switch_stream = switch_stream
+    service._uses_default_switch_stream = True
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+        "viewer_output_format": "fmp4",
+    }
+
+    should_continue = service._probe_target_once(udi, target, config)
+    status = service.get_status()
+    event = status["recent_events"][0]
+
+    assert should_continue is False
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert probe_urls == [
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1?output_format=fmp4",
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1?output_format=fmp4",
+    ]
+    assert event["type"] == "switch_failed"
+    assert event["details"]["switch_api_success"] is True
+    assert event["details"]["post_switch_verification"] is False
+    assert event["details"]["post_switch_verification_mode"] == "proxy_probe"
+    assert event["details"]["post_switch_proxy_probe_accepted"] is False
+    assert status["cooldowns"]
+
+
+def test_switch_falls_back_to_channel_uuid_without_numeric_id(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"blank_detected": True},
+        switch_calls=switch_calls,
+    )
+    service._ordered_alternative_streams = lambda *args, **kwargs: [11]
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": False,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": None,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+    }
+
+    should_continue = service._probe_target_once(udi, target, config)
+
+    assert should_continue is False
+    assert switch_calls == [("uuid-1", 11, None)]
+
+
+def test_switch_resolves_missing_numeric_channel_id_by_uuid(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"blank_detected": True},
+        switch_calls=switch_calls,
+    )
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": False,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": None,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+    }
+
+    should_continue = service._probe_target_once(udi, target, config)
+
+    assert should_continue is False
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert target["channel_id"] == 1
+    assert target["channel_ref"].startswith("channel-")
+    assert target["channel_ref"] != "channel-test"
+
+
+def test_preprobed_switch_resolves_missing_numeric_channel_id_by_uuid(tmp_path):
+    switch_calls = []
+    probe_results = iter([
+        {"blank_detected": True},
+        {"blank_detected": False},
+    ])
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={11: {"id": 11, "url": "http://example.test/good.m3u8"}},
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: next(probe_results),
+        switch_calls=switch_calls,
+    )
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": True,
+        "next_stream_pre_probe_duration_seconds": 1,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": None,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+    }
+
+    should_continue = service._probe_target_once(udi, target, config)
+
+    assert should_continue is False
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert target["channel_id"] == 1
+    assert target["channel_ref"].startswith("channel-")
+    assert target["channel_ref"] != "channel-test"
+
+
+def test_switch_prefers_channel_uuid_over_numeric_id(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"blank_detected": True},
+        switch_calls=switch_calls,
+    )
+    service._ordered_alternative_streams = lambda *args, **kwargs: [11]
+    config = normalize_config({
+        "enabled": False,
+        "dry_run": False,
+        "confirmation_count": 1,
+        "next_stream_pre_probe_enabled": False,
+    })
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-test",
+        "stream_id": 10,
+        "stream_ref": "stream-test",
+        "real_client_count": 1,
+    }
+
+    should_continue = service._probe_target_once(udi, target, config)
+
+    assert should_continue is False
+    assert switch_calls == [("uuid-1", 11, None)]
 
 
 def test_successful_proxy_probe_clears_attempted_switch_targets(tmp_path):
@@ -4061,6 +5046,52 @@ def test_continuous_watcher_ref_change_is_recorded_as_recovery(tmp_path):
     assert "raw-new-watcher" not in repr(status)
 
 
+def test_active_probe_watcher_ref_change_does_not_reset_detection(tmp_path):
+    udi = FakeUdi(
+        statuses=[
+            {
+                "uuid-1": active_status(
+                    stream_id=10,
+                    clients=[
+                        {"user_agent": "VLC"},
+                        {
+                            "user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0",
+                            "client_id": "raw-new-watcher",
+                            "connected_at": 1004.0,
+                        },
+                    ],
+                )
+            },
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(tmp_path, udi=udi, clock=lambda: 1005.0)
+    with service._lock:
+        service._active_probes.add("uuid-1")
+        service._watched["uuid-1"] = {
+            "channel_uuid": "uuid-1",
+            "channel_id": 1,
+            "channel_ref": "channel-test",
+            "stream_id": 10,
+            "stream_ref": "stream-test",
+            "real_client_count": 1,
+            "watcher_client_count": 1,
+            "watcher_client_ref": "client-old",
+            "active_probe_started_at": 1000.0,
+        }
+    config = normalize_config({"watch_mode": "continuous"})
+
+    service.discover_active_targets(udi, config)
+    status = service.get_status()
+    watched = status["watched_channels"][0]
+
+    assert watched["watcher_state"] == "watching"
+    assert watched["watcher_client_count"] == 1
+    with service._lock:
+        assert service._watched["uuid-1"]["active_probe_started_at"] == 1000.0
+    assert "watcher_recovered" not in [event["type"] for event in status["recent_events"]]
+
+
 def test_watcher_recovery_cooldown_does_not_block_reconnect_probe(tmp_path):
     now = {"value": 1000.0}
     probe_calls = []
@@ -4305,7 +5336,7 @@ def test_external_stream_change_is_recorded_and_clears_cooldown(tmp_path):
     assert status["cooldowns"] == []
 
 
-def test_continuous_mode_starts_uncovered_target_when_another_has_watcher(tmp_path):
+def test_scoped_continuous_mode_reprobes_orphaned_watcher_and_uncovered_target(tmp_path):
     probe_urls = []
     udi = FakeUdi(
         statuses=[{
@@ -4340,11 +5371,56 @@ def test_continuous_mode_starts_uncovered_target_when_another_has_watcher(tmp_pa
         "max_concurrent_watchers": 2,
     })
 
-    status = service.run_once(force=True)
+    status = service.run_once(
+        force=True,
+        include_channel_uuids=["uuid-1", "uuid-2"],
+    )
 
-    assert probe_urls == ["http://dispatcharr.local/proxy/ts/stream/uuid-2"]
+    assert probe_urls == [
+        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
+        "http://dispatcharr.local/proxy/ts/stream/uuid-2",
+    ]
     assert status["watched_count"] == 2
-    assert status["recent_events"][0]["type"] == "probe_ok"
+    assert "watcher_orphaned" in [event["type"] for event in status["recent_events"]]
+    assert [event["type"] for event in status["recent_events"]].count("probe_ok") == 2
+
+
+def test_orphaned_watcher_does_not_block_confirmed_blank_switch(tmp_path):
+    switch_calls = []
+    udi = FakeUdi(
+        statuses=[{
+            "uuid-1": active_status(
+                stream_id=10,
+                clients=[
+                    {"user_agent": "VLC"},
+                    {"user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0"},
+                ],
+            ),
+        }],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {
+            "blank_detected": True,
+            "blank_ratio": 1.0,
+            "blank_duration_secs": 3.0,
+        },
+        switch_calls=switch_calls,
+    )
+    service.update_config({
+        "enabled": False,
+        "dry_run": False,
+        "watch_mode": "continuous",
+        "confirmation_count": 1,
+    })
+
+    status = service.run_once(force=True, include_channel_uuids=["uuid-1"])
+
+    assert switch_calls == [("uuid-1", 11, None)]
+    assert status["recent_events"][0]["type"] == "switch_success"
+    assert "watcher_orphaned" in [event["type"] for event in status["recent_events"]]
 
 
 def test_continuous_default_probe_does_not_block_new_scans(tmp_path):

--- a/backend/tests/test_sidecar_loop_detector.py
+++ b/backend/tests/test_sidecar_loop_detector.py
@@ -3,7 +3,7 @@ import io
 import time
 import collections
 from PIL import Image
-from apps.stream.sidecar_loop_detector import SidecarLoopDetector
+from apps.stream.sidecar_loop_detector import SidecarHash, SidecarLoopDetector
 
 class MockPipe(io.BytesIO):
     def read(self, size):
@@ -89,6 +89,59 @@ class TestSidecarLoopDetector(unittest.TestCase):
             
         # Should NOT detect a loop (it's a static image)
         duration = detector.detect_loop()
+        self.assertIsNone(duration)
+
+    def test_compression_noisy_sequence_detected_by_stable_hash_consensus(self):
+        pipe = MockPipe()
+        detector = SidecarLoopDetector(pipe)
+        start = time.monotonic()
+
+        def make_hash(value):
+            return SidecarHash(value)
+
+        def signature(seed, noise=0):
+            base_phash = [0x1111222233334444, 0x5555666677778888, 0x9999AAAABBBBCCCC]
+            return {
+                "phash": make_hash(base_phash[seed] ^ noise),
+                "ahash": make_hash([0x3333333333333333, 0x7373733333333333, 0x3333333333333337][seed]),
+                "dhash": make_hash([0xE7E7E7E7E7E7E7E7, 0xE6E7E7E7E7E7E7E7, 0xE7E7E7E7E7E7E7EF][seed]),
+                "whash": make_hash([0x3333333333333333, 0x3333333333333331, 0x3333333333333333][seed]),
+            }
+
+        for offset, seed in enumerate([0, 1, 2]):
+            detector.buffer.append((start + offset, signature(seed)))
+        for index in range(10):
+            detector.buffer.append((start + 3 + index, signature(index % 3, noise=0x00FF00FF00FF00FF)))
+        for offset, seed in enumerate([0, 1, 2], start=15):
+            detector.buffer.append((start + offset, signature(seed, noise=0x0F0F0F0F0F0F0F0F)))
+        detector.last_frame_time = start + 17
+
+        duration = detector.detect_loop(hamming_tolerance=3)
+        self.assertIsNotNone(duration)
+        self.assertGreaterEqual(duration, 10.0)
+
+    def test_average_hash_alone_does_not_mark_noisy_sequence_as_loop(self):
+        pipe = MockPipe()
+        detector = SidecarLoopDetector(pipe)
+        start = time.monotonic()
+
+        def signature(seed, noise=0):
+            return {
+                "phash": SidecarHash([0x1111222233334444, 0x5555666677778888, 0x9999AAAABBBBCCCC][seed] ^ noise),
+                "ahash": SidecarHash(0x3333333333333333),
+                "dhash": SidecarHash([0x1111111111111111, 0x2222222222222222, 0x4444444444444444][seed] ^ noise),
+                "whash": SidecarHash([0x0101010101010101, 0x1010101010101010, 0x8080808080808080][seed] ^ noise),
+            }
+
+        for offset, seed in enumerate([0, 1, 2]):
+            detector.buffer.append((start + offset, signature(seed)))
+        for index in range(10):
+            detector.buffer.append((start + 3 + index, signature(index % 3, noise=0x0000FFFF0000FFFF)))
+        for offset, seed in enumerate([0, 1, 2], start=15):
+            detector.buffer.append((start + offset, signature(seed, noise=0xFFFF0000FFFF0000)))
+        detector.last_frame_time = start + 17
+
+        duration = detector.detect_loop(hamming_tolerance=3)
         self.assertIsNone(duration)
 
 if __name__ == '__main__':

--- a/backend/tests/test_stream_check_utils.py
+++ b/backend/tests/test_stream_check_utils.py
@@ -152,6 +152,63 @@ class TestLoopProbeSampling(unittest.TestCase):
         self.assertEqual(frames_processed, 0)
         self.assertTrue(process.terminated)
 
+    def test_loop_probe_latches_transient_loop_detection(self):
+        raw_frames = [self._ppm_frame(frame_index) for frame_index in range(40)]
+        pipe_bytes = b"".join(raw_frames)
+
+        class FakeProcess:
+            def __init__(self, payload):
+                self.stdout = io.BytesIO(payload)
+                self.stderr = io.BytesIO(b"")
+                self._size = len(payload)
+
+            def wait(self, timeout=None):
+                deadline = real_monotonic() + 5
+                while real_monotonic() < deadline:
+                    try:
+                        if self.stdout.tell() >= self._size:
+                            break
+                    except ValueError:
+                        break
+                    real_sleep(0.001)
+                return 0
+
+            def kill(self):
+                return None
+
+        monotonic_value = {"value": 100.0}
+        detect_calls = {"count": 0}
+
+        def fake_monotonic():
+            monotonic_value["value"] += 1.1
+            return monotonic_value["value"]
+
+        def fake_detect_loop(self, hamming_tolerance=None):
+            detect_calls["count"] += 1
+            return 12.0 if detect_calls["count"] == 10 else None
+
+        with patch.object(
+            stream_check_utils.subprocess,
+            "Popen",
+            return_value=FakeProcess(pipe_bytes),
+        ), patch.object(
+            stream_check_utils.time,
+            "monotonic",
+            side_effect=fake_monotonic,
+        ), patch(
+            "apps.stream.sidecar_loop_detector.SidecarLoopDetector.detect_loop",
+            fake_detect_loop,
+        ):
+            loop_detected, loop_duration, frames_processed = _probe_stream_for_loops(
+                url="http://example.invalid/loop.ts",
+                stream_tag="test-loop-latch",
+                probe_duration=60,
+            )
+
+        self.assertTrue(loop_detected)
+        self.assertEqual(loop_duration, 12.0)
+        self.assertEqual(frames_processed, len(raw_frames))
+
 
 class TestGetStreamInfo(unittest.TestCase):
     """Test extracting stream information with ffprobe."""

--- a/backend/tests/test_udi.py
+++ b/backend/tests/test_udi.py
@@ -606,7 +606,7 @@ class TestUDIManager(unittest.TestCase):
 
         self.manager.fetcher = Mock()
         self.manager.fetcher.refresh_config.return_value = None
-        self.manager.fetcher.fetch_entity_counts.return_value = {}
+        self.manager.fetcher.fetch_all_ids.return_value = {}
         self.manager.fetcher.fetch_channels.return_value = FetchResult()
         self.manager.fetcher.fetch_streams.return_value = FetchResult()
         self.manager.fetcher.fetch_channel_groups.return_value = []
@@ -668,7 +668,7 @@ class TestUDIManager(unittest.TestCase):
         """A real zero-count Dispatcharr response remains valid."""
         self.manager.fetcher = Mock()
         self.manager.fetcher.refresh_config.return_value = None
-        self.manager.fetcher.fetch_entity_counts.return_value = {'channels': 0, 'streams': 0}
+        self.manager.fetcher.fetch_all_ids.return_value = {'channels': set(), 'streams': set()}
         self.manager.fetcher.fetch_channels.return_value = FetchResult(items=[], expected_count=0)
         self.manager.fetcher.fetch_streams.return_value = FetchResult(items=[], expected_count=0)
         self.manager.fetcher.fetch_channel_groups.return_value = []
@@ -704,6 +704,43 @@ class TestUDIManager(unittest.TestCase):
 
         self.assertEqual(count, 1)
         self.assertEqual({channel['id'] for channel in channels}, {1, 42})
+        self.manager.fetcher.fetch_channels_by_ids.assert_called_once_with([42])
+
+    def test_refresh_all_rehydrates_hidden_channels_from_ids_oracle_without_state(self):
+        """Hidden channels remain in UDI after a reinstall when /ids/?all exposes them."""
+        self.manager.fetcher = Mock()
+        self.manager.fetcher.refresh_config.return_value = None
+        self.manager.fetcher.fetch_all_ids.return_value = {
+            'channels': {1, 42},
+            'streams': set(),
+        }
+        self.manager.fetcher.fetch_channels.return_value = FetchResult(
+            items=[{'id': 1, 'name': 'Visible Channel', 'streams': []}],
+            expected_count=1,
+        )
+        self.manager.fetcher.fetch_channels_by_ids.return_value = [
+            {'id': 42, 'name': 'Hidden News', 'hidden_from_output': True, 'streams': []},
+        ]
+        self.manager.fetcher.fetch_streams.return_value = FetchResult(items=[], expected_count=0)
+        self.manager.fetcher.fetch_channel_groups.return_value = []
+        self.manager.fetcher.fetch_logos.return_value = FetchResult(items=[], expected_count=0)
+        self.manager.fetcher.fetch_m3u_accounts.return_value = []
+        self.manager.fetcher.fetch_channel_profiles.return_value = [
+            {'id': 7, 'name': 'News Profile', 'channels': [42]},
+        ]
+
+        with patch('apps.udi.manager.get_dispatcharr_config') as mock_config:
+            mock_config.return_value.is_configured.return_value = True
+            result = self.manager.refresh_all()
+
+        self.assertTrue(result)
+        self.assertEqual({channel['id'] for channel in self.manager.get_channels()}, {1, 42})
+        self.assertEqual(self.manager.get_channel_by_id(42)['name'], 'Hidden News')
+        self.assertEqual(self.manager.get_profile_channels(7)['channels'], [42])
+        entity_counts = self.manager.get_init_progress()['entity_counts']
+        self.assertEqual(entity_counts['channels']['received'], 2)
+        self.assertEqual(entity_counts['channels']['expected'], 2)
+        self.assertEqual(entity_counts['channels']['rehydrated_missing'], 1)
         self.manager.fetcher.fetch_channels_by_ids.assert_called_once_with([42])
 
     def test_delta_refresh_keeps_streamflow_hidden_channel_omitted_by_ids(self):

--- a/frontend/src/lib/shadow-monitor-decision-history.js
+++ b/frontend/src/lib/shadow-monitor-decision-history.js
@@ -274,6 +274,11 @@ export const getShadowEventDetailParts = (event = {}) => {
 
   if (details.switch_source === 'external') {
     parts.push('outside StreamFlow')
+    if (details.switch_actor && details.switch_actor !== 'unknown') {
+      parts.push(`actor ${details.switch_actor}`)
+    } else {
+      parts.push('actor unavailable')
+    }
   }
 
   if (details.origin_stream_ref && details.target_stream_ref) {

--- a/frontend/src/lib/shadow-monitor-decision-history.test.js
+++ b/frontend/src/lib/shadow-monitor-decision-history.test.js
@@ -85,6 +85,23 @@ describe('shadow monitor decision history helpers', () => {
       },
     })).toEqual([
       'outside StreamFlow',
+      'actor unavailable',
+      'stream-old -> stream-new',
+    ])
+  })
+
+  it('summarizes externally observed stream changes with actor when available', () => {
+    expect(getShadowEventDetailParts({
+      type: 'external_stream_change',
+      details: {
+        origin_stream_ref: 'stream-old',
+        target_stream_ref: 'stream-new',
+        switch_source: 'external',
+        switch_actor: 'dispatcharr-admin',
+      },
+    })).toEqual([
+      'outside StreamFlow',
+      'actor dispatcharr-admin',
       'stream-old -> stream-new',
     ])
   })

--- a/frontend/src/pages/Changelog.jsx
+++ b/frontend/src/pages/Changelog.jsx
@@ -14,7 +14,7 @@ import {
   getChangelogVisibilityMetrics,
 } from '@/lib/changelog-run-summary.js'
 import { formatDuration } from '@/lib/time-format.js'
-import { Loader2, CheckCircle2, AlertCircle, Activity, ChevronDown, Download } from 'lucide-react'
+import { Loader2, CheckCircle2, AlertCircle, Activity, ChevronDown, Download, EyeOff } from 'lucide-react'
 
 function formatTimestamp(timestamp) {
   const date = new Date(timestamp)
@@ -269,6 +269,7 @@ function getStepIcon(name) {
     case 'validation': return <AlertCircle className="h-4 w-4" />
     case 'assignment': return <CheckCircle2 className="h-4 w-4" />
     case 'quality check': return <Activity className="h-4 w-4" />
+    case 'channel visibility': return <EyeOff className="h-4 w-4" />
     default: return <Activity className="h-4 w-4" />
   }
 }
@@ -279,6 +280,11 @@ function getStepColor(status, name = '') {
   if (stepName === 'assignment') return 'text-green-500 bg-green-500/5 border-green-500/10'
   if (stepName === 'quality check') return 'text-indigo-500 bg-indigo-500/5 border-indigo-500/10'
   if (stepName === 'validation') return 'text-purple-500 bg-purple-500/5 border-purple-500/10'
+  if (stepName === 'channel visibility') {
+    return status === 'warning'
+      ? 'text-amber-500 bg-amber-500/5 border-amber-500/10'
+      : 'text-green-500 bg-green-500/5 border-green-500/10'
+  }
 
   if (status === 'success') return 'text-green-500 bg-green-500/5 border-green-500/10'
   if (status === 'failed') return 'text-destructive bg-destructive/5 border-destructive/10'
@@ -290,6 +296,7 @@ function hasStepDetails(name, details) {
   return (name === 'Validation' && details.removed_count > 0) ||
     (name === 'Assignment' && details.added_count > 0) ||
     (name === 'Playlist Refresh' && details.accounts && details.accounts.length > 0) ||
+    (name === 'Channel Visibility' && details.changed) ||
     (name === 'Quality Check' && (details.dead_streams_count > 0 || details.revived_streams_count > 0 || details.skipped_streams_count > 0 || details.checked_streams?.length > 0))
 }
 
@@ -367,6 +374,29 @@ function StepContent({ step }) {
                 </li>
               ))}
             </ul>
+          </div>
+        </div>
+      )}
+
+      {name === 'Channel Visibility' && details.changed && (
+        <div className="text-xs space-y-2 mt-1 opacity-90">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              variant="outline"
+              className={details.action === 'hidden'
+                ? 'border-amber-500/60 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+                : 'border-green-500/60 bg-green-500/10 text-green-700 dark:text-green-300'}
+            >
+              {details.action === 'hidden' ? 'Hidden' : 'Restored'}
+            </Badge>
+            <Badge variant="secondary" className="max-w-full truncate text-xs">
+              {formatVisibilityReason(details.reason)}
+            </Badge>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-muted-foreground">
+            <span>{details.details?.good_streams_count ?? 0} good</span>
+            <span>{details.details?.dead_streams_count ?? 0} dead</span>
+            <span>{details.details?.total_streams ?? 0} total</span>
           </div>
         </div>
       )}


### PR DESCRIPTION
﻿## Summary

Fixes Shadow Monitor reliability issues found during V7 live testing for proxied Dispatcharr streams. This keeps the Shadow watcher attached/released correctly for real viewers, handles Dispatcharr's stale proxy status after switches, resolves channel identity when proxy status only exposes UUIDs, and preserves hidden-channel recovery visibility in StreamFlow.

## Why

Live testing showed several failure modes that looked safe in unit tests but broke in real proxy behavior:

- Dispatcharr can switch the proxy output successfully while `/proxy/status` still reports the old `active_stream_id`.
- Some Shadow targets only had channel UUID/current stream identity at decision time, so StreamFlow could falsely hit `no_alternative`/cooldown instead of finding the channel's fallback streams.
- Viewer/watchers must release when the real viewer leaves, otherwise Shadow holds streams open after playback stops.
- Hidden channels must remain visible to StreamFlow so later full runs can match streams again and restore them instead of leaving users stuck with hidden channels.

## What Changed

- Adds stricter Shadow switch verification with a conservative post-switch proxy-output probe when Dispatcharr status is stale.
- Resolves Shadow channel identity from UUID, current stream membership, previous target, and scoped include mappings before selecting alternatives.
- Improves continuous watcher cleanup/recovery so watcher-only clients do not keep a stream alive after the real viewer leaves.
- Improves loop/freeze/silent/garbled analysis timing and loop confirmation resilience for proxied MPEGTS/fMP4 streams.
- Records external stream changes in Decision History when the active stream changes outside StreamFlow.
- Keeps hidden channels recoverable in StreamFlow's UDI/cache path and shows hidden/restored channel names in Changelog summaries.

## Validation

Local regression tests on the final tree:

- `python -m pytest backend/tests/test_shadow_blank_monitor_service.py` -> 118 passed
- `python -m pytest backend/tests/test_shadow_blank_monitor_service.py -k "external_stream_change or watcher_recovery or loop_detection or missing_numeric_channel_id or switch_falls_back_to_channel_uuid_without_numeric_id" -q` -> 13 passed
- `python -m pytest backend/tests/test_udi.py -k "hidden or visibility" -q` -> 3 passed
- `npm.cmd run test:ci -- shadow-monitor-decision-history.test.js` -> 10 passed

CI/image/deploy gates on clean head `1e92fdab2766784ea05c07527a9099c4fc0d5068`:

- PR checks green: Analyze JavaScript, Analyze Python, Backend smoke tests, CodeQL, Frontend build and tests.
- GHCR build `27866667707` green for amd64/arm64 and manifest push.
- Home-Unraid updated through the normal Docker update path to `ghcr.io/bttfw/streamflow:shadow-loop-proxy-hash-fix` with revision label `1e92fdab2766784ea05c07527a9099c4fc0d5068`.
- Post-update `/api/health` healthy and Shadow Monitor running with no active watched channels, no cooldowns, and no last error.

Home-Unraid live gates on the PR image before squash, same final tree/content:

- Artificial MPEGTS black/fault channel switched to good alternate with configured Shadow watcher and real proxy viewer.
- Artificial fMP4 black/fault channel switched to good alternate with configured Shadow watcher and real proxy viewer.
- Real proxy viewer attach/release verified on Fox Weather, Weather Channel, and CNN.
- Garbled audio detection verified for MPEGTS and fMP4 corrupted AAC.
- Silent audio detection verified for MPEGTS and fMP4 moving video with silent AAC.
- Full-screen black detected as blank+freeze; full-screen green/red detected as freeze/static video for MPEGTS and fMP4.
- Loop detection verified for throttled MPEGTS and fMP4 loop fixtures.
- External Dispatcharr stream change recorded as `external_stream_change`.
- Hidden-channel recovery verified with `visibility_filter=all` and StreamFlow-owned hidden-state rehydration.
- Final forced automation run completed: telemetry run `1322`, ~6h42m, `last_error=null`, 218 channels, 3255 streams, 18 revived streams, 2 hidden channels, 8 visibility changes.
- Hidden/restored Changelog names verified: hidden `Yahoo Finance` and `Welt der Wunder HD`; restored `BBC News`, `TalkTV`, `Sky Sport Austria 6 HD`, `i24NEWS`, `CNN International`, and `WeatherNation`.
- Temporary SFV7 Dispatcharr channels/groups/streams were audited after cleanup; final marker audit found zero SFV7/safe-fault/test leftovers.
- Final direct Home-Unraid process audit was clean.

No Dispatcharr code changes. No Teamarr code changes.
