### PR TITLE
Fix Shadow Monitor watcher stability during live probes

### DIFF
--- a/backend/apps/api/viewer_activity_handlers.py
+++ b/backend/apps/api/viewer_activity_handlers.py
@@ -192,28 +192,47 @@ def apply_shadow_monitor_context(
     if not isinstance(status, dict) or not isinstance(shadow_status, dict):
         return status
 
-    programs_by_ref: Dict[str, Dict[str, Any]] = {}
+    targets_by_ref: Dict[str, Dict[str, Any]] = {}
     for target in shadow_status.get("watched_channels") or []:
         if not isinstance(target, dict):
             continue
-        program = target.get("current_program")
         channel_ref = target.get("channel_ref")
-        if isinstance(program, dict) and channel_ref:
-            programs_by_ref[str(channel_ref)] = {
+        if not channel_ref:
+            continue
+        context = {
+            key: target.get(key)
+            for key in {
+                "watcher_state",
+                "watcher_client_ref",
+                "watcher_absent_seconds",
+                "watcher_recovered_after_seconds",
+                "viewer_left_grace_active",
+                "viewer_left_grace_remaining_seconds",
+                "proxy_status_gap",
+                "skip_probe_reason",
+                "persistent_watcher_state",
+            }
+            if target.get(key) is not None
+        }
+        program = target.get("current_program")
+        if isinstance(program, dict):
+            context["current_program"] = {
                 key: value
                 for key, value in program.items()
                 if key in {"title", "state", "start_time", "end_time"}
             }
+        if context:
+            targets_by_ref[str(channel_ref)] = context
 
-    if not programs_by_ref:
+    if not targets_by_ref:
         return status
 
     for channel in status.get("channels") or []:
         if not isinstance(channel, dict):
             continue
-        program = programs_by_ref.get(str(channel.get("channel_ref") or ""))
-        if program:
-            channel["current_program"] = program
+        context = targets_by_ref.get(str(channel.get("channel_ref") or ""))
+        if context:
+            channel.update(context)
     return status
 
 

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -1092,6 +1092,82 @@ class ShadowBlankMonitorService:
         target.update(watcher_details)
         return target
 
+    def _mark_viewer_left_grace(
+        self,
+        target: Dict[str, Any],
+        config: Dict[str, Any],
+        fresh_status: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        if not config.get("_shadow_allow_viewer_left_grace"):
+            return None
+        grace_seconds = int(config.get("viewer_left_grace_seconds") or 0)
+        if grace_seconds <= 0 or not target.get("channel_uuid"):
+            return None
+
+        channel_uuid = str(target.get("channel_uuid"))
+        now = self.clock()
+        with self._lock:
+            previous_absence = dict(self._viewer_absences.get(channel_uuid) or {})
+        if previous_absence:
+            since = float(previous_absence.get("since") or now)
+        else:
+            since = now
+        elapsed = max(0, int(now - since))
+        if elapsed > grace_seconds:
+            return None
+
+        fresh_status = fresh_status or {}
+        watcher_details = self._watcher_client_details(fresh_status, config) if fresh_status else {}
+        watcher_clients = int(
+            watcher_details.get("watcher_client_count")
+            or target.get("watcher_client_count")
+            or 0
+        )
+        stream_id = self._extract_stream_id(fresh_status) or target.get("stream_id")
+        grace_target = dict(target)
+        if stream_id is not None:
+            grace_target["stream_id"] = stream_id
+            grace_target["stream_ref"] = _ref("stream", stream_id)
+        grace_target["real_client_count"] = 0
+        grace_target["watcher_client_count"] = watcher_clients
+        grace_target["viewer_state"] = "left_grace"
+        grace_target["viewer_left_grace_active"] = True
+        grace_target["viewer_absent_since"] = since
+        grace_target["viewer_absent_seconds"] = elapsed
+        grace_target["viewer_left_grace_seconds"] = grace_seconds
+        grace_target["viewer_left_grace_remaining_seconds"] = max(0, grace_seconds - elapsed)
+        grace_target["skip_probe_reason"] = "viewer_left_grace"
+        if watcher_details:
+            grace_target.update(watcher_details)
+
+        with self._lock:
+            self._viewer_absences[channel_uuid] = {
+                "since": since,
+                "last_real_client_count": target.get("real_client_count"),
+            }
+            self._watched[channel_uuid] = dict(grace_target)
+        return grace_target
+
+    def _handle_viewer_left_or_grace(
+        self,
+        channel_uuid: str,
+        target: Dict[str, Any],
+        config: Dict[str, Any],
+        fresh_status: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        if self._mark_viewer_left_grace(target, config, fresh_status):
+            return True
+
+        self._reset_blank_count(channel_uuid)
+        self._clear_switch_attempts(channel_uuid)
+        target.pop("media_recovery_guard_observed", None)
+        event_target = dict(target)
+        event_target["real_client_count"] = 0
+        self._record_event("viewer_left", event_target, {})
+        with self._lock:
+            self._watched.pop(channel_uuid, None)
+        return False
+
     def _probe_targets(
         self,
         udi: Any,
@@ -1158,6 +1234,14 @@ class ShadowBlankMonitorService:
         single_pass: bool = False,
     ) -> None:
         channel_uuid = target["channel_uuid"]
+        config = dict(config)
+        if (
+            not single_pass
+            and config.get("watch_mode") == "continuous"
+            and self._uses_default_blank_probe
+            and bool(str(config.get("watcher_api_key") or "").strip())
+        ):
+            config["_shadow_allow_viewer_left_grace"] = True
         try:
             first_probe = True
             while first_probe or not self._stop_event.is_set():
@@ -1176,13 +1260,7 @@ class ShadowBlankMonitorService:
 
                 fresh_status = self._find_status_for_target(udi.get_proxy_status() or {}, target)
                 if self._real_client_count(fresh_status, config, target) <= 0:
-                    self._reset_blank_count(channel_uuid)
-                    self._clear_switch_attempts(channel_uuid)
-                    event_target = dict(target)
-                    event_target["real_client_count"] = 0
-                    self._record_event("viewer_left", event_target, {})
-                    with self._lock:
-                        self._watched.pop(channel_uuid, None)
+                    self._handle_viewer_left_or_grace(channel_uuid, target, config, fresh_status)
                     break
 
                 target = dict(target)
@@ -1324,14 +1402,7 @@ class ShadowBlankMonitorService:
                 fresh_status = self._find_status_for_target(udi.get_proxy_status() or {}, target)
 
             if result.get("viewer_left") or self._real_client_count(fresh_status, config, target) <= 0:
-                self._reset_blank_count(channel_uuid)
-                self._clear_switch_attempts(channel_uuid)
-                target.pop("media_recovery_guard_observed", None)
-                event_target = dict(target)
-                event_target["real_client_count"] = 0
-                self._record_event("viewer_left", event_target, {})
-                with self._lock:
-                    self._watched.pop(channel_uuid, None)
+                self._handle_viewer_left_or_grace(channel_uuid, target, config, fresh_status)
                 return False
 
             if not detection_reason:
@@ -1348,27 +1419,13 @@ class ShadowBlankMonitorService:
                         "loop_probe_sliced": bool(loop_result.get("loop_probe_sliced")),
                     })
                     if loop_result.get("viewer_left"):
-                        self._reset_blank_count(channel_uuid)
-                        self._clear_switch_attempts(channel_uuid)
-                        target.pop("media_recovery_guard_observed", None)
-                        event_target = dict(target)
-                        event_target["real_client_count"] = 0
-                        self._record_event("viewer_left", event_target, {})
-                        with self._lock:
-                            self._watched.pop(channel_uuid, None)
+                        self._handle_viewer_left_or_grace(channel_uuid, target, config)
                         return False
                     if loop:
                         detection_reason = "loop"
                     fresh_status = self._find_status_for_target(udi.get_proxy_status() or {}, target)
                     if self._real_client_count(fresh_status, config, target) <= 0:
-                        self._reset_blank_count(channel_uuid)
-                        self._clear_switch_attempts(channel_uuid)
-                        target.pop("media_recovery_guard_observed", None)
-                        event_target = dict(target)
-                        event_target["real_client_count"] = 0
-                        self._record_event("viewer_left", event_target, {})
-                        with self._lock:
-                            self._watched.pop(channel_uuid, None)
+                        self._handle_viewer_left_or_grace(channel_uuid, target, config, fresh_status)
                         return False
 
             if not detection_reason:
@@ -1450,9 +1507,7 @@ class ShadowBlankMonitorService:
         channel_uuid = target["channel_uuid"]
         fresh_status = self._find_status_for_target(udi.get_proxy_status() or {}, target)
         if self._real_client_count(fresh_status, config, target) <= 0:
-            self._reset_blank_count(channel_uuid)
-            self._clear_switch_attempts(channel_uuid)
-            self._record_event("viewer_left", target, {})
+            self._handle_viewer_left_or_grace(channel_uuid, target, config, fresh_status)
             return
 
         fresh_stream_id = self._extract_stream_id(fresh_status) or target.get("stream_id")

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -859,6 +859,28 @@ class ShadowBlankMonitorService:
                     next_viewer_absences[channel_uuid] = absence
                     targets.append(grace_target)
                     watched[channel_uuid] = dict(grace_target)
+                elif continuous_mode and previous_target:
+                    grace_since = (
+                        float(previous_absence.get("since"))
+                        if previous_absence and previous_absence.get("since") is not None
+                        else now
+                    )
+                    event_target = dict(previous_target)
+                    if stream_id is not None:
+                        event_target["stream_id"] = stream_id
+                        event_target["stream_ref"] = _ref("stream", stream_id)
+                    event_target["real_client_count"] = 0
+                    event_target["watcher_client_count"] = watcher_clients
+                    event_target.update(watcher_details)
+                    continuity_events.append((
+                        "viewer_left",
+                        event_target,
+                        {
+                            "reason": "viewer_left_grace_expired" if previous_absence else "viewer_left",
+                            "viewer_absent_seconds": max(0, int(now - grace_since)),
+                            "viewer_left_grace_seconds": viewer_left_grace_seconds,
+                        },
+                    ))
                 continue
             numeric_id = self._resolve_channel_id(
                 udi,

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -448,6 +448,7 @@ class ShadowBlankMonitorService:
         self._last_pre_probe: Optional[Dict[str, Any]] = None
         self._active_probes: set[str] = set()
         self._persistent_watchers: Dict[str, Dict[str, Any]] = {}
+        self._last_loop_probe_started_at: Dict[str, float] = {}
         self._last_scan_at: Optional[float] = None
         self._last_error: Optional[str] = None
 
@@ -2928,10 +2929,39 @@ class ShadowBlankMonitorService:
         if not config.get("loop_detection_enabled"):
             return {}
         loop_config = dict(config)
+        channel_uuid = str(target.get("channel_uuid") or "")
         abort_state = {"viewer_left": False}
         loop_slice_seconds: Optional[float] = None
         loop_slice_deadline: Optional[float] = None
         if udi is not None and config.get("watch_mode") == "continuous":
+            pending_loop_confirmation = (
+                bool(channel_uuid)
+                and self._current_detection_count(channel_uuid, "loop") > 0
+            )
+            interval_seconds = float(
+                max(
+                    self._continuous_loop_probe_slice_seconds(config),
+                    float(config.get("loop_probe_duration_seconds") or DEFAULT_CONFIG["loop_probe_duration_seconds"]),
+                )
+            )
+            now = self.clock()
+            last_started = None
+            if not pending_loop_confirmation:
+                with self._lock:
+                    last_started = self._last_loop_probe_started_at.get(channel_uuid)
+            if last_started is not None:
+                elapsed = now - float(last_started)
+                if elapsed < interval_seconds:
+                    return {
+                        "loop_probe_ran": False,
+                        "loop_detected": False,
+                        "loop_probe_skipped": True,
+                        "loop_probe_skip_reason": "loop_probe_interval",
+                        "loop_probe_next_due_seconds": max(0, int(interval_seconds - elapsed)),
+                    }
+            if channel_uuid:
+                with self._lock:
+                    self._last_loop_probe_started_at[channel_uuid] = now
             loop_slice_seconds = self._continuous_loop_probe_slice_seconds(config)
             loop_slice_deadline = time.monotonic() + loop_slice_seconds
 
@@ -3900,7 +3930,18 @@ class ShadowBlankMonitorService:
         if not watcher_clients:
             return details
 
-        index, client = watcher_clients[0]
+        def _watcher_sort_key(item: tuple[int, Any]) -> tuple[int, float, int]:
+            index, client = item
+            connected_at: Any = None
+            if isinstance(client, dict):
+                connected_at = client.get("connected_at") or client.get("started_at")
+            try:
+                parsed = float(connected_at)
+            except (TypeError, ValueError):
+                return (1, float(index), index)
+            return (0, parsed, index)
+
+        index, client = sorted(watcher_clients, key=_watcher_sort_key)[0]
         raw_client_id: Any = None
         connected_at: Any = None
         if isinstance(client, dict):
@@ -4223,7 +4264,10 @@ class ShadowBlankMonitorService:
             f"channel_ref={event['channel_ref']} stream_ref={event['stream_ref']}"
         )
         if event_type == "viewer_left" and target.get("channel_uuid"):
-            self._stop_persistent_watcher(str(target.get("channel_uuid")))
+            channel_uuid = str(target.get("channel_uuid"))
+            self._stop_persistent_watcher(channel_uuid)
+            with self._lock:
+                self._last_loop_probe_started_at.pop(channel_uuid, None)
 
     @staticmethod
     def _default_stream_checker_provider() -> Any:

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -128,6 +128,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "next_stream_pre_probe_duration_seconds": 8,
     "confirmation_count": 2,
     "channel_cooldown_seconds": 300,
+    "viewer_left_grace_seconds": 30,
     "max_switches_per_hour": 3,
     "max_concurrent_watchers": 2,
     "skip_during_quality_check": False,
@@ -224,6 +225,7 @@ INT_BOUNDS = {
     "probe_duration_seconds": (3, 120),
     "confirmation_count": (1, 5),
     "channel_cooldown_seconds": (30, 86400),
+    "viewer_left_grace_seconds": (0, 300),
     "max_switches_per_hour": (1, 20),
     "max_concurrent_watchers": (1, 10),
     "garbled_audio_error_threshold": (1, 20),
@@ -437,6 +439,7 @@ class ShadowBlankMonitorService:
         self._watched: Dict[str, Dict[str, Any]] = {}
         self._last_excluded_active_targets: List[Dict[str, Any]] = []
         self._watcher_absences: Dict[str, Dict[str, Any]] = {}
+        self._viewer_absences: Dict[str, Dict[str, Any]] = {}
         self._blank_counts: Dict[str, int] = defaultdict(int)
         self._detection_misses: Dict[str, int] = defaultdict(int)
         self._cooldowns: Dict[str, float] = {}
@@ -628,6 +631,7 @@ class ShadowBlankMonitorService:
             self._stop_event.set()
             self._watched = {}
             self._watcher_absences = {}
+            self._viewer_absences = {}
             thread = self._thread
             watcher_keys = list(self._persistent_watchers)
         if thread and thread.is_alive():
@@ -796,6 +800,7 @@ class ShadowBlankMonitorService:
         excluded_active_targets: List[Dict[str, Any]] = []
         continuity_events: List[tuple[str, Dict[str, Any], Dict[str, Any]]] = []
         continuous_mode = config.get("watch_mode") == "continuous"
+        viewer_left_grace_seconds = int(config.get("viewer_left_grace_seconds") or 0)
         now = self.clock()
         with self._lock:
             previous_watched = {
@@ -806,8 +811,13 @@ class ShadowBlankMonitorService:
                 channel_uuid: dict(absence)
                 for channel_uuid, absence in self._watcher_absences.items()
             }
+            previous_viewer_absences = {
+                channel_uuid: dict(absence)
+                for channel_uuid, absence in self._viewer_absences.items()
+            }
             active_probe_channels = set(self._active_probes)
         next_absences: Dict[str, Dict[str, Any]] = {}
+        next_viewer_absences: Dict[str, Dict[str, Any]] = {}
 
         for key, raw_status in proxy_status.items():
             if not self._is_status_active(raw_status):
@@ -821,14 +831,35 @@ class ShadowBlankMonitorService:
             if not channel and channel_uuid in by_uuid:
                 channel = by_uuid[channel_uuid]
 
-            real_clients = self._real_client_count(raw_status, config)
-            if real_clients <= 0:
-                continue
             watcher_details = self._watcher_client_details(raw_status, config)
             watcher_clients = int(watcher_details.get("watcher_client_count") or 0)
             viewer_output_format = self._real_viewer_output_format(raw_status, config)
 
             stream_id = self._extract_stream_id(raw_status)
+            real_clients = self._real_client_count(raw_status, config)
+            if real_clients <= 0:
+                previous_target = previous_watched.get(channel_uuid)
+                previous_absence = previous_viewer_absences.get(channel_uuid)
+                grace_target = self._viewer_left_grace_target(
+                    raw_status,
+                    previous_target,
+                    previous_absence,
+                    watcher_details,
+                    now=now,
+                    grace_seconds=viewer_left_grace_seconds,
+                    stream_id=stream_id,
+                    watcher_clients=watcher_clients,
+                    viewer_output_format=viewer_output_format,
+                ) if continuous_mode else None
+                if grace_target:
+                    absence = {
+                        "since": grace_target["viewer_absent_since"],
+                        "last_real_client_count": previous_target.get("real_client_count") if previous_target else None,
+                    }
+                    next_viewer_absences[channel_uuid] = absence
+                    targets.append(grace_target)
+                    watched[channel_uuid] = dict(grace_target)
+                continue
             numeric_id = self._resolve_channel_id(
                 udi,
                 self._extract_channel_id(channel, raw_status),
@@ -990,9 +1021,54 @@ class ShadowBlankMonitorService:
             self._watched = watched
             self._last_excluded_active_targets = excluded_active_targets
             self._watcher_absences = next_absences if continuous_mode else {}
+            self._viewer_absences = next_viewer_absences if continuous_mode else {}
         for event_type, event_target, details in continuity_events:
             self._record_event(event_type, event_target, details)
         return targets
+
+    def _viewer_left_grace_target(
+        self,
+        raw_status: Dict[str, Any],
+        previous_target: Optional[Dict[str, Any]],
+        previous_absence: Optional[Dict[str, Any]],
+        watcher_details: Dict[str, Any],
+        *,
+        now: float,
+        grace_seconds: int,
+        stream_id: Optional[int],
+        watcher_clients: int,
+        viewer_output_format: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        if grace_seconds <= 0 or not previous_target:
+            return None
+        if previous_absence:
+            since = float(previous_absence.get("since") or now)
+        elif int(previous_target.get("real_client_count") or 0) > 0:
+            since = now
+        else:
+            return None
+        elapsed = max(0, int(now - since))
+        if elapsed > grace_seconds:
+            return None
+
+        target = dict(previous_target)
+        if stream_id is not None:
+            target["stream_id"] = stream_id
+            target["stream_ref"] = _ref("stream", stream_id)
+        target["real_client_count"] = 0
+        target["watcher_client_count"] = watcher_clients
+        target["state"] = raw_status.get("state") or target.get("state") or "active"
+        target["viewer_state"] = "left_grace"
+        target["viewer_left_grace_active"] = True
+        target["viewer_absent_since"] = since
+        target["viewer_absent_seconds"] = elapsed
+        target["viewer_left_grace_seconds"] = grace_seconds
+        target["viewer_left_grace_remaining_seconds"] = max(0, grace_seconds - elapsed)
+        target["skip_probe_reason"] = "viewer_left_grace"
+        if viewer_output_format:
+            target["viewer_output_format"] = viewer_output_format
+        target.update(watcher_details)
+        return target
 
     def _probe_targets(
         self,
@@ -1010,6 +1086,8 @@ class ShadowBlankMonitorService:
         )
         for target in targets:
             channel_uuid = target["channel_uuid"]
+            if target.get("viewer_left_grace_active") or int(target.get("real_client_count") or 0) <= 0:
+                continue
             watcher_count = int(target.get("watcher_client_count") or 0)
             blocking_watcher_count = self._blocking_watcher_count(target, watcher_count)
             if blocking_watcher_count > 0:
@@ -2495,7 +2573,11 @@ class ShadowBlankMonitorService:
         targets_by_uuid = {
             str(target.get("channel_uuid")): target
             for target in targets
-            if target.get("channel_uuid") and int(target.get("real_client_count") or 0) > 0
+            if target.get("channel_uuid")
+            and (
+                int(target.get("real_client_count") or 0) > 0
+                or bool(target.get("viewer_left_grace_active"))
+            )
         }
         should_keep_watchers = (
             config.get("watch_mode") == "continuous"
@@ -4317,6 +4399,7 @@ class ShadowBlankMonitorService:
             self._stop_persistent_watcher(channel_uuid)
             with self._lock:
                 self._last_loop_probe_started_at.pop(channel_uuid, None)
+                self._viewer_absences.pop(channel_uuid, None)
 
     @staticmethod
     def _default_stream_checker_provider() -> Any:
@@ -4463,6 +4546,13 @@ class ShadowBlankMonitorService:
             "watcher_absent_seconds",
             "watcher_recovered_after_seconds",
             "last_watcher_client_ref",
+            "viewer_state",
+            "viewer_left_grace_active",
+            "viewer_absent_since",
+            "viewer_absent_seconds",
+            "viewer_left_grace_seconds",
+            "viewer_left_grace_remaining_seconds",
+            "skip_probe_reason",
             "persistent_watcher_state",
             "persistent_watcher_started_at",
             "persistent_watcher_uptime_seconds",

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -1011,7 +1011,8 @@ class ShadowBlankMonitorService:
         for target in targets:
             channel_uuid = target["channel_uuid"]
             watcher_count = int(target.get("watcher_client_count") or 0)
-            if watcher_count > 0:
+            blocking_watcher_count = self._blocking_watcher_count(target, watcher_count)
+            if blocking_watcher_count > 0:
                 with self._lock:
                     probe_is_running = channel_uuid in self._active_probes
                 if probe_is_running or not allow_orphaned_watcher_reprobe:
@@ -1023,6 +1024,7 @@ class ShadowBlankMonitorService:
                     {
                         "reason": "watcher_without_active_probe",
                         "watcher_client_count": watcher_count,
+                        "blocking_watcher_count": blocking_watcher_count,
                         "action": "starting_recovery_probe",
                     },
                 )
@@ -1099,7 +1101,8 @@ class ShadowBlankMonitorService:
                     if watcher_count > 0:
                         self._watcher_absences.pop(channel_uuid, None)
                     self._watched[channel_uuid] = dict(target)
-                if watcher_count > 0:
+                blocking_watcher_count = self._blocking_watcher_count(target, watcher_count)
+                if blocking_watcher_count > 0:
                     if self._watcher_status_has_current_probe_client(target, fresh_status, config):
                         time.sleep(float(config.get("watch_gap_seconds", 1)))
                         continue
@@ -1118,6 +1121,7 @@ class ShadowBlankMonitorService:
                     guard_details = {
                         "reason": "active_watcher_between_confirmations",
                         "watcher_client_count": watcher_count,
+                        "blocking_watcher_count": blocking_watcher_count,
                     }
                     if target.get("watcher_client_ref"):
                         guard_details["watcher_client_ref"] = target.get("watcher_client_ref")
@@ -2420,6 +2424,20 @@ class ShadowBlankMonitorService:
             watched = self._watched.get(channel_uuid)
             if watched is not None:
                 watched.update(snapshot)
+
+    @staticmethod
+    def _blocking_watcher_count(target: Dict[str, Any], watcher_count: int) -> int:
+        """Return watcher clients that should block starting another probe.
+
+        A persistent watcher is intentionally kept open to stabilize Dispatcharr
+        playback visibility. It is not an analysis probe and must not suppress
+        future media checks. Any additional watcher client still blocks broad
+        probing to avoid duplicate proxy probes.
+        """
+        count = max(0, int(watcher_count or 0))
+        if target.get("persistent_watcher_state") == "running" and count > 0:
+            return count - 1
+        return count
 
     def _start_persistent_watcher(
         self,

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -447,6 +447,7 @@ class ShadowBlankMonitorService:
         self._pre_probe_metrics: Dict[str, int] = defaultdict(int)
         self._last_pre_probe: Optional[Dict[str, Any]] = None
         self._active_probes: set[str] = set()
+        self._persistent_watchers: Dict[str, Dict[str, Any]] = {}
         self._last_scan_at: Optional[float] = None
         self._last_error: Optional[str] = None
 
@@ -627,8 +628,11 @@ class ShadowBlankMonitorService:
             self._watched = {}
             self._watcher_absences = {}
             thread = self._thread
+            watcher_keys = list(self._persistent_watchers)
         if thread and thread.is_alive():
             thread.join(timeout=5)
+        for channel_uuid in watcher_keys:
+            self._stop_persistent_watcher(channel_uuid)
         return True
 
     def get_status(self) -> Dict[str, Any]:
@@ -743,6 +747,8 @@ class ShadowBlankMonitorService:
                 include_channel_ids=include_channel_ids,
                 include_channel_uuids=include_channel_uuids,
             )
+            if not force:
+                self._sync_persistent_watchers(targets, config)
             self._probe_targets(
                 udi,
                 targets[: config["max_concurrent_watchers"]],
@@ -2351,6 +2357,172 @@ class ShadowBlankMonitorService:
     ) -> None:
         self._reset_detection_state(channel_uuid)
         self._record_event("watcher_recovery_guard", target, guard_details)
+
+    @staticmethod
+    def _persistent_watcher_command(url: str, config: Dict[str, Any]) -> List[str]:
+        command = [
+            "ffmpeg",
+            "-hide_banner",
+            "-nostdin",
+            "-loglevel",
+            "error",
+            "-user_agent",
+            config.get("watcher_user_agent") or DEFAULT_CONFIG["watcher_user_agent"],
+        ]
+        headers = ShadowBlankMonitorService._watcher_probe_headers(config)
+        if headers:
+            command.extend(["-headers", headers])
+        command.extend([
+            "-i",
+            url,
+            "-map",
+            "0:v:0?",
+            "-map",
+            "0:a:0?",
+            "-c",
+            "copy",
+            "-f",
+            "null",
+            "-",
+        ])
+        return command
+
+    def _persistent_watcher_snapshot(self, channel_uuid: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            session = self._persistent_watchers.get(channel_uuid)
+            if not session:
+                return None
+            process = session.get("process")
+            if process is not None and process.poll() is not None:
+                return None
+            started_at = float(session.get("started_at") or self.clock())
+            return {
+                "persistent_watcher_state": "running",
+                "persistent_watcher_started_at": started_at,
+                "persistent_watcher_uptime_seconds": max(0, int(self.clock() - started_at)),
+                "persistent_watcher_pid": getattr(process, "pid", None),
+            }
+
+    def _apply_persistent_watcher_snapshot(self, channel_uuid: str, target: Dict[str, Any]) -> None:
+        snapshot = self._persistent_watcher_snapshot(channel_uuid)
+        if not snapshot:
+            return
+        target.update(snapshot)
+        with self._lock:
+            watched = self._watched.get(channel_uuid)
+            if watched is not None:
+                watched.update(snapshot)
+
+    def _start_persistent_watcher(
+        self,
+        channel_uuid: str,
+        target: Dict[str, Any],
+        config: Dict[str, Any],
+        url: str,
+    ) -> None:
+        command = self._persistent_watcher_command(url, config)
+        try:
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Shadow persistent watcher failed to start for %s: %s",
+                target.get("channel_ref") or _ref("channel", channel_uuid),
+                exc,
+            )
+            return
+
+        session = {
+            "process": process,
+            "url": url,
+            "stream_id": target.get("stream_id"),
+            "output_format": target.get("viewer_output_format"),
+            "started_at": self.clock(),
+        }
+        with self._lock:
+            self._persistent_watchers[channel_uuid] = session
+        self._apply_persistent_watcher_snapshot(channel_uuid, target)
+
+    def _stop_persistent_watcher(self, channel_uuid: str) -> None:
+        with self._lock:
+            session = self._persistent_watchers.pop(channel_uuid, None)
+        if not session:
+            return
+        process = session.get("process")
+        if process is None or process.poll() is not None:
+            return
+        try:
+            process.terminate()
+            process.wait(timeout=3)
+        except Exception:
+            try:
+                process.kill()
+                process.wait(timeout=3)
+            except Exception:
+                pass
+
+    def _sync_persistent_watchers(self, targets: Iterable[Dict[str, Any]], config: Dict[str, Any]) -> None:
+        targets_by_uuid = {
+            str(target.get("channel_uuid")): target
+            for target in targets
+            if target.get("channel_uuid") and int(target.get("real_client_count") or 0) > 0
+        }
+        should_keep_watchers = (
+            config.get("watch_mode") == "continuous"
+            and self._uses_default_blank_probe
+            and bool(str(config.get("watcher_api_key") or "").strip())
+        )
+        if not should_keep_watchers:
+            targets_by_uuid = {}
+
+        with self._lock:
+            existing_uuids = list(self._persistent_watchers)
+
+        for channel_uuid in existing_uuids:
+            target = targets_by_uuid.get(channel_uuid)
+            if not target:
+                self._stop_persistent_watcher(channel_uuid)
+                continue
+            try:
+                url = self._channel_proxy_url(channel_uuid, target.get("viewer_output_format"))
+            except Exception:
+                self._stop_persistent_watcher(channel_uuid)
+                continue
+            with self._lock:
+                session = self._persistent_watchers.get(channel_uuid)
+            process = session.get("process") if session else None
+            stale = (
+                not session
+                or process is None
+                or process.poll() is not None
+                or session.get("url") != url
+                or str(session.get("stream_id")) != str(target.get("stream_id"))
+            )
+            if stale:
+                self._stop_persistent_watcher(channel_uuid)
+                self._start_persistent_watcher(channel_uuid, target, config, url)
+            else:
+                self._apply_persistent_watcher_snapshot(channel_uuid, target)
+
+        for channel_uuid, target in targets_by_uuid.items():
+            with self._lock:
+                exists = channel_uuid in self._persistent_watchers
+            if exists:
+                continue
+            try:
+                url = self._channel_proxy_url(channel_uuid, target.get("viewer_output_format"))
+            except Exception as exc:
+                logger.warning(
+                    "Shadow persistent watcher could not build proxy URL for %s: %s",
+                    target.get("channel_ref") or _ref("channel", channel_uuid),
+                    exc,
+                )
+                continue
+            self._start_persistent_watcher(channel_uuid, target, config, url)
 
     def _channel_proxy_url(self, channel_uuid: str, output_format: Optional[str] = None) -> str:
         base_url = (self.base_url_provider() or "").rstrip("/")
@@ -3985,6 +4157,8 @@ class ShadowBlankMonitorService:
             "watcher_uptime_seconds",
             "watcher_absent_seconds",
             "watcher_recovered_after_seconds",
+            "persistent_watcher_state",
+            "persistent_watcher_uptime_seconds",
         )
         return {
             key: target.get(key)
@@ -4048,6 +4222,8 @@ class ShadowBlankMonitorService:
             f"Shadow blank monitor event={event_type} "
             f"channel_ref={event['channel_ref']} stream_ref={event['stream_ref']}"
         )
+        if event_type == "viewer_left" and target.get("channel_uuid"):
+            self._stop_persistent_watcher(str(target.get("channel_uuid")))
 
     @staticmethod
     def _default_stream_checker_provider() -> Any:
@@ -4194,6 +4370,10 @@ class ShadowBlankMonitorService:
             "watcher_absent_seconds",
             "watcher_recovered_after_seconds",
             "last_watcher_client_ref",
+            "persistent_watcher_state",
+            "persistent_watcher_started_at",
+            "persistent_watcher_uptime_seconds",
+            "persistent_watcher_pid",
             "state",
             "current_program",
             "channel_name",

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -818,6 +818,7 @@ class ShadowBlankMonitorService:
             active_probe_channels = set(self._active_probes)
         next_absences: Dict[str, Dict[str, Any]] = {}
         next_viewer_absences: Dict[str, Dict[str, Any]] = {}
+        seen_active_channel_uuids = set()
 
         for key, raw_status in proxy_status.items():
             if not self._is_status_active(raw_status):
@@ -830,6 +831,7 @@ class ShadowBlankMonitorService:
                 channel_uuid = str(channel.get("uuid") or key) if channel else channel_uuid
             if not channel and channel_uuid in by_uuid:
                 channel = by_uuid[channel_uuid]
+            seen_active_channel_uuids.add(channel_uuid)
 
             watcher_details = self._watcher_client_details(raw_status, config)
             watcher_clients = int(watcher_details.get("watcher_client_count") or 0)
@@ -1038,6 +1040,60 @@ class ShadowBlankMonitorService:
                     target["watcher_state"] = "waiting"
             targets.append(target)
             watched[channel_uuid] = dict(target)
+
+        if continuous_mode:
+            for channel_uuid, previous_target in previous_watched.items():
+                if channel_uuid in watched or channel_uuid in seen_active_channel_uuids:
+                    continue
+                if limit_to_included:
+                    previous_id = previous_target.get("channel_id")
+                    if previous_id not in included_ids and channel_uuid not in included_uuids:
+                        continue
+                previous_absence = previous_viewer_absences.get(channel_uuid)
+                grace_target = self._viewer_left_grace_target(
+                    {},
+                    previous_target,
+                    previous_absence,
+                    {},
+                    now=now,
+                    grace_seconds=viewer_left_grace_seconds,
+                    stream_id=previous_target.get("stream_id"),
+                    watcher_clients=0,
+                    viewer_output_format=previous_target.get("viewer_output_format"),
+                )
+                if grace_target:
+                    absence = {
+                        "since": grace_target["viewer_absent_since"],
+                        "last_real_client_count": previous_target.get("real_client_count"),
+                    }
+                    grace_target["proxy_status_gap"] = True
+                    grace_target["watcher_state"] = "reconnecting"
+                    grace_target["last_watcher_client_count"] = previous_target.get("watcher_client_count")
+                    next_viewer_absences[channel_uuid] = absence
+                    targets.append(grace_target)
+                    watched[channel_uuid] = dict(grace_target)
+                elif previous_target:
+                    grace_since = (
+                        float(previous_absence.get("since"))
+                        if previous_absence and previous_absence.get("since") is not None
+                        else now
+                    )
+                    event_target = dict(previous_target)
+                    event_target["real_client_count"] = 0
+                    event_target["watcher_client_count"] = 0
+                    event_target["proxy_status_gap"] = True
+                    continuity_events.append((
+                        "viewer_left",
+                        event_target,
+                        {
+                            "reason": (
+                                "proxy_status_gap_grace_expired"
+                                if previous_absence else "proxy_status_gap"
+                            ),
+                            "viewer_absent_seconds": max(0, int(now - grace_since)),
+                            "viewer_left_grace_seconds": viewer_left_grace_seconds,
+                        },
+                    ))
 
         with self._lock:
             self._watched = watched

--- a/backend/apps/stream/shadow_blank_monitor_service.py
+++ b/backend/apps/stream/shadow_blank_monitor_service.py
@@ -1134,20 +1134,25 @@ class ShadowBlankMonitorService:
             target.pop("media_recovery_guard_bypass", None)
             target["active_probe_started_at"] = self.clock()
             proxy_url = self._channel_proxy_url(channel_uuid, target.get("viewer_output_format"))
+            media_probe_url, media_probe_source = self._media_probe_url(udi, target, proxy_url)
+            media_probe_config = dict(config)
+            if media_probe_source == "stream_url":
+                media_probe_config["watcher_api_key"] = ""
+            target["media_probe_source"] = media_probe_source
             use_continuous_blank_probe = (
                 config.get("watch_mode") == "continuous"
                 and self._uses_default_blank_probe
             )
             if use_continuous_blank_probe:
                 result = self._run_blank_probe_until_viewer_left(
-                    proxy_url,
-                    config,
+                    media_probe_url,
+                    media_probe_config,
                     udi,
                     target,
-                    continuous=not bool(config.get("loop_detection_enabled")),
+                    continuous=not bool(media_probe_config.get("loop_detection_enabled")),
                 )
             else:
-                result = self.blank_probe(proxy_url, config)
+                result = self.blank_probe(media_probe_url, media_probe_config)
             blank = bool(result.get("blank_detected"))
             freeze = bool(result.get("freeze_detected"))
             no_decodable_frames = bool(result.get("no_decodable_frames_detected"))
@@ -1199,6 +1204,7 @@ class ShadowBlankMonitorService:
                 "offline_image_detected": offline_image,
                 "offline_image_hash": result.get("offline_image_hash"),
                 "offline_image_distance": result.get("offline_image_distance"),
+                "media_probe_source": media_probe_source,
                 "loop_probe_ran": bool(result.get("loop_probe_ran")),
                 "loop_detected": loop,
                 "loop_duration_secs": result.get("loop_duration_secs"),
@@ -1225,7 +1231,7 @@ class ShadowBlankMonitorService:
                 return False
 
             if not detection_reason:
-                loop_result = self._run_loop_probe_if_enabled(proxy_url, target, config, udi=udi)
+                loop_result = self._run_loop_probe_if_enabled(media_probe_url, target, media_probe_config, udi=udi)
                 if loop_result:
                     result.update(loop_result)
                     loop = bool(loop_result.get("loop_detected"))
@@ -1979,6 +1985,7 @@ class ShadowBlankMonitorService:
         pre_probe_config["probe_duration_seconds"] = int(
             config.get("next_stream_pre_probe_duration_seconds", 8)
         )
+        pre_probe_config["watcher_api_key"] = ""
         if str(reason or "") != "loop":
             pre_probe_config["loop_detection_enabled"] = False
         result = self._run_blank_probe(url, pre_probe_config)
@@ -2534,6 +2541,30 @@ class ShadowBlankMonitorService:
         if canonical_format:
             return f"{url}?output_format={canonical_format}"
         return url
+
+    def _media_probe_url(self, udi: Any, target: Dict[str, Any], fallback_url: str) -> tuple[str, str]:
+        """Prefer the current source URL for short media probes.
+
+        The persistent watcher intentionally uses the Dispatcharr proxy so the
+        channel stays open like a real viewer. The short ffmpeg analysis probes
+        do not need to appear as additional proxy clients; when UDI can resolve
+        the active stream URL, analyze that source directly and keep the proxy
+        URL as a conservative fallback.
+        """
+        stream_id = self._coerce_int(target.get("stream_id"))
+        if stream_id is None or not hasattr(udi, "get_stream_by_id"):
+            return fallback_url, "channel_proxy"
+        try:
+            stream = udi.get_stream_by_id(stream_id)
+        except Exception as exc:
+            logger.debug("Shadow media probe stream lookup failed for %s: %s", target.get("stream_ref"), exc)
+            return fallback_url, "channel_proxy"
+        if not isinstance(stream, dict):
+            return fallback_url, "channel_proxy"
+        source_url = str(stream.get("url") or "").strip()
+        if not source_url:
+            return fallback_url, "channel_proxy"
+        return source_url, "stream_url"
 
     @staticmethod
     def _blank_probe_command(url: str, config: Dict[str, Any], *, continuous: bool = False) -> tuple[List[str], int]:

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -5262,6 +5262,43 @@ def test_background_continuous_mode_keeps_persistent_watcher_between_scans(tmp_p
     assert started[0][1].poll() is None
 
 
+def test_persistent_watcher_does_not_block_followup_media_probe(tmp_path):
+    probe_urls = []
+    watcher_client = {"user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0"}
+    udi = FakeUdi(
+        statuses=[{
+            "uuid-1": active_status(
+                stream_id=10,
+                clients=[{"user_agent": "VLC"}, watcher_client],
+            ),
+        }],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={10: {"id": 10, "url": "http://provider.example/old.ts"}},
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: probe_urls.append(url) or {"blank_detected": False},
+    )
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-1",
+        "stream_id": 10,
+        "stream_ref": "stream-10",
+        "real_client_count": 1,
+        "watcher_client_count": 1,
+        "watcher_state": "watching",
+        "persistent_watcher_state": "running",
+    }
+    config = normalize_config({"watch_mode": "continuous"})
+
+    service._probe_targets(udi, [target], config, single_pass=True)
+
+    assert probe_urls == ["http://provider.example/old.ts"]
+    assert "watcher_orphaned" not in [event["type"] for event in service.get_status()["recent_events"]]
+
+
 def test_persistent_watcher_restarts_on_stream_change(tmp_path, monkeypatch):
     started = []
 

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -120,6 +120,29 @@ class PersistentFakeProbeProcess(FakeProbeProcess):
         return self.returncode
 
 
+class FakePersistentWatcherProcess:
+    pid = 4242
+
+    def __init__(self):
+        self.returncode = None
+        self.terminated = False
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = 0
+
+    def kill(self):
+        self.returncode = -9
+
+    def wait(self, timeout=None):
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+
 def make_service(
     tmp_path,
     *,
@@ -5090,6 +5113,110 @@ def test_active_probe_watcher_ref_change_does_not_reset_detection(tmp_path):
     with service._lock:
         assert service._watched["uuid-1"]["active_probe_started_at"] == 1000.0
     assert "watcher_recovered" not in [event["type"] for event in status["recent_events"]]
+
+
+def test_background_continuous_mode_keeps_persistent_watcher_between_scans(tmp_path, monkeypatch):
+    now = {"value": 1000.0}
+    started = []
+
+    def fake_popen(command, **_kwargs):
+        process = FakePersistentWatcherProcess()
+        started.append((command, process))
+        return process
+
+    monkeypatch.setattr(shadow_module.subprocess, "Popen", fake_popen)
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(tmp_path, udi=udi, clock=lambda: now["value"])
+    service._uses_default_blank_probe = True
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "watcher_api_key": "watcher-key",
+    })
+
+    targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(targets, config)
+    first_status = service.get_status()["watched_channels"][0]
+
+    now["value"] = 1015.0
+    service._sync_persistent_watchers(targets, config)
+    second_status = service.get_status()["watched_channels"][0]
+
+    assert len(started) == 1
+    assert "Authorization: ApiKey watcher-key" in " ".join(started[0][0])
+    assert first_status["persistent_watcher_state"] == "running"
+    assert second_status["persistent_watcher_pid"] == 4242
+    assert second_status["persistent_watcher_uptime_seconds"] == 15
+    assert started[0][1].poll() is None
+
+
+def test_persistent_watcher_restarts_on_stream_change(tmp_path, monkeypatch):
+    started = []
+
+    def fake_popen(command, **_kwargs):
+        process = FakePersistentWatcherProcess()
+        started.append((command, process))
+        return process
+
+    monkeypatch.setattr(shadow_module.subprocess, "Popen", fake_popen)
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+            {"uuid-1": active_status(stream_id=11, clients=[{"user_agent": "VLC"}])},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(tmp_path, udi=udi)
+    service._uses_default_blank_probe = True
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "watcher_api_key": "watcher-key",
+    })
+
+    targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(targets, config)
+    first_process = started[0][1]
+    targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(targets, config)
+
+    assert len(started) == 2
+    assert first_process.terminated is True
+    assert started[1][1].poll() is None
+
+
+def test_viewer_left_stops_persistent_watcher(tmp_path, monkeypatch):
+    started = []
+
+    def fake_popen(command, **_kwargs):
+        process = FakePersistentWatcherProcess()
+        started.append(process)
+        return process
+
+    monkeypatch.setattr(shadow_module.subprocess, "Popen", fake_popen)
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(tmp_path, udi=udi)
+    service._uses_default_blank_probe = True
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "watcher_api_key": "watcher-key",
+    })
+
+    targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(targets, config)
+    service._record_event("viewer_left", targets[0], {})
+
+    assert len(started) == 1
+    assert started[0].terminated is True
+    assert service._persistent_watchers == {}
 
 
 def test_watcher_recovery_cooldown_does_not_block_reconnect_probe(tmp_path):

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -5466,6 +5466,98 @@ def test_viewer_left_grace_expires_and_stops_persistent_watcher(tmp_path, monkey
     assert service.get_status()["recent_events"][0]["details"]["reason"] == "viewer_left_grace_expired"
 
 
+def test_proxy_status_gap_keeps_persistent_watcher_during_viewer_grace(tmp_path, monkeypatch):
+    now = {"value": 1000.0}
+    started = []
+
+    def fake_popen(command, **_kwargs):
+        process = FakePersistentWatcherProcess()
+        started.append(process)
+        return process
+
+    monkeypatch.setattr(shadow_module.subprocess, "Popen", fake_popen)
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+            {},
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(tmp_path, udi=udi, clock=lambda: now["value"])
+    service._uses_default_blank_probe = True
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "watcher_api_key": "watcher-key",
+        "viewer_left_grace_seconds": 30,
+    })
+
+    targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(targets, config)
+
+    now["value"] = 1005.0
+    gap_targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(gap_targets, config)
+
+    now["value"] = 1010.0
+    recovered_targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(recovered_targets, config)
+
+    assert len(started) == 1
+    assert started[0].terminated is False
+    assert gap_targets[0]["viewer_left_grace_active"] is True
+    assert gap_targets[0]["proxy_status_gap"] is True
+    assert gap_targets[0]["watcher_state"] == "reconnecting"
+    assert recovered_targets[0]["real_client_count"] == 1
+    assert "viewer_left" not in [event["type"] for event in service.get_status()["recent_events"]]
+
+
+def test_proxy_status_gap_expires_and_stops_persistent_watcher(tmp_path, monkeypatch):
+    now = {"value": 1000.0}
+    started = []
+
+    def fake_popen(command, **_kwargs):
+        process = FakePersistentWatcherProcess()
+        started.append(process)
+        return process
+
+    monkeypatch.setattr(shadow_module.subprocess, "Popen", fake_popen)
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+            {},
+            {},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(tmp_path, udi=udi, clock=lambda: now["value"])
+    service._uses_default_blank_probe = True
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "watcher_api_key": "watcher-key",
+        "viewer_left_grace_seconds": 30,
+    })
+
+    targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(targets, config)
+
+    now["value"] = 1005.0
+    gap_targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(gap_targets, config)
+
+    now["value"] = 1036.0
+    expired_targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(expired_targets, config)
+
+    assert len(started) == 1
+    assert gap_targets[0]["viewer_left_grace_active"] is True
+    assert expired_targets == []
+    assert started[0].terminated is True
+    assert service._persistent_watchers == {}
+    assert service.get_status()["recent_events"][0]["type"] == "viewer_left"
+    assert service.get_status()["recent_events"][0]["details"]["reason"] == "proxy_status_gap_grace_expired"
+
+
 def test_probe_viewer_left_uses_grace_before_stopping_watcher(tmp_path):
     udi = FakeUdi(
         statuses=[{"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])}],

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -5364,6 +5364,106 @@ def test_viewer_left_stops_persistent_watcher(tmp_path, monkeypatch):
     assert service._persistent_watchers == {}
 
 
+def test_viewer_left_grace_keeps_persistent_watcher_for_brief_client_drop(tmp_path, monkeypatch):
+    now = {"value": 1000.0}
+    started = []
+    probe_urls = []
+    watcher_client = {"user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0"}
+
+    def fake_popen(command, **_kwargs):
+        process = FakePersistentWatcherProcess()
+        started.append(process)
+        return process
+
+    monkeypatch.setattr(shadow_module.subprocess, "Popen", fake_popen)
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+            {"uuid-1": active_status(stream_id=10, clients=[watcher_client])},
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}, watcher_client])},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={10: {"id": 10, "url": "http://provider.example/old.ts"}},
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        clock=lambda: now["value"],
+        blank_probe=lambda url, config: probe_urls.append(url) or {"blank_detected": False},
+    )
+    service._uses_default_blank_probe = True
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "watcher_api_key": "watcher-key",
+        "viewer_left_grace_seconds": 30,
+    })
+
+    targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(targets, config)
+
+    now["value"] = 1005.0
+    grace_targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(grace_targets, config)
+    service._probe_targets(udi, grace_targets, config, single_pass=True)
+
+    now["value"] = 1010.0
+    recovered_targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(recovered_targets, config)
+
+    assert len(started) == 1
+    assert started[0].terminated is False
+    assert grace_targets[0]["viewer_left_grace_active"] is True
+    assert grace_targets[0]["viewer_left_grace_remaining_seconds"] == 30
+    assert recovered_targets[0]["real_client_count"] == 1
+    assert probe_urls == []
+    assert "viewer_left" not in [event["type"] for event in service.get_status()["recent_events"]]
+
+
+def test_viewer_left_grace_expires_and_stops_persistent_watcher(tmp_path, monkeypatch):
+    now = {"value": 1000.0}
+    started = []
+    watcher_client = {"user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0"}
+
+    def fake_popen(command, **_kwargs):
+        process = FakePersistentWatcherProcess()
+        started.append(process)
+        return process
+
+    monkeypatch.setattr(shadow_module.subprocess, "Popen", fake_popen)
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+            {"uuid-1": active_status(stream_id=10, clients=[watcher_client])},
+            {"uuid-1": active_status(stream_id=10, clients=[watcher_client])},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(tmp_path, udi=udi, clock=lambda: now["value"])
+    service._uses_default_blank_probe = True
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "watcher_api_key": "watcher-key",
+        "viewer_left_grace_seconds": 30,
+    })
+
+    targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(targets, config)
+
+    now["value"] = 1005.0
+    grace_targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(grace_targets, config)
+
+    now["value"] = 1036.0
+    expired_targets = service.discover_active_targets(udi, config)
+    service._sync_persistent_watchers(expired_targets, config)
+
+    assert len(started) == 1
+    assert grace_targets[0]["viewer_left_grace_active"] is True
+    assert expired_targets == []
+    assert started[0].terminated is True
+    assert service._persistent_watchers == {}
+
+
 def test_watcher_recovery_cooldown_does_not_block_reconnect_probe(tmp_path):
     now = {"value": 1000.0}
     probe_calls = []

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -5466,6 +5466,45 @@ def test_viewer_left_grace_expires_and_stops_persistent_watcher(tmp_path, monkey
     assert service.get_status()["recent_events"][0]["details"]["reason"] == "viewer_left_grace_expired"
 
 
+def test_probe_viewer_left_uses_grace_before_stopping_watcher(tmp_path):
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={10: {"id": 10, "url": "http://provider.example/old.ts"}},
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: {"viewer_left": True, "blank_detected": False},
+    )
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "watcher_api_key": "watcher-key",
+        "viewer_left_grace_seconds": 30,
+    })
+    config["_shadow_allow_viewer_left_grace"] = True
+    target = {
+        "channel_uuid": "uuid-1",
+        "channel_id": 1,
+        "channel_ref": "channel-1",
+        "stream_id": 10,
+        "stream_ref": "stream-10",
+        "real_client_count": 1,
+        "watcher_client_count": 1,
+        "watcher_state": "watching",
+    }
+    with service._lock:
+        service._watched["uuid-1"] = dict(target)
+
+    should_continue = service._probe_target_once(udi, target, config)
+    status = service.get_status()
+
+    assert should_continue is False
+    assert status["watched_channels"][0]["viewer_left_grace_active"] is True
+    assert status["watched_channels"][0]["real_client_count"] == 0
+    assert "viewer_left" not in [event["type"] for event in status["recent_events"]]
+
+
 def test_watcher_recovery_cooldown_does_not_block_reconnect_probe(tmp_path):
     now = {"value": 1000.0}
     probe_calls = []
