### PR TITLE
Preserve preflight stream assignments

### DIFF
--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -806,6 +806,92 @@ class StreamCheckerService:
         return config
 
     @staticmethod
+    def _coerce_stream_id_list(raw_stream_ids: Any) -> List[int]:
+        """Return stream IDs as ints, accepting Dispatcharr int or object lists."""
+        if not isinstance(raw_stream_ids, (list, tuple)):
+            return []
+
+        coerced: List[int] = []
+        seen = set()
+        for raw_stream_id in raw_stream_ids:
+            if isinstance(raw_stream_id, dict):
+                raw_stream_id = raw_stream_id.get('id')
+            try:
+                stream_id = int(raw_stream_id)
+            except (TypeError, ValueError):
+                continue
+            if stream_id in seen:
+                continue
+            seen.add(stream_id)
+            coerced.append(stream_id)
+        return coerced
+
+    def _get_channel_assignment_stream_ids(
+        self,
+        channel_id: int,
+        channel_data: Optional[Dict[str, Any]],
+        udi: Any,
+        fallback_stream_ids: Optional[List[int]] = None,
+        refresh_from_dispatcharr: bool = False,
+    ) -> List[int]:
+        """Return the best available full Dispatcharr channel assignment list.
+
+        When dead-stream removal is disabled, the checker still rewrites the
+        channel for ordering. A stale UDI stream cache must not make that write
+        shrink the user's existing channel assignment list.
+        """
+        if refresh_from_dispatcharr:
+            try:
+                fetcher = getattr(udi, 'fetcher', None)
+                fetch_channel_by_id = getattr(fetcher, 'fetch_channel_by_id', None)
+                if callable(fetch_channel_by_id):
+                    fresh_channel = fetch_channel_by_id(channel_id)
+                    if isinstance(fresh_channel, dict) and 'streams' in fresh_channel:
+                        try:
+                            update_channel = getattr(udi, 'update_channel', None)
+                            if callable(update_channel):
+                                update_channel(channel_id, fresh_channel)
+                        except Exception as cache_err:
+                            logger.debug(
+                                "Could not refresh cached channel assignment for %s: %s",
+                                channel_id,
+                                cache_err,
+                            )
+                        return self._coerce_stream_id_list(fresh_channel.get('streams'))
+            except Exception as exc:
+                logger.warning(
+                    "Could not fetch fresh channel assignment for %s before write-back: %s",
+                    channel_id,
+                    exc,
+                )
+
+        assignment_ids: List[int] = []
+        if isinstance(channel_data, dict):
+            assignment_ids.extend(self._coerce_stream_id_list(channel_data.get('streams')))
+        assignment_ids.extend(self._coerce_stream_id_list(fallback_stream_ids or []))
+        return self._coerce_stream_id_list(assignment_ids)
+
+    @staticmethod
+    def _build_write_back_valid_stream_ids(
+        udi: Any,
+        assignment_stream_ids: List[int],
+        dead_stream_removal_enabled: bool,
+    ) -> Optional[set]:
+        """Return valid IDs for write-back without losing assigned cache misses."""
+        if dead_stream_removal_enabled:
+            return None
+
+        valid_stream_ids = set()
+        try:
+            get_valid_stream_ids = getattr(udi, 'get_valid_stream_ids', None)
+            if callable(get_valid_stream_ids):
+                valid_stream_ids.update(get_valid_stream_ids() or set())
+        except Exception as exc:
+            logger.warning("Could not read UDI valid stream IDs before write-back: %s", exc)
+        valid_stream_ids.update(assignment_stream_ids or [])
+        return valid_stream_ids
+
+    @staticmethod
     def _get_uncached_channel_stream_ids(
         raw_channel_stream_ids: List[int],
         cached_stream_id_set: set,
@@ -2268,6 +2354,13 @@ class StreamCheckerService:
                     logger.warning(f"Failed to parse last_check timestamp for channel {channel_id}: {e}")
             
             current_stream_ids = [s['id'] for s in streams]
+            assigned_stream_ids = self._get_channel_assignment_stream_ids(
+                channel_id,
+                channel_data,
+                udi,
+                fallback_stream_ids=current_stream_ids,
+                refresh_from_dispatcharr=not dead_stream_removal_enabled,
+            )
             protected_active_stream_ids = self._get_active_viewer_protected_stream_ids(
                 channel_id,
                 streams,
@@ -3012,7 +3105,7 @@ class StreamCheckerService:
             # Without this guard, a stale cache causes those streams to be silently dropped
             # when the checker PATCHes the channel's stream list back to Dispatcharr.
             _uncached_ids = self._get_uncached_channel_stream_ids(
-                channel_data.get('streams', []),
+                assigned_stream_ids,
                 set(reordered_ids),
                 dead_stream_removal_enabled,
                 dead_stream_ids,
@@ -3025,6 +3118,12 @@ class StreamCheckerService:
                     f"{_uncached_ids[:5]}{'...' if len(_uncached_ids) > 5 else ''}"
                 )
                 reordered_ids.extend(_uncached_ids)
+
+            write_back_valid_stream_ids = self._build_write_back_valid_stream_ids(
+                udi,
+                assigned_stream_ids,
+                dead_stream_removal_enabled,
+            )
 
             if not hasattr(update_channel_streams, "mock_calls"):
                 failed_connectivity = self._require_quality_check_connectivity(
@@ -3043,6 +3142,7 @@ class StreamCheckerService:
             update_channel_streams(
                 channel_id,
                 reordered_ids,
+                valid_stream_ids=write_back_valid_stream_ids,
                 allow_dead_streams=(not dead_stream_removal_enabled),
                 protected_stream_ids=protected_active_stream_ids,
             )
@@ -3571,6 +3671,13 @@ class StreamCheckerService:
                     logger.warning(f"Failed to parse last_check timestamp for channel {channel_id}: {e}")
             
             current_stream_ids = [s['id'] for s in streams]
+            assigned_stream_ids = self._get_channel_assignment_stream_ids(
+                channel_id,
+                channel_data,
+                udi,
+                fallback_stream_ids=current_stream_ids,
+                refresh_from_dispatcharr=not dead_stream_removal_enabled,
+            )
             protected_active_stream_ids = self._get_active_viewer_protected_stream_ids(
                 channel_id,
                 streams,
@@ -4138,7 +4245,7 @@ class StreamCheckerService:
             # Without this guard, a stale cache causes those streams to be silently dropped
             # when the checker PATCHes the channel's stream list back to Dispatcharr.
             _uncached_ids = self._get_uncached_channel_stream_ids(
-                channel_data.get('streams', []),
+                assigned_stream_ids,
                 set(reordered_ids),
                 dead_stream_removal_enabled,
                 dead_stream_ids,
@@ -4151,6 +4258,12 @@ class StreamCheckerService:
                     f"{_uncached_ids[:5]}{'...' if len(_uncached_ids) > 5 else ''}"
                 )
                 reordered_ids.extend(_uncached_ids)
+
+            write_back_valid_stream_ids = self._build_write_back_valid_stream_ids(
+                udi,
+                assigned_stream_ids,
+                dead_stream_removal_enabled,
+            )
 
             if not hasattr(update_channel_streams, "mock_calls"):
                 failed_connectivity = self._require_quality_check_connectivity(
@@ -4169,6 +4282,7 @@ class StreamCheckerService:
             update_channel_streams(
                 channel_id,
                 reordered_ids,
+                valid_stream_ids=write_back_valid_stream_ids,
                 allow_dead_streams=(not dead_stream_removal_enabled),
                 protected_stream_ids=protected_active_stream_ids,
             )

--- a/backend/tests/test_preflight_preserves_channel_assignments.py
+++ b/backend/tests/test_preflight_preserves_channel_assignments.py
@@ -1,0 +1,170 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock
+
+os.environ['CONFIG_DIR'] = tempfile.mkdtemp()
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestPreflightPreservesChannelAssignments(unittest.TestCase):
+    def test_fresh_dispatcharr_assignment_is_used_when_removal_disabled(self):
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        fresh_channel = {'id': 906, 'name': 'Event Channel', 'streams': [10, 11, 12, 13, 14, 15, 16]}
+        stale_channel = {'id': 906, 'name': 'Event Channel', 'streams': [10, 11]}
+
+        udi = Mock()
+        udi.fetcher.fetch_channel_by_id.return_value = fresh_channel
+
+        assignment_ids = service._get_channel_assignment_stream_ids(
+            906,
+            stale_channel,
+            udi,
+            fallback_stream_ids=[10, 11],
+            refresh_from_dispatcharr=True,
+        )
+
+        self.assertEqual(assignment_ids, [10, 11, 12, 13, 14, 15, 16])
+        udi.fetcher.fetch_channel_by_id.assert_called_once_with(906)
+        udi.update_channel.assert_called_once_with(906, fresh_channel)
+
+    def test_removal_disabled_write_back_keeps_all_assigned_stream_ids(self):
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        assigned_ids = [10, 11, 12, 13, 14, 15, 16]
+        reordered_ids = [16, 15]
+
+        missing_assigned_ids = StreamCheckerService._get_uncached_channel_stream_ids(
+            assigned_ids,
+            set(reordered_ids),
+            dead_stream_removal_enabled=False,
+            dead_stream_ids={12, 13},
+        )
+        reordered_ids.extend(missing_assigned_ids)
+
+        self.assertEqual(reordered_ids, [16, 15, 10, 11, 12, 13, 14])
+
+    def test_removal_disabled_valid_ids_include_assigned_cache_misses(self):
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        udi = Mock()
+        udi.get_valid_stream_ids.return_value = {10, 11}
+
+        valid_ids = StreamCheckerService._build_write_back_valid_stream_ids(
+            udi,
+            [10, 11, 12, 13, 14, 15, 16],
+            dead_stream_removal_enabled=False,
+        )
+
+        self.assertEqual(valid_ids, {10, 11, 12, 13, 14, 15, 16})
+
+    def test_removal_enabled_keeps_existing_dead_filtering_behavior(self):
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        missing_assigned_ids = StreamCheckerService._get_uncached_channel_stream_ids(
+            [10, 11, 12, 13, 14],
+            {10, 11},
+            dead_stream_removal_enabled=True,
+            dead_stream_ids={12, 13},
+        )
+        valid_ids = StreamCheckerService._build_write_back_valid_stream_ids(
+            Mock(),
+            [10, 11, 12, 13, 14],
+            dead_stream_removal_enabled=True,
+        )
+
+        self.assertEqual(missing_assigned_ids, [14])
+        self.assertIsNone(valid_ids)
+
+    def test_multiple_channels_preserve_assignments_when_removal_disabled(self):
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        udi = Mock()
+        udi.get_valid_stream_ids.return_value = {10, 11, 15, 16, 20, 22}
+
+        cases = [
+            {
+                'channel_id': 906,
+                'assigned': [10, 11, 12, 13, 14, 15, 16],
+                'reordered': [16, 15],
+                'dead': {12, 13},
+                'expected_write_back': [16, 15, 10, 11, 12, 13, 14],
+            },
+            {
+                'channel_id': 907,
+                'assigned': [20, 21, 22, 23],
+                'reordered': [22],
+                'dead': {21},
+                'expected_write_back': [22, 20, 21, 23],
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(channel_id=case['channel_id']):
+                write_back_ids = list(case['reordered'])
+                write_back_ids.extend(
+                    service._get_uncached_channel_stream_ids(
+                        case['assigned'],
+                        set(write_back_ids),
+                        dead_stream_removal_enabled=False,
+                        dead_stream_ids=case['dead'],
+                    )
+                )
+                valid_ids = service._build_write_back_valid_stream_ids(
+                    udi,
+                    case['assigned'],
+                    dead_stream_removal_enabled=False,
+                )
+
+                self.assertEqual(write_back_ids, case['expected_write_back'])
+                self.assertTrue(set(case['assigned']).issubset(valid_ids))
+
+    def test_multiple_channels_still_drop_dead_assignments_when_removal_enabled(self):
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        service = StreamCheckerService.__new__(StreamCheckerService)
+        cases = [
+            {
+                'channel_id': 906,
+                'assigned': [10, 11, 12, 13, 14, 15, 16],
+                'reordered': [16, 15],
+                'dead': {12, 13},
+                'expected_write_back': [16, 15, 10, 11, 14],
+            },
+            {
+                'channel_id': 907,
+                'assigned': [20, 21, 22, 23],
+                'reordered': [22],
+                'dead': {21, 23},
+                'expected_write_back': [22, 20],
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(channel_id=case['channel_id']):
+                write_back_ids = list(case['reordered'])
+                write_back_ids.extend(
+                    service._get_uncached_channel_stream_ids(
+                        case['assigned'],
+                        set(write_back_ids),
+                        dead_stream_removal_enabled=True,
+                        dead_stream_ids=case['dead'],
+                    )
+                )
+                valid_ids = service._build_write_back_valid_stream_ids(
+                    Mock(),
+                    case['assigned'],
+                    dead_stream_removal_enabled=True,
+                )
+
+                self.assertEqual(write_back_ids, case['expected_write_back'])
+                self.assertIsNone(valid_ids)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Preserve existing Dispatcharr channel stream assignments during Preflight / checking-only quality runs when `remove_dead_streams` is disabled.
- Refresh the channel assignment list directly from Dispatcharr before write-back in safe/no-removal mode, so a stale or partial UDI stream cache cannot shrink the channel.
- Pass preserved assignment IDs as valid for the write-back; Dispatcharr's existing Invalid-PK retry still filters IDs that are truly gone.
- Add regression tests for single and multiple channel scenarios, including the inverse gate that `remove_dead_streams=true` still removes known-dead assignments.

## Root Cause
A checking-only run still rewrites the Dispatcharr channel stream order after scoring. The code tried to preserve stream IDs that were assigned to the channel but absent from the UDI stream cache, but those preserved IDs could be filtered out again by `update_channel_streams()` because it validated against the same stale/incomplete UDI valid-ID set. In a partial-cache case this can turn a channel with 7 assigned streams into only the 2 streams StreamFlow currently saw/analyzed, even when dead removal is disabled.

## Validation
- `python -m pytest backend/tests/test_preflight_preserves_channel_assignments.py backend/tests/test_stream_checker_single_channel_profile_flags.py backend/tests/test_dead_stream_removal_switch_comprehensive.py backend/tests/test_dead_stream_removal_filtering.py backend/tests/test_active_viewer_stream_protection.py backend/tests/test_stream_validation.py backend/tests/test_incremental_stream_checking.py -q` -> 55 passed
- `python -m pytest backend/tests/test_udi.py::TestUDIManager::test_refresh_all_rehydrates_hidden_channels_from_ids_oracle_without_state backend/tests/test_preflight_preserves_channel_assignments.py -q` -> 7 passed
- `python -m compileall -q backend/apps/stream/stream_checker_service.py backend/tests/test_preflight_preserves_channel_assignments.py`
- `git diff --check`
- GitHub checks are green: backend smoke, frontend build/tests, Python CodeQL, JavaScript CodeQL, aggregate CodeQL.

## Live Home-Unraid Gate
Deployed through the normal Unraid Docker update path with:
`ghcr.io/bttfw/streamflow:preflight-preserve-stream-assignments`

Current live status after validation:
- StreamFlow container healthy on the PR image.
- Stream Checker idle, queue empty, no active StreamFlow job.

Remove disabled / Preflight-preserve gate with forced profile `2` (`Teamarr Event Preflight`, `remove_dead_streams=false`):
- `BBC News` channel `8092`: `2 -> 2` streams, exact same stream IDs.
- `TalkTV` channel `2154`: `1 -> 1` streams, exact same stream IDs.
- `Heimatkanal` channel `76`: `7 -> 7` streams, exact same stream IDs.

Remove enabled inverse gate with forced profile `3` (`remove_dead_streams=true`, no M3U refresh):
- `Crime + Investigation HD` channel `77`: checked successfully, stream IDs unchanged.
- `Heimatkanal` channel `76`: checked successfully and removed known-dead assignment `473809`, `7 -> 6` streams.

## Notes
A full `python -m pytest backend/tests -q` run reached `1391 passed, 1 skipped` but hit the existing/order-sensitive UDI progress assertion `test_refresh_all_rehydrates_hidden_channels_from_ids_oracle_without_state`; the same UDI test passes when run in isolation with this patch.