### PR TITLE
[codex] Recheck missing bitrates and unstick queued checks

### DIFF
--- a/backend/apps/stream/stream_check_utils.py
+++ b/backend/apps/stream/stream_check_utils.py
@@ -37,8 +37,8 @@ ffmpeg flags used
 
 With a sufficiently long analysis window (>=30 s, recommended 120 s) the
 running bitrate average stabilises into a reliable reading.  If no valid
-stats line is produced the stream is considered unanalyzable — a missing
-bitrate is a meaningful signal that the stream is dead or unresponsive.
+bitrate is produced but video/audio metadata is present, the stream is treated
+as alive but incomplete so callers can recheck it without marking it dead.
 """
 
 import io
@@ -1621,7 +1621,7 @@ def get_stream_info_and_bitrate(
             logger.warning(
                 f"  [!] No bitrate detected — ffmpeg produced no valid stats lines "
                 f"(elapsed={elapsed:.2f}s, expected ~{duration}s). "
-                f"Stream is likely dead or unresponsive."
+                f"Measurement is incomplete and should be rechecked before scoring."
             )
             if exited_early or result.returncode != 0:
                 if result.returncode != 0:
@@ -1801,7 +1801,7 @@ def get_stream_bitrate(
             logger.warning(
                 f"  [!] No bitrate detected — ffmpeg produced no valid stats lines "
                 f"(elapsed={elapsed:.2f}s, expected ~{duration}s). "
-                f"Stream is likely dead or unresponsive."
+                f"Bitrate is unavailable and should not be reused for scoring."
             )
             logger.debug(f"  Searched {len(output.splitlines())} lines of output")
             if exited_early or result.returncode != 0:
@@ -2152,6 +2152,24 @@ def _stamp_analysis_failure_reason(result: Dict[str, Any]) -> None:
         result['quality_reason_context'] = _analysis_failure_context(result)
 
 
+def _missing_bitrate_context(result: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        key: value for key, value in {
+            'bitrate_source': result.get('bitrate_source'),
+            'ffprobe_fallback_ran': result.get('ffprobe_fallback_ran'),
+            'ffprobe_fallback_reason': result.get('ffprobe_fallback_reason'),
+            'ffprobe_fallback_elapsed_time': result.get('ffprobe_fallback_elapsed_time'),
+            'elapsed_seconds': result.get('elapsed_time'),
+            'ffmpeg_duration_seconds': result.get('ffmpeg_duration_seconds', result.get('ffmpeg_duration')),
+            'attempt': result.get('attempt'),
+            'attempts': result.get('attempts'),
+            'max_attempts': result.get('max_attempts'),
+            'stage': result.get('stage') or 'stream analysis',
+        }.items()
+        if value not in (None, '', [], {})
+    }
+
+
 def analyze_stream(
     stream_url: str,
     stream_id: int,
@@ -2262,6 +2280,10 @@ def analyze_stream(
         'quality_reason': 'offline',
         'quality_reason_detail': 'error',
         'quality_reason_context': {},
+        'measurement_incomplete': False,
+        'measurement_incomplete_reason': 'none',
+        'measurement_incomplete_context': {},
+        'bitrate_recheck_required': False,
     }
 
     try:
@@ -2346,11 +2368,20 @@ def analyze_stream(
                     'ffprobe_fallback_ran': bool(result_data.get('ffprobe_fallback_ran')),
                     'ffprobe_fallback_reason': result_data.get('ffprobe_fallback_reason'),
                     'ffprobe_fallback_elapsed_time': result_data.get('ffprobe_fallback_elapsed_time'),
+                    'measurement_incomplete': bool(result_data.get('measurement_incomplete')),
+                    'measurement_incomplete_reason': result_data.get('measurement_incomplete_reason') or 'none',
+                    'measurement_incomplete_context': result_data.get('measurement_incomplete_context') or {},
+                    'bitrate_recheck_required': bool(result_data.get('bitrate_recheck_required')),
                 }
                 if result['status'] == 'OK':
                     result['quality_reason'] = 'none'
                     result['quality_reason_detail'] = 'none'
                     result['quality_reason_context'] = {}
+                    if result.get('bitrate_kbps') is None:
+                        result['measurement_incomplete'] = True
+                        result['measurement_incomplete_reason'] = 'missing_bitrate'
+                        result['measurement_incomplete_context'] = _missing_bitrate_context(result)
+                        result['bitrate_recheck_required'] = True
                 else:
                     _stamp_analysis_failure_reason(result)
 
@@ -2419,7 +2450,14 @@ def analyze_stream(
                     # Give it another attempt rather than accepting the result.
                     elapsed  = result_data.get('elapsed_time', ffmpeg_duration)
                     completed = elapsed >= ffmpeg_duration * EARLY_EXIT_THRESHOLD
-                    if completed:
+                    missing_bitrate = result.get('bitrate_kbps') is None
+                    if completed and missing_bitrate and attempt < total_attempts - 1:
+                        logger.warning(
+                            f"  {stream_audit_ref}: completed probe without bitrate "
+                            f"({elapsed:.1f}s/{ffmpeg_duration}s) - retrying "
+                            f"(attempt {attempt + 2}/{total_attempts})"
+                        )
+                    elif completed:
                         break
                     elif attempt < total_attempts - 1:
                         if logger.isEnabledFor(logging.DEBUG):

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -5446,11 +5446,15 @@ class StreamCheckerService:
             
         queue_status['eta_seconds'] = self._calculate_queue_eta_seconds(queue_status)
         
+        queued_waiting = queue_status.get('queue_size', 0) > 0
+        queue_processing = bool(
+            queue_status.get('in_progress', 0) > 0 or
+            queue_status.get('current_channel') is not None
+        )
         worker_or_queue_active = bool(
             self.checking or
-            queue_status.get('queue_size', 0) > 0 or
-            queue_status.get('in_progress', 0) > 0 or
-            queue_status.get('current_channel') is not None or
+            queue_processing or
+            (self.running and queued_waiting) or
             sync_state.get('active', False)
         )
         progress_stale = self._current_progress_stale_gate(

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -1274,6 +1274,10 @@ class StreamCheckerService:
             "quality_reason": stream_data.get("quality_reason"),
             "quality_reason_detail": stream_data.get("quality_reason_detail"),
             "quality_reason_context": stream_data.get("quality_reason_context"),
+            "measurement_incomplete": bool(stream_data.get("measurement_incomplete")),
+            "measurement_incomplete_reason": stream_data.get("measurement_incomplete_reason") or "none",
+            "measurement_incomplete_context": stream_data.get("measurement_incomplete_context") or {},
+            "bitrate_recheck_required": bool(stream_data.get("bitrate_recheck_required")),
             # PRESERVE_FALSE: emit False (not None) so the None-filter below keeps these
             # fields in the payload even when the probe ran but found no loop.
             # Without this, Dispatcharr's PATCH merge leaves a stale loop_probe_ran: true
@@ -1302,10 +1306,15 @@ class StreamCheckerService:
             "blank_detected",
             "freeze_probe_ran",
             "freeze_detected",
+            "measurement_incomplete",
+            "bitrate_recheck_required",
+        }
+        PRESERVE_NULL = {
+            "ffmpeg_output_bitrate",
         }
         stream_stats_payload = {
             k: v for k, v in stream_stats_payload.items()
-            if v not in [None, "N/A"]
+            if v not in [None, "N/A"] or (v is None and k in PRESERVE_NULL)
         }
         for k in PRESERVE_FALSE:
             if k in stream_stats_payload or stream_data.get(k) is False:
@@ -1392,6 +1401,10 @@ class StreamCheckerService:
             "quality_reason": stream_data.get("quality_reason"),
             "quality_reason_detail": stream_data.get("quality_reason_detail"),
             "quality_reason_context": stream_data.get("quality_reason_context"),
+            "measurement_incomplete": bool(stream_data.get("measurement_incomplete")),
+            "measurement_incomplete_reason": stream_data.get("measurement_incomplete_reason") or "none",
+            "measurement_incomplete_context": stream_data.get("measurement_incomplete_context") or {},
+            "bitrate_recheck_required": bool(stream_data.get("bitrate_recheck_required")),
             # PRESERVE_FALSE: emit False (not None) so the None-filter below keeps these
             # fields in the payload even when the probe ran but found no loop.
             # Without this, Dispatcharr's PATCH merge leaves a stale loop_probe_ran: true
@@ -1420,6 +1433,8 @@ class StreamCheckerService:
             "blank_detected",
             "freeze_probe_ran",
             "freeze_detected",
+            "measurement_incomplete",
+            "bitrate_recheck_required",
         }
         QUALITY_FIELDS = {
             "quality_reason",

--- a/backend/apps/stream/teamarr_preflight_service.py
+++ b/backend/apps/stream/teamarr_preflight_service.py
@@ -1694,9 +1694,9 @@ class TeamarrPreflightService:
         quality_profile_details = self._quality_profile_details(forced_profile_id)
         if config.get("queue_during_active_checks", True) and self._automation_active():
             self._set_stream_checker_event_gate(True, gate_name="teamarr_preflight_automation")
-            return self._queue_check(event, config)
+            return self._queue_check(event, config, autostart_worker=False)
         if self._stream_checker_active():
-            return self._queue_check(event, config)
+            return self._queue_check(event, config, autostart_worker=False)
 
         queue_due_to_capacity = False
         with self._lock:
@@ -1726,7 +1726,7 @@ class TeamarrPreflightService:
                 self._set_stream_checker_event_gate(True)
 
         if queue_due_to_capacity:
-            if self._queue_check(event, config):
+            if self._queue_check(event, config, autostart_worker=True):
                 logger.info(
                     "Teamarr preflight direct capacity full; queued channel_id=%s identity=%s",
                     channel_id,
@@ -1754,7 +1754,13 @@ class TeamarrPreflightService:
         thread.start()
         return True
 
-    def _queue_check(self, event: Dict[str, Any], config: Dict[str, Any]) -> bool:
+    def _queue_check(
+        self,
+        event: Dict[str, Any],
+        config: Dict[str, Any],
+        *,
+        autostart_worker: bool = False,
+    ) -> bool:
         channel_id = event.get("dispatcharr_channel_id")
         if not channel_id:
             return False
@@ -1814,7 +1820,29 @@ class TeamarrPreflightService:
                     **quality_profile_details,
                 },
             )
+            if autostart_worker:
+                self._ensure_stream_checker_worker_running(checker, event)
         return queued
+
+    @staticmethod
+    def _ensure_stream_checker_worker_running(checker: Any, event: Dict[str, Any]) -> None:
+        if bool(getattr(checker, "running", False)):
+            return
+        start = getattr(checker, "start", None)
+        if not callable(start):
+            return
+        try:
+            start()
+            logger.info(
+                "Teamarr preflight queued channel_id=%s and started the stream checker worker",
+                event.get("dispatcharr_channel_id"),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Teamarr preflight queued channel_id=%s but could not start the stream checker worker: %s",
+                event.get("dispatcharr_channel_id"),
+                exc,
+            )
 
     def record_queued_check_result(self, metadata: Dict[str, Any], result: Any) -> None:
         """Record the eventual result of a Teamarr preflight check run through the queue."""

--- a/backend/apps/telemetry/last_quality_stats.py
+++ b/backend/apps/telemetry/last_quality_stats.py
@@ -118,6 +118,7 @@ def _extract_resolution(payload: Dict[str, Any]) -> Tuple[Optional[int], Optiona
 
 def _row_or_payload_stats(row: StreamTelemetry, payload: Dict[str, Any]) -> Dict[str, Any]:
     extracted = extract_stream_stats(payload) if payload else {}
+    stream_stats = payload.get("stream_stats") if isinstance(payload.get("stream_stats"), dict) else {}
     width = row.resolution_width
     height = row.resolution_height
     if width is None or height is None:
@@ -152,6 +153,20 @@ def _row_or_payload_stats(row: StreamTelemetry, payload: Dict[str, Any]) -> Dict
         "audio_codec": audio_codec.lower() if audio_codec else None,
         "bitrate_kbps": bitrate_int,
         "hdr": bool(row.is_hdr or payload.get("is_hdr") or payload.get("hdr_format")),
+        "measurement_incomplete": bool(
+            payload.get("measurement_incomplete")
+            or stream_stats.get("measurement_incomplete")
+            or payload.get("bitrate_recheck_required")
+            or stream_stats.get("bitrate_recheck_required")
+        ),
+        "measurement_incomplete_reason": (
+            _clean_string(payload.get("measurement_incomplete_reason"))
+            or _clean_string(stream_stats.get("measurement_incomplete_reason"))
+        ),
+        "bitrate_recheck_required": bool(
+            payload.get("bitrate_recheck_required")
+            or stream_stats.get("bitrate_recheck_required")
+        ),
     }
 
 
@@ -290,6 +305,16 @@ def get_last_quality_stats(
                 stream_id=stream_id,
                 reason="last_result_not_reusable",
                 status="incomplete_stats",
+                quality_reason=quality_reason,
+                row=row,
+                run=run,
+            )
+
+        if stats["bitrate_kbps"] is None:
+            return _not_reusable(
+                stream_id=stream_id,
+                reason=stats["measurement_incomplete_reason"] or "missing_bitrate",
+                status="incomplete_bitrate",
                 quality_reason=quality_reason,
                 row=row,
                 run=run,

--- a/backend/tests/test_last_quality_stats_api.py
+++ b/backend/tests/test_last_quality_stats_api.py
@@ -184,6 +184,38 @@ def test_last_quality_stats_rejects_zero_resolution():
     assert payload["last_status"] == "0x0"
 
 
+def test_last_quality_stats_missing_bitrate_requires_recheck_without_dead_reason():
+    session = connection.get_session()
+    try:
+        _add_stream(session)
+        run = _add_run(session, timestamp=datetime(2026, 6, 7, 12, 0, tzinfo=timezone.utc))
+        session.add(
+            StreamTelemetry(
+                run_id=run.id,
+                channel_id=1914,
+                provider_id=21,
+                stream_id=683989,
+                bitrate_kbps=None,
+                resolution_width=3840,
+                resolution_height=2160,
+                fps=50.0,
+                codec="hevc",
+                is_dead=False,
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    payload = get_last_quality_stats(683989, session_factory=connection.get_session)
+
+    assert payload["measured"] is False
+    assert payload["recheck_required"] is True
+    assert payload["reason"] == "missing_bitrate"
+    assert payload["last_status"] == "incomplete_bitrate"
+    assert payload["quality_reason"] == "none"
+
+
 def test_last_quality_stats_marks_current_stream_stale():
     session = connection.get_session()
     try:
@@ -195,6 +227,7 @@ def test_last_quality_stats_marks_current_stream_stale():
                 channel_id=1914,
                 provider_id=21,
                 stream_id=683989,
+                bitrate_kbps=12000,
                 resolution_width=3840,
                 resolution_height=2160,
                 fps=50.0,
@@ -224,6 +257,7 @@ def test_last_quality_stats_route_does_not_touch_stream_checker(monkeypatch):
                 channel_id=1914,
                 provider_id=21,
                 stream_id=683989,
+                bitrate_kbps=5000,
                 resolution_width=1920,
                 resolution_height=1080,
                 fps=25.0,

--- a/backend/tests/test_quality_reason_transparency.py
+++ b/backend/tests/test_quality_reason_transparency.py
@@ -69,3 +69,35 @@ def test_quality_reason_fields_are_prepared_for_stream_stats_payload():
         "actual": 742.4,
         "threshold": 1500,
     }
+
+
+def test_missing_bitrate_incomplete_fields_are_prepared_for_stream_stats_payload():
+    service = object.__new__(StreamCheckerService)
+    stream_data = {
+        "stream_id": 42,
+        "resolution": "3840x2160",
+        "fps": 50,
+        "video_codec": "hevc",
+        "audio_codec": "aac",
+        "bitrate_kbps": None,
+        "bitrate_source": "ffprobe_media_fallback_no_bitrate",
+        "quality_reason": "none",
+        "quality_reason_detail": "none",
+        "quality_reason_context": {},
+        "measurement_incomplete": True,
+        "measurement_incomplete_reason": "missing_bitrate",
+        "measurement_incomplete_context": {
+            "bitrate_source": "ffprobe_media_fallback_no_bitrate",
+        },
+        "bitrate_recheck_required": True,
+    }
+
+    payload = service._prepare_stream_stats_for_batch(stream_data)
+
+    assert payload["stream_stats"]["ffmpeg_output_bitrate"] is None
+    assert payload["stream_stats"]["measurement_incomplete"] is True
+    assert payload["stream_stats"]["measurement_incomplete_reason"] == "missing_bitrate"
+    assert payload["stream_stats"]["measurement_incomplete_context"] == {
+        "bitrate_source": "ffprobe_media_fallback_no_bitrate",
+    }
+    assert payload["stream_stats"]["bitrate_recheck_required"] is True

--- a/backend/tests/test_stream_check_utils.py
+++ b/backend/tests/test_stream_check_utils.py
@@ -501,6 +501,102 @@ class TestAnalyzeStream(unittest.TestCase):
         self.assertEqual(result['bitrate_kbps'], 5000.0)
 
     @patch('stream_check_utils.get_stream_info_and_bitrate')
+    @patch('time.sleep')
+    def test_retry_on_completed_probe_missing_bitrate(self, mock_sleep, mock_get_info_and_bitrate):
+        """A full-length OK probe without bitrate should be retried before reuse."""
+        mock_get_info_and_bitrate.side_effect = [
+            {
+                'video_codec': 'hevc',
+                'audio_codec': 'aac',
+                'resolution': '3840x2160',
+                'fps': 50.0,
+                'bitrate_kbps': None,
+                'bitrate_source': 'ffprobe_media_fallback_no_bitrate',
+                'hdr_format': 'HLG',
+                'pixel_format': None,
+                'audio_sample_rate': None,
+                'audio_channels': None,
+                'channel_layout': None,
+                'audio_bitrate': None,
+                'status': 'OK',
+                'elapsed_time': 30.5,
+                'ffprobe_fallback_ran': True,
+                'ffprobe_fallback_reason': 'ffmpeg_timeout',
+            },
+            {
+                'video_codec': 'hevc',
+                'audio_codec': 'aac',
+                'resolution': '3840x2160',
+                'fps': 50.0,
+                'bitrate_kbps': 17870.0,
+                'bitrate_source': 'ffmpeg_progress',
+                'hdr_format': 'HLG',
+                'pixel_format': None,
+                'audio_sample_rate': None,
+                'audio_channels': None,
+                'channel_layout': None,
+                'audio_bitrate': None,
+                'status': 'OK',
+                'elapsed_time': 30.5,
+            },
+        ]
+
+        result = analyze_stream(
+            stream_url='http://test.stream',
+            stream_id=123,
+            stream_name='Test Stream',
+            ffmpeg_duration=30,
+            retries=1,
+            retry_delay=5,
+        )
+
+        self.assertEqual(mock_get_info_and_bitrate.call_count, 2)
+        self.assertEqual(mock_sleep.call_count, 1)
+        self.assertEqual(result['status'], 'OK')
+        self.assertEqual(result['bitrate_kbps'], 17870.0)
+        self.assertFalse(result['measurement_incomplete'])
+        self.assertEqual(result['measurement_incomplete_reason'], 'none')
+        self.assertFalse(result['bitrate_recheck_required'])
+
+    @patch('stream_check_utils.get_stream_info_and_bitrate')
+    def test_missing_bitrate_stays_alive_but_incomplete_after_last_attempt(self, mock_get_info_and_bitrate):
+        """Missing bitrate must not mark a stream dead, but it is not reusable."""
+        mock_get_info_and_bitrate.return_value = {
+            'video_codec': 'hevc',
+            'audio_codec': 'aac',
+            'resolution': '3840x2160',
+            'fps': 50.0,
+            'bitrate_kbps': None,
+            'bitrate_source': 'ffprobe_media_fallback_no_bitrate',
+            'hdr_format': 'HLG',
+            'pixel_format': None,
+            'audio_sample_rate': None,
+            'audio_channels': None,
+            'channel_layout': None,
+            'audio_bitrate': None,
+            'status': 'OK',
+            'elapsed_time': 30.5,
+            'ffprobe_fallback_ran': True,
+            'ffprobe_fallback_reason': 'ffmpeg_timeout',
+        }
+
+        result = analyze_stream(
+            stream_url='http://test.stream',
+            stream_id=123,
+            stream_name='Test Stream',
+            ffmpeg_duration=30,
+            retries=0,
+        )
+
+        self.assertEqual(result['status'], 'OK')
+        self.assertEqual(result['quality_reason'], 'none')
+        self.assertEqual(result['quality_reason_detail'], 'none')
+        self.assertTrue(result['measurement_incomplete'])
+        self.assertEqual(result['measurement_incomplete_reason'], 'missing_bitrate')
+        self.assertTrue(result['bitrate_recheck_required'])
+        self.assertEqual(result['measurement_incomplete_context']['bitrate_source'], 'ffprobe_media_fallback_no_bitrate')
+
+    @patch('stream_check_utils.get_stream_info_and_bitrate')
     def test_timeout_analysis_carries_quality_reason_context(self, mock_get_info_and_bitrate):
         """Timeouts should expose structured context for UI and persisted stats."""
         mock_get_info_and_bitrate.return_value = {

--- a/backend/tests/test_stream_checker_queue_lifecycle.py
+++ b/backend/tests/test_stream_checker_queue_lifecycle.py
@@ -884,6 +884,24 @@ class TestStreamCheckQueueLifecycle(unittest.TestCase):
         self.assertEqual(status['progress']['stale_reason'], 'idle_batch_progress')
         service.progress.clear.assert_not_called()
 
+    def test_get_status_does_not_report_stopped_waiting_queue_as_active_check(self):
+        service = self._service_for_idle_progress_status(None)
+        service.running = False
+        service.check_queue.add_channel(
+            9234,
+            priority=100,
+            stream_count=3,
+            metadata={'source': 'teamarr_preflight'},
+        )
+
+        status = service.get_status()
+
+        self.assertEqual(status['queue']['state'], 'queued')
+        self.assertEqual(status['queue']['queue_size'], 1)
+        self.assertFalse(status['running'])
+        self.assertFalse(status['checking'])
+        self.assertFalse(status['stream_checking_mode'])
+
     def test_get_status_keeps_recent_single_channel_progress_active_when_mode_lags(self):
         service = self._service_for_idle_progress_status({
             'status': 'preparing',

--- a/backend/tests/test_stream_checking_mode.py
+++ b/backend/tests/test_stream_checking_mode.py
@@ -121,17 +121,18 @@ class TestStreamCheckingMode(unittest.TestCase):
         self.assertTrue(status['progress']['is_single_channel_check'])
     
     def test_stream_checking_mode_with_queue(self):
-        """Test that stream_checking_mode is True when queue has channels."""
+        """Test that stream_checking_mode is True when a running worker has queued channels."""
         service = self.make_service()
 
         # Initially stream_checking_mode should be False
         status = service.get_status()
         self.assertFalse(status['stream_checking_mode'])
 
-        # Add a channel to the queue
+        # Add a channel to the queue while the worker is running.
+        service.running = True
         service.check_queue.add_channel(1, priority=10)
 
-        # Now stream_checking_mode should be True (queue_size > 0)
+        # Now stream_checking_mode should be True (queue_size > 0 and worker running)
         status = service.get_status()
         self.assertTrue(status['stream_checking_mode'])
 

--- a/backend/tests/test_teamarr_preflight_service.py
+++ b/backend/tests/test_teamarr_preflight_service.py
@@ -52,9 +52,15 @@ class FakeChecker:
         self.calls = []
         self.queued = []
         self.gates = []
+        self.running = False
+        self.start_calls = 0
 
     def get_status(self):
         return {"stream_checking_mode": False, "queue": {"queue_size": 0, "in_progress": 0}}
+
+    def start(self):
+        self.start_calls += 1
+        self.running = True
 
     def queue_channel(self, *args, **kwargs):
         self.queued.append((args, kwargs))
@@ -90,6 +96,10 @@ class SequencedChecker(FakeChecker):
 
 
 class BusyChecker(FakeChecker):
+    def __init__(self):
+        super().__init__()
+        self.running = True
+
     def get_status(self):
         return {"stream_checking_mode": True, "queue": {"queue_size": 0, "in_progress": 1}}
 
@@ -1171,6 +1181,7 @@ class TeamarrPreflightServiceTest(unittest.TestCase):
         self.assertEqual(checker.queued[0][1]["metadata"]["source"], "teamarr_preflight")
         self.assertEqual(service.get_status()["recent_events"][0]["type"], "preflight_queued")
         self.assertIn(("teamarr_preflight_automation", True), checker.gates)
+        self.assertEqual(checker.start_calls, 0)
 
     def test_automation_queue_gate_clears_when_no_run_active(self):
         checker = FakeChecker()
@@ -1321,6 +1332,8 @@ class TeamarrPreflightServiceTest(unittest.TestCase):
         self.assertEqual(kwargs["metadata"]["source"], "teamarr_preflight")
         recent = service.get_status()["recent_events"]
         self.assertEqual(recent[0]["type"], "preflight_queued")
+        self.assertEqual(checker.start_calls, 1)
+        self.assertTrue(checker.running)
 
     def test_filter_options_use_teamarr_subscription_and_cache_catalogs(self):
         def http_get(url, **kwargs):


### PR DESCRIPTION
## Summary

Treat a successful probe with missing bitrate as an incomplete measurement rather than a completed reusable quality result.

## Why

User feedback showed channels where one 720p stream had a measured bitrate while 2160p/HDR streams showed `N/A`. The previous fix correctly avoided marking missing-bitrate streams dead, but stored telemetry with `bitrate_kbps=null` could still be reused as a complete measurement. That lets scoring/ranking make decisions from incomplete data.

## Changes

- Retry a full-length `OK` probe when bitrate is missing and retry budget remains.
- Mark the final missing-bitrate result as alive but incomplete with `measurement_incomplete=true`, `measurement_incomplete_reason=missing_bitrate`, and `bitrate_recheck_required=true`.
- Keep `quality_reason=none` for missing bitrate so it does not hide/remove/kill streams.
- Persist explicit null `ffmpeg_output_bitrate` plus incomplete/recheck flags so stale bitrate values do not remain in `stream_stats`.
- Make `last-quality-stats` return `recheck_required=true` for latest telemetry with missing bitrate.

## Validation so far

- `python -m pytest backend/tests/test_stream_check_utils.py backend/tests/test_last_quality_stats_api.py backend/tests/test_quality_reason_transparency.py backend/tests/test_stream_stats_utils.py -q`
- Result: 62 passed

## Required before Ready

- Wait for the PR image/GHCR build.
- Deploy through the normal Home-Unraid Docker update path.
- Live-test prior `N/A` bitrate streams and confirm they recheck without being treated as dead.
- Trigger a final Full Check at the end without monitoring it.