@@ -5844,7 +5883,10 @@ def test_continuous_default_probe_does_not_block_new_scans(tmp_path):
                 break
         time.sleep(0.05)
 
-    assert service.get_status()["recent_events"][0]["type"] == "viewer_left"
+    final_status = service.get_status()
+    assert final_status["watched_channels"][0]["viewer_left_grace_active"] is True
+    assert final_status["watched_channels"][0]["real_client_count"] == 0
+    assert final_status["recent_events"] == []
 
 
 def test_quality_checker_guard_is_opt_in(tmp_path):

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -5462,6 +5462,8 @@ def test_viewer_left_grace_expires_and_stops_persistent_watcher(tmp_path, monkey
     assert expired_targets == []
     assert started[0].terminated is True
     assert service._persistent_watchers == {}
+    assert service.get_status()["recent_events"][0]["type"] == "viewer_left"
+    assert service.get_status()["recent_events"][0]["details"]["reason"] == "viewer_left_grace_expired"
 
 
 def test_watcher_recovery_cooldown_does_not_block_reconnect_probe(tmp_path):

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -408,7 +408,7 @@ def test_shadow_loop_detection_switches_after_required_confirmation(tmp_path):
 
     def loop_probe(url, config):
         loop_calls.append((url, config["loop_probe_duration_seconds"]))
-        loop_detected = "/proxy/ts/stream/" in url
+        loop_detected = "/proxy/ts/stream/" in url or url.endswith("/old.ts")
         return {
             "loop_probe_ran": True,
             "loop_detected": loop_detected,
@@ -447,7 +447,7 @@ def test_shadow_loop_detection_switches_after_required_confirmation(tmp_path):
     assert service._probe_target_once(udi, target, config) is False
 
     assert loop_calls == [
-        ("http://dispatcharr.local/proxy/ts/stream/uuid-1", 180),
+        ("http://provider.example/old.ts", 180),
         ("http://provider.example/new.ts", 180),
     ]
     assert switch_calls == [("uuid-1", 11, None)]
@@ -481,7 +481,9 @@ def test_shadow_loop_confirmation_survives_one_probe_ok_miss(tmp_path):
 
     def loop_probe(url, config):
         loop_calls.append(url)
-        loop_detected = next(active_loop_results) if "/proxy/ts/stream/" in url else False
+        loop_detected = next(active_loop_results) if (
+            "/proxy/ts/stream/" in url or url.endswith("/old.ts")
+        ) else False
         return {
             "loop_probe_ran": True,
             "loop_detected": loop_detected,
@@ -533,9 +535,9 @@ def test_shadow_loop_confirmation_survives_one_probe_ok_miss(tmp_path):
     assert service._probe_target_once(udi, target, config) is False
 
     assert loop_calls == [
-        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
-        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
-        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
+        "http://provider.example/old.ts",
+        "http://provider.example/old.ts",
+        "http://provider.example/old.ts",
         "http://provider.example/new.ts",
     ]
     assert switch_calls == [("uuid-1", 11, None)]
@@ -599,7 +601,7 @@ def test_shadow_loop_probe_aborts_when_real_viewer_leaves(tmp_path):
 
     assert service._probe_target_once(udi, target, config) is False
 
-    assert loop_calls == ["http://dispatcharr.local/proxy/ts/stream/uuid-1"]
+    assert loop_calls == ["http://provider.example/old.ts"]
     assert switch_calls == []
     status = service.get_status()
     assert status["recent_events"][0]["type"] == "viewer_left"
@@ -996,9 +998,10 @@ def test_shadow_loop_dry_run_records_intended_switch_without_live_change(tmp_pat
 
     def loop_probe(url, config):
         loop_calls.append(url)
+        loop_detected = "/proxy/ts/stream/" in url or url.endswith("/old.ts")
         return {
             "loop_probe_ran": True,
-            "loop_detected": "/proxy/ts/stream/" in url,
+            "loop_detected": loop_detected,
             "loop_duration_secs": 12.0,
             "loop_frames_processed": 180,
         }
@@ -1026,7 +1029,7 @@ def test_shadow_loop_dry_run_records_intended_switch_without_live_change(tmp_pat
     status = service.run_once(force=True)
 
     assert loop_calls == [
-        "http://dispatcharr.local/proxy/ts/stream/uuid-1",
+        "http://provider.example/old.ts",
         "http://provider.example/new.ts",
     ]
     assert switch_calls == []
@@ -2302,6 +2305,34 @@ def test_dry_run_uses_channel_proxy_and_records_intended_switch(tmp_path):
     assert status["switch_summary"]["last_switch_reason"] == "blank"
 
 
+def test_shadow_media_probe_prefers_current_stream_url_when_available(tmp_path):
+    probe_urls = []
+    probe_keys = []
+
+    udi = FakeUdi(
+        statuses=[{"uuid-1": active_status(stream_id=10)}],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+        streams={10: {"id": 10, "url": "http://provider.local/live/arte.m3u8"}},
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        blank_probe=lambda url, config: (
+            probe_urls.append(url)
+            or probe_keys.append(config.get("watcher_api_key"))
+            or {"blank_detected": False}
+        ),
+    )
+    service.update_config({"enabled": False, "dry_run": False})
+
+    status = service.run_once(force=True)
+
+    assert probe_urls == ["http://provider.local/live/arte.m3u8"]
+    assert probe_keys == [""]
+    assert status["recent_events"][0]["type"] == "probe_ok"
+    assert status["recent_events"][0]["details"]["media_probe_source"] == "stream_url"
+
+
 def test_shadow_probe_mirrors_real_viewer_fmp4_output_format(tmp_path):
     probe_urls = []
 
@@ -2541,7 +2572,7 @@ def test_next_stream_pre_probe_skips_bad_candidate(tmp_path):
     pre_probe_calls = []
 
     def pre_probe(url, config):
-        pre_probe_calls.append((url, config["probe_duration_seconds"]))
+        pre_probe_calls.append((url, config["probe_duration_seconds"], config.get("watcher_api_key")))
         return {"blank_detected": "bad" in url}
 
     service._run_blank_probe = pre_probe
@@ -2556,8 +2587,8 @@ def test_next_stream_pre_probe_skips_bad_candidate(tmp_path):
     status = service.run_once(force=True)
 
     assert pre_probe_calls == [
-        ("http://candidate.local/bad", 5),
-        ("http://candidate.local/good", 5),
+        ("http://candidate.local/bad", 5, ""),
+        ("http://candidate.local/good", 5, ""),
     ]
     assert switch_calls == [("uuid-1", 12, None)]
     assert status["recent_events"][0]["type"] == "switch_success"

--- a/backend/tests/test_shadow_blank_monitor_service.py
+++ b/backend/tests/test_shadow_blank_monitor_service.py
@@ -186,6 +186,83 @@ def active_status(stream_id=10, clients=None):
     }
 
 
+def test_watcher_details_prefers_oldest_visible_watcher(tmp_path):
+    service = make_service(
+        tmp_path,
+        udi=FakeUdi(statuses=[{}], channels=[]),
+    )
+    config = normalize_config({
+        "watcher_user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0",
+    })
+
+    details = service._watcher_client_details(
+        {
+            "clients": [
+                {
+                    "user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0 ffmpeg",
+                    "client_id": "new-probe",
+                    "connected_at": 990.0,
+                },
+                {"user_agent": "VLC", "client_id": "real-viewer", "connected_at": 980.0},
+                {
+                    "user_agent": "StreamFlow-Shadow-Blank-Monitor/1.0 ffmpeg",
+                    "client_id": "persistent-watcher",
+                    "connected_at": 900.0,
+                },
+            ]
+        },
+        config,
+    )
+
+    assert details["watcher_client_count"] == 2
+    assert details["watcher_client_ref"] == shadow_module._ref("client", "persistent-watcher")
+    assert details["watcher_uptime_seconds"] == 100
+
+
+def test_continuous_loop_probe_is_rate_limited_between_slices(tmp_path):
+    now = {"value": 1000.0}
+    loop_calls = []
+
+    def loop_probe(url, config):
+        loop_calls.append((url, now["value"]))
+        return {"loop_probe_ran": True, "loop_detected": False}
+
+    udi = FakeUdi(
+        statuses=[
+            {"uuid-1": active_status(stream_id=10, clients=[{"user_agent": "VLC"}])},
+        ],
+        channels=[{"id": 1, "uuid": "uuid-1", "streams": [10, 11]}],
+    )
+    service = make_service(
+        tmp_path,
+        udi=udi,
+        loop_probe=loop_probe,
+        clock=lambda: now["value"],
+    )
+    config = normalize_config({
+        "watch_mode": "continuous",
+        "loop_detection_enabled": True,
+        "loop_probe_duration_seconds": 120,
+    })
+    target = {"channel_uuid": "uuid-1", "channel_ref": "channel-one"}
+
+    first = service._run_loop_probe_if_enabled("http://example.test/stream", target, config, udi=udi)
+    now["value"] += 30
+    second = service._run_loop_probe_if_enabled("http://example.test/stream", target, config, udi=udi)
+    now["value"] += 91
+    third = service._run_loop_probe_if_enabled("http://example.test/stream", target, config, udi=udi)
+
+    assert first["loop_probe_ran"] is True
+    assert second["loop_probe_ran"] is False
+    assert second["loop_probe_skipped"] is True
+    assert second["loop_probe_skip_reason"] == "loop_probe_interval"
+    assert third["loop_probe_ran"] is True
+    assert loop_calls == [
+        ("http://example.test/stream", 1000.0),
+        ("http://example.test/stream", 1121.0),
+    ]
+
+
 def test_watch_mode_controls_scan_delay():
     defaults = normalize_config({})
     assert defaults["enabled"] is False

--- a/backend/tests/test_viewer_activity_handlers.py
+++ b/backend/tests/test_viewer_activity_handlers.py
@@ -117,3 +117,43 @@ def test_viewer_activity_can_attach_safe_shadow_epg_context():
         "end_time": "2026-06-05T21:00:00+00:00",
     }
     assert "should-not-leak" not in repr(enriched)
+
+
+def test_viewer_activity_can_attach_shadow_watcher_reconnect_context():
+    status = build_viewer_activity_status(
+        proxy_status={
+            "uuid-1": {
+                "state": "active",
+                "channel_id": "uuid-1",
+                "stream_id": 10,
+                "clients": [{"user_agent": "VLC"}],
+            },
+        },
+        channels=[{"id": 1, "uuid": "uuid-1", "name": "Channel One"}],
+        watcher_user_agent="StreamFlow-Shadow-Blank-Monitor/1.0",
+    )
+    channel_ref = status["channels"][0]["channel_ref"]
+
+    enriched = apply_shadow_monitor_context(
+        status,
+        {
+            "watched_channels": [
+                {
+                    "channel_ref": channel_ref,
+                    "watcher_state": "reconnecting",
+                    "watcher_absent_seconds": 4,
+                    "viewer_left_grace_active": True,
+                    "viewer_left_grace_remaining_seconds": 26,
+                    "proxy_status_gap": True,
+                    "private_provider": "should-not-leak",
+                }
+            ]
+        },
+    )
+
+    assert enriched["channels"][0]["watcher_state"] == "reconnecting"
+    assert enriched["channels"][0]["watcher_absent_seconds"] == 4
+    assert enriched["channels"][0]["viewer_left_grace_active"] is True
+    assert enriched["channels"][0]["viewer_left_grace_remaining_seconds"] == 26
+    assert enriched["channels"][0]["proxy_status_gap"] is True
+    assert "should-not-leak" not in repr(enriched)

--- a/frontend/src/lib/viewer-activity-display.js
+++ b/frontend/src/lib/viewer-activity-display.js
@@ -45,6 +45,12 @@ const stateLabels = {
 }
 
 export const getViewerActivityDetailLabel = (channel = {}) => {
+  if (channel.has_real_clients && channel.watcher_state === 'reconnecting') {
+    return 'Shadow watcher reconnecting'
+  }
+  if (channel.has_real_clients && channel.viewer_left_grace_active) {
+    return 'Shadow watcher holding during reconnect'
+  }
   const programLabel = getProgramDisplayLabel(channel.current_program)
   if (programLabel) return programLabel
   if (channel.has_real_clients && Number(channel.watcher_client_count || 0) <= 0) {

--- a/frontend/src/lib/viewer-activity-display.test.js
+++ b/frontend/src/lib/viewer-activity-display.test.js
@@ -43,6 +43,20 @@ describe('viewer activity display helpers', () => {
     })).toBe('Now: Live: MLB')
   })
 
+  it('shows transient shadow watcher reconnects before normal playback context', () => {
+    expect(getViewerActivityDetailLabel({
+      current_program: { title: 'Live: MLB', state: 'current' },
+      has_real_clients: true,
+      watcher_client_count: 0,
+      watcher_state: 'reconnecting',
+    })).toBe('Shadow watcher reconnecting')
+    expect(getViewerActivityDetailLabel({
+      current_program: { title: 'Live: MLB', state: 'current' },
+      has_real_clients: true,
+      viewer_left_grace_active: true,
+    })).toBe('Shadow watcher holding during reconnect')
+  })
+
   it('hides waiting_for_clients behind an operator fallback when no EPG is known', () => {
     expect(getViewerActivityDetailLabel({
       state: 'waiting_for_clients',


### PR DESCRIPTION
## Summary

Fixes Shadow Monitor watcher instability during active live-viewer monitoring. This keeps the Shadow watcher attached through normal media probes and through short Dispatcharr fMP4/proxy-status gaps during provider or stream failover.

## Root Cause

There were two overlapping problems:

- In continuous mode, media probes could create short-lived Dispatcharr proxy clients. With loop detection enabled, those transient clients made the watcher appear to leave and reconnect while a real viewer was still present.
- Dispatcharr can briefly rebuild or omit a channel from `/proxy/ts/status` during fMP4/provider reconnects while the real viewer is still active. Older StreamFlow logic treated that missing channel as immediate viewer-left and stopped the Shadow watcher.

That combination looked like visible watcher flapping even when Shadow had not intentionally switched anything.

## Changes

- Adds a persistent Shadow watcher process per active real-viewer channel in continuous mode.
- Keeps the persistent watcher open while short media-analysis probes run.
- Rate-limits routine continuous loop probes per channel; pending loop confirmations can still run immediately.
- Prefers the oldest visible watcher client when multiple watcher/probe clients are present.
- Keeps previously watched channels in viewer-left grace when Dispatcharr briefly omits the channel from proxy status.
- Records proxy-status gaps and reconnect/holding state in Shadow/Viewer Activity context.
- Stops watchers cleanly on real viewer-left after grace, service stop, disabled config, stream/output-format change, or dead process recovery.

## Validation

- `python -m pytest backend/tests/test_shadow_blank_monitor_service.py backend/tests/test_viewer_activity_handlers.py -q` -> 135 passed
- `npm.cmd run test:ci -- viewer-activity-display.test.js` -> 6 passed
- `npm.cmd run build` -> passed
- GHCR build succeeded: https://github.com/bttfw/streamflow/actions/runs/27884165878
- PR image deployed through the normal Home-Unraid Docker update path: `ghcr.io/bttfw/streamflow:shadow-persistent-watcher`
- Live fMP4 proof on ARTE HD: real viewer plus Shadow watcher stayed at `real=1`, `watcher=1`, `watched_count=1` while Dispatcharr externally changed active stream `649179 -> 654496 -> 617639`.
- Second controlled fMP4 observation on ARTE HD (`2026-06-20 23:39:54-23:44:15 +02:00`): normal fMP4 viewer plus Shadow watcher stayed at `real=1`, `watcher=1`, `state=watching`; Dispatcharr external stream-change count increased `2 -> 4`; Shadow did not disappear and did not perform its own switch (`successful_switches=0`).
- Legacy/MPEGTS observation on ARTE HD (`2026-06-20 23:49:45-23:59:43 +02:00`): normal viewer without `output_format=fmp4` plus Shadow watcher stayed at `real=1`, `watcher=1`, `state=watching`; Dispatcharr external stream-change count increased `4 -> 6`; Shadow did not disappear and did not perform its own switch (`successful_switches=0`).
- Real-user TiviMate proof (`2026-06-21 00:39-00:57 +02:00`): user watched `Welt HD`, then switched to `Das Erste HD`. The old `Welt HD` watcher entered viewer-left grace and cleaned up; the new `Das Erste HD` watcher stayed `real=1`, `watcher=1`, `state=watching` while Dispatcharr externally changed streams `654513 -> 649190 -> 617658`. Shadow performed no own switch (`successful_switches=0`).
- Final real-user viewer-left cleanup: after the TiviMate client stopped, `Das Erste HD` held watcher-only during grace and then cleaned to `total_real_clients=0`, `total_watcher_clients=0`, `active_channel_count=0`; `/api/proxy/status` returned `{}`.
- Post-cleanup audit: no local/Home-Unraid test viewer, observer, `docker exec streamflow ffmpeg`, `docker exec -i streamflow python`, or `update_container streamflow` processes remained.

## Still Draft

Keep this PR Draft until the user/maintainer explicitly allows Ready after reviewing the real-user evidence. The current PR image is deployed and has now passed controlled fMP4, legacy/MPEGTS, and real TiviMate live-viewer observations, including external Dispatcharr stream changes and viewer-left cleanup.