### PR TITLE
Fix stream bitrate probing and visual checks

### DIFF
--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -6030,11 +6030,14 @@ class AutomatedStreamManager:
                             int(c_result.get('good_streams_count', 0) or 0),
                             sum(
                                 1 for stream in checked_streams
-                                if stream.get('status') == 'completed'
+                                if stream.get('status') in {'completed', 'incomplete_bitrate'}
                                 and stream.get('blank_detected') is not True
                                 and stream.get('freeze_detected') is not True
                                 and stream.get('dead_reason') not in {'blank', 'freeze', 'low_quality', 'offline', 'unstable'}
-                                and stream.get('quality_reason_detail') in {None, '', 'none'}
+                                and (
+                                    stream.get('status') == 'incomplete_bitrate'
+                                    or stream.get('quality_reason_detail') in {None, '', 'none'}
+                                )
                             ),
                         )
                         ch_blank = max(

--- a/backend/apps/stream/stream_check_utils.py
+++ b/backend/apps/stream/stream_check_utils.py
@@ -44,6 +44,7 @@ as alive but incomplete so callers can recheck it without marking it dead.
 import io
 import json
 import logging
+import math
 import os
 import re
 import shlex
@@ -102,6 +103,28 @@ MAX_DEBUG_LINES_TO_LOG = 10  # Maximum number of debug lines to log from ffmpeg 
 # has flowed.  Values at or below this threshold are startup artifacts and
 # are ignored so they cannot be mistaken for a real (very low) bitrate.
 MIN_VALID_PROGRESS_BITRATE = 10.0  # kbps
+
+# Blank/freeze decoding can be expensive on UHD/HEVC streams. Keep the regular
+# bitrate probe cheap and cap concurrent visual probes so provider/profile slots
+# are not exhausted by filter work.
+try:
+    VISUAL_PROBE_MAX_CONCURRENCY = max(
+        1,
+        int(os.getenv('STREAMFLOW_VISUAL_PROBE_MAX_CONCURRENCY', '2') or '2'),
+    )
+except (TypeError, ValueError):
+    VISUAL_PROBE_MAX_CONCURRENCY = 2
+VISUAL_PROBE_DEFAULT_BLANK_SECONDS = 8
+VISUAL_PROBE_DEFAULT_FREEZE_SECONDS = 10
+_VISUAL_PROBE_SEMAPHORE = threading.BoundedSemaphore(VISUAL_PROBE_MAX_CONCURRENCY)
+
+try:
+    STREAM_ANALYSIS_COMPLETION_HEADROOM_SECONDS = max(
+        0,
+        int(os.getenv('STREAMFLOW_STREAM_ANALYSIS_COMPLETION_HEADROOM_SECONDS', '20') or '20'),
+    )
+except (TypeError, ValueError):
+    STREAM_ANALYSIS_COMPLETION_HEADROOM_SECONDS = 20
 
 BLACK_START_RE = re.compile(r'black_start:(?P<start>-?[0-9]+(?:\.[0-9]+)?)')
 BLACK_END_RE = re.compile(r'black_end:(?P<end>-?[0-9]+(?:\.[0-9]+)?)')
@@ -495,7 +518,16 @@ def _run_ffmpeg_with_optional_fallback(
             if process.poll() is None:
                 process.kill()
 
-    result = _run(command)
+    try:
+        result = _run(command)
+    except subprocess.TimeoutExpired:
+        if fallback_command:
+            logger.warning(
+                "FFmpeg hardware acceleration timed out during %s; retrying on CPU",
+                context,
+            )
+            return _run(fallback_command)
+        raise
     if (
         fallback_command
         and result.returncode != 0
@@ -507,6 +539,23 @@ def _run_ffmpeg_with_optional_fallback(
         )
         return _run(fallback_command)
     return result
+
+
+def _stream_analysis_timeout(
+    timeout: int,
+    duration: int,
+    stream_startup_buffer: int,
+) -> int:
+    """
+    Timeout for real-time ffmpeg remux probes.
+
+    The probe intentionally uses ``-re`` so the stats bitrate reflects playback
+    pace. Some high-bitrate UHD streams need a little extra time after the
+    requested window for segment startup/teardown before ffmpeg exits cleanly.
+    Without this completion headroom, good streams can fall back to ffprobe and
+    lose bitrate even though the stream is playable.
+    """
+    return timeout + duration + stream_startup_buffer + STREAM_ANALYSIS_COMPLETION_HEADROOM_SECONDS
 
 
 def _log_ffmpeg_errors(output: str, logger: logging.Logger, error_patterns: list) -> None:
@@ -587,6 +636,34 @@ def _estimate_bitrate_from_ffmpeg_bytes_read(
     if bitrate_kbps <= MIN_VALID_PROGRESS_BITRATE:
         return None
     return bitrate_kbps
+
+
+def _visual_probe_duration(
+    *,
+    duration: int,
+    blank_check_enabled: bool,
+    blank_check_min_duration: float,
+    freeze_check_enabled: bool,
+    freeze_check_min_duration: float,
+) -> int:
+    """Pick a short visual probe window while respecting the user analysis window."""
+    requested = max(1.0, float(duration or 0))
+    target = 0.0
+    if blank_check_enabled:
+        target = max(
+            target,
+            float(blank_check_min_duration or 0) + 1.0,
+            float(VISUAL_PROBE_DEFAULT_BLANK_SECONDS),
+        )
+    if freeze_check_enabled:
+        target = max(
+            target,
+            float(freeze_check_min_duration or 0) + 1.0,
+            float(VISUAL_PROBE_DEFAULT_FREEZE_SECONDS),
+        )
+    if target <= 0:
+        return max(1, int(math.ceil(requested)))
+    return max(1, int(math.ceil(min(requested, target))))
 
 
 def _parse_blank_detection(
@@ -1182,6 +1259,211 @@ def _ffprobe_media_fallback(
     }
 
 
+def _visual_probe_default_result(
+    *,
+    visual_duration: int,
+    blank_check_enabled: bool,
+    freeze_check_enabled: bool,
+) -> Dict[str, Any]:
+    return {
+        'visual_probe_ran': bool(blank_check_enabled or freeze_check_enabled),
+        'visual_probe_completed': False,
+        'visual_probe_incomplete': False,
+        'visual_probe_incomplete_reason': 'none',
+        'visual_probe_duration_seconds': visual_duration,
+        'visual_probe_elapsed_time': None,
+        'blank_probe_ran': bool(blank_check_enabled),
+        'blank_detected': False,
+        'blank_duration_secs': None,
+        'blank_ratio': None,
+        'blank_segments': [],
+        'freeze_probe_ran': bool(freeze_check_enabled),
+        'freeze_detected': False,
+        'freeze_duration_secs': None,
+        'freeze_ratio': None,
+        'freeze_segments': [],
+    }
+
+
+def _mark_visual_probe_incomplete(
+    result: Dict[str, Any],
+    *,
+    reason: str,
+    elapsed: Optional[float] = None,
+) -> Dict[str, Any]:
+    result['visual_probe_incomplete'] = True
+    result['visual_probe_incomplete_reason'] = reason
+    result['blank_detected'] = False
+    result['freeze_detected'] = False
+    if elapsed is not None:
+        result['visual_probe_elapsed_time'] = elapsed
+    result['measurement_incomplete'] = True
+    result['measurement_incomplete_reason'] = f'visual_probe_{reason}'
+    result['measurement_incomplete_context'] = {
+        'reason': reason,
+        'visual_probe_duration_seconds': result.get('visual_probe_duration_seconds'),
+        'visual_probe_elapsed_time': result.get('visual_probe_elapsed_time'),
+        'blank_probe_ran': result.get('blank_probe_ran'),
+        'freeze_probe_ran': result.get('freeze_probe_ran'),
+    }
+    return result
+
+
+def _run_visual_detection_probe(
+    url: str,
+    *,
+    duration: int,
+    timeout: int,
+    user_agent: str,
+    stream_startup_buffer: int,
+    blank_check_enabled: bool,
+    blank_check_min_duration: float,
+    blank_check_pixel_threshold: float,
+    blank_check_ratio_threshold: float,
+    freeze_check_enabled: bool,
+    freeze_check_min_duration: float,
+    freeze_check_noise_threshold: float,
+    freeze_check_ratio_threshold: float,
+    hardware_acceleration: Optional[Dict[str, Any]],
+    preempt_check: Optional[Callable[[], bool]],
+) -> Dict[str, Any]:
+    """Run expensive visual filters separately from the cheap bitrate probe."""
+    visual_duration = _visual_probe_duration(
+        duration=duration,
+        blank_check_enabled=blank_check_enabled,
+        blank_check_min_duration=blank_check_min_duration,
+        freeze_check_enabled=freeze_check_enabled,
+        freeze_check_min_duration=freeze_check_min_duration,
+    )
+    result_data = _visual_probe_default_result(
+        visual_duration=visual_duration,
+        blank_check_enabled=blank_check_enabled,
+        freeze_check_enabled=freeze_check_enabled,
+    )
+
+    video_filters = []
+    if blank_check_enabled:
+        video_filters.append(
+            f'blackdetect=d={float(blank_check_min_duration):g}:'
+            f'pix_th={float(blank_check_pixel_threshold):g}'
+        )
+    if freeze_check_enabled:
+        video_filters.append(
+            f'freezedetect=n={float(freeze_check_noise_threshold):g}:'
+            f'd={float(freeze_check_min_duration):g}'
+        )
+    if not video_filters:
+        return result_data
+
+    extra_args = _get_ffmpeg_extra_args()
+    hwaccel_config = _resolve_ffmpeg_hwaccel_config(hardware_acceleration)
+    hwaccel_args = _get_ffmpeg_hwaccel_args(hwaccel_config)
+    command = [
+        'ffmpeg', '-re', '-v', 'info', '-stats',
+        '-user_agent', user_agent,
+    ] + hwaccel_args + extra_args + [
+        '-i', url, '-t', str(visual_duration),
+        '-map', '0:v:0?', '-an', '-sn',
+        '-vf', ','.join(video_filters),
+        '-f', 'null', os.devnull,
+    ]
+    fallback_command = None
+    if hwaccel_args and hwaccel_config.get('allow_fallback', True):
+        fallback_command = [
+            'ffmpeg', '-re', '-v', 'info', '-stats',
+            '-user_agent', user_agent,
+        ] + extra_args + [
+            '-i', url, '-t', str(visual_duration),
+            '-map', '0:v:0?', '-an', '-sn',
+            '-vf', ','.join(video_filters),
+            '-f', 'null', os.devnull,
+        ]
+
+    _log_ffmpeg_hwaccel_request(
+        "visual stream analysis",
+        hwaccel_config,
+        hwaccel_args,
+        decode_filters=True,
+    )
+
+    visual_timeout = timeout + visual_duration + stream_startup_buffer
+    try:
+        start = time.time()
+        with _VISUAL_PROBE_SEMAPHORE:
+            visual_result = _run_ffmpeg_with_optional_fallback(
+                command,
+                fallback_command=fallback_command,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                timeout=visual_timeout,
+                text=True,
+                context="visual stream analysis",
+                preempt_check=preempt_check,
+            )
+        elapsed = time.time() - start
+        result_data['visual_probe_elapsed_time'] = elapsed
+        result_data['visual_probe_completed'] = visual_result.returncode == 0
+
+        output = visual_result.stderr or ''
+        if blank_check_enabled:
+            result_data.update(_parse_blank_detection(
+                output,
+                duration=visual_duration,
+                blank_ratio_threshold=float(blank_check_ratio_threshold),
+            ))
+            if result_data.get('blank_detected'):
+                logger.warning(
+                    "  [blank-detect] Blank screen detected "
+                    f"({result_data['blank_duration_secs']:.1f}s/"
+                    f"{visual_duration}s, ratio={result_data['blank_ratio']:.2f})"
+                )
+        if freeze_check_enabled:
+            result_data.update(_parse_freeze_detection(
+                output,
+                duration=visual_duration,
+                freeze_ratio_threshold=float(freeze_check_ratio_threshold),
+            ))
+            if result_data.get('freeze_detected'):
+                logger.warning(
+                    "  [freeze-detect] Frozen picture detected "
+                    f"({result_data['freeze_duration_secs']:.1f}s/"
+                    f"{visual_duration}s, ratio={result_data['freeze_ratio']:.2f})"
+                )
+
+        if visual_result.returncode != 0:
+            return _mark_visual_probe_incomplete(
+                result_data,
+                reason=f'exit_{visual_result.returncode}',
+                elapsed=elapsed,
+            )
+        return result_data
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Visual blank/freeze probe timed out after %ss; keeping bitrate "
+            "measurement and marking visual detection incomplete",
+            visual_timeout,
+        )
+        return _mark_visual_probe_incomplete(
+            result_data,
+            reason='timeout',
+            elapsed=float(visual_timeout),
+        )
+    except StreamProbePreempted:
+        logger.info("Visual blank/freeze probe preempted because viewer capacity is needed")
+        result_data['preempted'] = True
+        result_data['preempt_reason'] = 'viewer_preempted'
+        return _mark_visual_probe_incomplete(
+            result_data,
+            reason='preempted',
+        )
+    except Exception as exc:
+        logger.warning(f"Visual blank/freeze probe failed: {scrub_urls(exc)}")
+        return _mark_visual_probe_incomplete(
+            result_data,
+            reason=type(exc).__name__,
+        )
+
+
 def get_stream_info_and_bitrate(
     url: str,
     duration: int = 30,
@@ -1200,7 +1482,7 @@ def get_stream_info_and_bitrate(
     preempt_check: Optional[Callable[[], bool]] = None,
 ) -> Dict[str, Any]:
     """
-    Get complete stream information using ffmpeg in a single call.
+    Get complete stream information using ffmpeg.
 
     Uses ffmpeg flags:
         -v info   : preserves Input#/Stream# lines for codec+resolution parsing
@@ -1216,11 +1498,11 @@ def get_stream_info_and_bitrate(
         timeout: Base timeout in seconds (actual timeout includes duration + overhead)
         user_agent: User agent string to use for HTTP requests
         stream_startup_buffer: Buffer in seconds for stream startup (default: 10s)
-        blank_check_enabled: Run ffmpeg blackdetect on the same input connection
+        blank_check_enabled: Run a separate ffmpeg blackdetect visual probe
         blank_check_min_duration: Minimum continuous black duration in seconds
         blank_check_pixel_threshold: blackdetect pixel threshold
         blank_check_ratio_threshold: Probe-window ratio required to flag blank
-        freeze_check_enabled: Run ffmpeg freezedetect on the same input connection
+        freeze_check_enabled: Run a separate ffmpeg freezedetect visual probe
         freeze_check_min_duration: Minimum continuous frozen duration in seconds
         freeze_check_noise_threshold: freezedetect noise threshold
         freeze_check_ratio_threshold: Probe-window ratio required to flag frozen
@@ -1316,41 +1598,15 @@ def get_stream_info_and_bitrate(
             '-c', 'copy', '-f', 'mpegts', 'pipe:1'
         ]
 
-    video_filters = []
-    if blank_check_enabled:
-        video_filters.append(
-            f'blackdetect=d={float(blank_check_min_duration):g}:'
-            f'pix_th={float(blank_check_pixel_threshold):g}'
-        )
-    if freeze_check_enabled:
-        video_filters.append(
-            f'freezedetect=n={float(freeze_check_noise_threshold):g}:'
-            f'd={float(freeze_check_min_duration):g}'
-        )
-    if video_filters:
-        command += [
-            '-map', '0:v:0?', '-t', str(duration),
-            '-an', '-sn',
-            '-vf', ','.join(video_filters),
-            '-f', 'null', os.devnull,
-        ]
-        if fallback_command:
-            fallback_command += [
-                '-map', '0:v:0?', '-t', str(duration),
-                '-an', '-sn',
-                '-vf', ','.join(video_filters),
-                '-f', 'null', os.devnull,
-            ]
-
     _log_ffmpeg_hwaccel_request(
         "stream analysis",
         hwaccel_config,
         hwaccel_args,
-        decode_filters=bool(video_filters),
+        decode_filters=False,
     )
 
-    # Total subprocess timeout: analysis window + startup headroom.
-    actual_timeout = timeout + duration + stream_startup_buffer
+    # Total subprocess timeout: analysis window + startup and completion headroom.
+    actual_timeout = _stream_analysis_timeout(timeout, duration, stream_startup_buffer)
 
     result_data = {
         'video_codec': 'N/A', 'audio_codec': 'N/A', 'resolution': '0x0',
@@ -1362,12 +1618,22 @@ def get_stream_info_and_bitrate(
         'operation_timeout_seconds': timeout,
         'ffmpeg_duration_seconds': duration,
         'startup_buffer_seconds': stream_startup_buffer,
+        'completion_headroom_seconds': STREAM_ANALYSIS_COMPLETION_HEADROOM_SECONDS,
         'blank_probe_ran': False, 'blank_detected': False,
         'blank_duration_secs': None, 'blank_ratio': None,
         'blank_segments': [],
         'freeze_probe_ran': False, 'freeze_detected': False,
         'freeze_duration_secs': None, 'freeze_ratio': None,
         'freeze_segments': [],
+        'visual_probe_ran': False,
+        'visual_probe_completed': False,
+        'visual_probe_incomplete': False,
+        'visual_probe_incomplete_reason': 'none',
+        'visual_probe_duration_seconds': None,
+        'visual_probe_elapsed_time': None,
+        'measurement_incomplete': False,
+        'measurement_incomplete_reason': 'none',
+        'measurement_incomplete_context': {},
         'preempted': False, 'preempt_reason': None,
         'bitrate_source': None,
         'ffprobe_fallback_ran': False,
@@ -1391,30 +1657,6 @@ def get_stream_info_and_bitrate(
         result_data['elapsed_time'] = elapsed
 
         output = result.stderr
-        if blank_check_enabled:
-            result_data.update(_parse_blank_detection(
-                output,
-                duration=duration,
-                blank_ratio_threshold=float(blank_check_ratio_threshold),
-            ))
-            if result_data.get('blank_detected'):
-                logger.warning(
-                    "  [blank-detect] Blank screen detected "
-                    f"({result_data['blank_duration_secs']:.1f}s/"
-                    f"{duration}s, ratio={result_data['blank_ratio']:.2f})"
-                )
-        if freeze_check_enabled:
-            result_data.update(_parse_freeze_detection(
-                output,
-                duration=duration,
-                freeze_ratio_threshold=float(freeze_check_ratio_threshold),
-            ))
-            if result_data.get('freeze_detected'):
-                logger.warning(
-                    "  [freeze-detect] Frozen picture detected "
-                    f"({result_data['freeze_duration_secs']:.1f}s/"
-                    f"{duration}s, ratio={result_data['freeze_ratio']:.2f})"
-                )
         progress_bitrate = None
         last_stats_line = None  # keeps updating; final line is the most stable average
         last_media_time = 0.0
@@ -1638,6 +1880,26 @@ def get_stream_info_and_bitrate(
                 ]
                 _log_ffmpeg_errors(output, logger, error_patterns)
 
+        if blank_check_enabled or freeze_check_enabled:
+            visual_result = _run_visual_detection_probe(
+                url,
+                duration=duration,
+                timeout=timeout,
+                user_agent=user_agent,
+                stream_startup_buffer=stream_startup_buffer,
+                blank_check_enabled=blank_check_enabled,
+                blank_check_min_duration=blank_check_min_duration,
+                blank_check_pixel_threshold=blank_check_pixel_threshold,
+                blank_check_ratio_threshold=blank_check_ratio_threshold,
+                freeze_check_enabled=freeze_check_enabled,
+                freeze_check_min_duration=freeze_check_min_duration,
+                freeze_check_noise_threshold=freeze_check_noise_threshold,
+                freeze_check_ratio_threshold=freeze_check_ratio_threshold,
+                hardware_acceleration=hardware_acceleration,
+                preempt_check=preempt_check,
+            )
+            result_data.update(visual_result)
+
         logger.debug(f"  Analysis completed in {elapsed:.2f}s")
 
     except subprocess.TimeoutExpired:
@@ -1728,7 +1990,7 @@ def get_stream_bitrate(
 
     bitrate = None
     status = "OK"
-    actual_timeout = timeout + duration + stream_startup_buffer
+    actual_timeout = _stream_analysis_timeout(timeout, duration, stream_startup_buffer)
 
     try:
         start = time.time()
@@ -2272,6 +2534,12 @@ def analyze_stream(
         'freeze_duration_secs': None,
         'freeze_ratio': None,
         'freeze_segments': [],
+        'visual_probe_ran': False,
+        'visual_probe_completed': False,
+        'visual_probe_incomplete': False,
+        'visual_probe_incomplete_reason': 'none',
+        'visual_probe_duration_seconds': None,
+        'visual_probe_elapsed_time': None,
         'preempted': False,
         'preempt_reason': None,
         'ffprobe_fallback_ran': False,
@@ -2301,7 +2569,7 @@ def analyze_stream(
 
             try:
                 if logger.isEnabledFor(logging.DEBUG):
-                    logger.info("  Analyzing stream (single ffmpeg call)...")
+                    logger.info("  Analyzing stream (basis probe plus optional visual probe)...")
 
                 result_data = get_stream_info_and_bitrate(
                     url=stream_url,
@@ -2363,6 +2631,12 @@ def analyze_stream(
                     'freeze_duration_secs': result_data.get('freeze_duration_secs'),
                     'freeze_ratio': result_data.get('freeze_ratio'),
                     'freeze_segments': result_data.get('freeze_segments', []),
+                    'visual_probe_ran': bool(result_data.get('visual_probe_ran')),
+                    'visual_probe_completed': bool(result_data.get('visual_probe_completed')),
+                    'visual_probe_incomplete': bool(result_data.get('visual_probe_incomplete')),
+                    'visual_probe_incomplete_reason': result_data.get('visual_probe_incomplete_reason') or 'none',
+                    'visual_probe_duration_seconds': result_data.get('visual_probe_duration_seconds'),
+                    'visual_probe_elapsed_time': result_data.get('visual_probe_elapsed_time'),
                     'preempted': bool(result_data.get('preempted')),
                     'preempt_reason': result_data.get('preempt_reason'),
                     'ffprobe_fallback_ran': bool(result_data.get('ffprobe_fallback_ran')),

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -1556,6 +1556,39 @@ class StreamCheckerService:
         context.setdefault("preserved_bitrate_kbps", previous_bitrate)
         context.setdefault("preserved_bitrate_source", "previous_stream_stats")
         analyzed["measurement_incomplete_context"] = context
+
+    @classmethod
+    def _has_incomplete_bitrate_measurement(cls, stream_data: Optional[Dict[str, Any]]) -> bool:
+        if not isinstance(stream_data, dict):
+            return False
+        if cls._bitrate_payload_value(stream_data.get("bitrate_kbps")) is not None:
+            return False
+        return bool(
+            stream_data.get("measurement_incomplete_reason") == "missing_bitrate"
+            or stream_data.get("bitrate_recheck_required")
+        )
+
+    @classmethod
+    def _apply_incomplete_bitrate_status(
+        cls,
+        target: Dict[str, Any],
+        source: Optional[Dict[str, Any]],
+    ) -> None:
+        if not cls._has_incomplete_bitrate_measurement(source):
+            return
+        context = {}
+        if isinstance(source, dict) and isinstance(source.get("measurement_incomplete_context"), dict):
+            context = source.get("measurement_incomplete_context") or {}
+        target["status"] = "incomplete_bitrate"
+        target["reason"] = "missing_bitrate"
+        target["reason_detail"] = "missing_bitrate"
+        target["quality_reason"] = "missing_bitrate"
+        target["quality_reason_detail"] = "missing_bitrate"
+        target["quality_reason_context"] = context
+        target["measurement_incomplete"] = True
+        target["measurement_incomplete_reason"] = "missing_bitrate"
+        target["measurement_incomplete_context"] = context
+        target["bitrate_recheck_required"] = True
     
     def _start_batch_changelog(self):
         """Start a new batch for changelog entries."""
@@ -2784,10 +2817,13 @@ class StreamCheckerService:
                             stream_statuses[stream_id]['bitrate'] = result.get('bitrate_kbps')
                             stream_statuses[stream_id]['hdr_format'] = result.get('hdr_format')
                         else:
-                            stream_statuses[stream_id]['status'] = 'completed'
-                            stream_statuses[stream_id]['quality_reason'] = 'none'
-                            stream_statuses[stream_id]['quality_reason_detail'] = 'none'
-                            stream_statuses[stream_id]['quality_reason_context'] = {}
+                            if self._has_incomplete_bitrate_measurement(result):
+                                self._apply_incomplete_bitrate_status(stream_statuses[stream_id], result)
+                            else:
+                                stream_statuses[stream_id]['status'] = 'completed'
+                                stream_statuses[stream_id]['quality_reason'] = 'none'
+                                stream_statuses[stream_id]['quality_reason_detail'] = 'none'
+                                stream_statuses[stream_id]['quality_reason_context'] = {}
                             # Optional: record score or resolution
                             stream_statuses[stream_id]['score'] = temp_score
                             stream_statuses[stream_id]['resolution'] = result.get('resolution', '0x0')
@@ -3346,6 +3382,22 @@ class StreamCheckerService:
                         stream_stat['score'] = round(analyzed.get('score', 0), 2)
                     elif analyzed.get('reason_detail') == 'viewer_preempted':
                         stream_stat['status'] = 'viewer_preempted'
+                    elif self._has_incomplete_bitrate_measurement(analyzed):
+                        stream_stat['status'] = 'incomplete_bitrate'
+                        stream_stat['reason'] = 'missing_bitrate'
+                        stream_stat['reason_detail'] = 'missing_bitrate'
+                        stream_stat['quality_reason'] = 'missing_bitrate'
+                        stream_stat['quality_reason_detail'] = 'missing_bitrate'
+                        stream_stat['quality_reason_context'] = (
+                            analyzed.get('measurement_incomplete_context') or {}
+                        )
+                        stream_stat['measurement_incomplete'] = True
+                        stream_stat['measurement_incomplete_reason'] = 'missing_bitrate'
+                        stream_stat['measurement_incomplete_context'] = (
+                            analyzed.get('measurement_incomplete_context') or {}
+                        )
+                        stream_stat['bitrate_recheck_required'] = True
+                        stream_stat['score'] = round(analyzed.get('score', 0), 2)
                     else:
                         stream_stat['status'] = 'completed'
                         stream_stat['score'] = round(analyzed.get('score', 0), 2)
@@ -4108,11 +4160,14 @@ class StreamCheckerService:
                         stream_statuses[stream['id']]['bitrate'] = analyzed.get('bitrate_kbps')
                         stream_statuses[stream['id']]['hdr_format'] = analyzed.get('hdr_format')
                     else:
-                        stream_statuses[stream['id']]['status'] = 'completed'
                         stream_statuses[stream['id']]['score'] = score
-                        stream_statuses[stream['id']]['quality_reason'] = 'none'
-                        stream_statuses[stream['id']]['quality_reason_detail'] = 'none'
-                        stream_statuses[stream['id']]['quality_reason_context'] = {}
+                        if self._has_incomplete_bitrate_measurement(analyzed):
+                            self._apply_incomplete_bitrate_status(stream_statuses[stream['id']], analyzed)
+                        else:
+                            stream_statuses[stream['id']]['status'] = 'completed'
+                            stream_statuses[stream['id']]['quality_reason'] = 'none'
+                            stream_statuses[stream['id']]['quality_reason_detail'] = 'none'
+                            stream_statuses[stream['id']]['quality_reason_context'] = {}
                         stream_statuses[stream['id']]['resolution'] = analyzed.get('resolution', '0x0')
                         stream_statuses[stream['id']]['video_codec'] = analyzed.get('video_codec', 'N/A')
                         stream_statuses[stream['id']]['fps'] = analyzed.get('fps', 0)
@@ -4483,6 +4538,22 @@ class StreamCheckerService:
                         stream_stat['status'] = analyzed.get('dead_reason') if analyzed.get('dead_reason') in ('blank', 'freeze', 'low_quality') else 'dead'
                     elif is_revived:
                         stream_stat['status'] = 'revived'
+                        stream_stat['score'] = round(analyzed.get('score', 0), 2)
+                    elif self._has_incomplete_bitrate_measurement(analyzed):
+                        stream_stat['status'] = 'incomplete_bitrate'
+                        stream_stat['reason'] = 'missing_bitrate'
+                        stream_stat['reason_detail'] = 'missing_bitrate'
+                        stream_stat['quality_reason'] = 'missing_bitrate'
+                        stream_stat['quality_reason_detail'] = 'missing_bitrate'
+                        stream_stat['quality_reason_context'] = (
+                            analyzed.get('measurement_incomplete_context') or {}
+                        )
+                        stream_stat['measurement_incomplete'] = True
+                        stream_stat['measurement_incomplete_reason'] = 'missing_bitrate'
+                        stream_stat['measurement_incomplete_context'] = (
+                            analyzed.get('measurement_incomplete_context') or {}
+                        )
+                        stream_stat['bitrate_recheck_required'] = True
                         stream_stat['score'] = round(analyzed.get('score', 0), 2)
                     else:
                         stream_stat['status'] = 'completed'
@@ -6019,7 +6090,7 @@ class StreamCheckerService:
         if not isinstance(checked_streams, list):
             return 0
         bad_reasons = {'blank', 'freeze', 'low_quality', 'offline', 'unstable'}
-        good_statuses = {None, '', 'completed', 'revived'}
+        good_statuses = {None, '', 'completed', 'revived', 'incomplete_bitrate'}
         return sum(
             1
             for stream in checked_streams
@@ -6028,7 +6099,10 @@ class StreamCheckerService:
             and stream.get('blank_detected') is not True
             and stream.get('freeze_detected') is not True
             and stream.get('dead_reason') not in bad_reasons
-            and stream.get('quality_reason_detail') in {None, '', 'none'}
+            and (
+                stream.get('status') == 'incomplete_bitrate'
+                or stream.get('quality_reason_detail') in {None, '', 'none'}
+            )
         )
 
     @classmethod
@@ -7120,6 +7194,21 @@ class StreamCheckerService:
                     stream_detail['reason_detail'] = 'freeze'
                     stream_detail['quality_reason'] = 'freeze'
                     stream_detail['quality_reason_detail'] = 'freeze'
+                elif self._has_incomplete_bitrate_measurement(analyzed):
+                    stream_detail['status'] = 'incomplete_bitrate'
+                    stream_detail['reason'] = 'missing_bitrate'
+                    stream_detail['reason_detail'] = 'missing_bitrate'
+                    stream_detail['quality_reason'] = 'missing_bitrate'
+                    stream_detail['quality_reason_detail'] = 'missing_bitrate'
+                    stream_detail['quality_reason_context'] = (
+                        analyzed.get('measurement_incomplete_context') or {}
+                    )
+                    stream_detail['measurement_incomplete'] = True
+                    stream_detail['measurement_incomplete_reason'] = 'missing_bitrate'
+                    stream_detail['measurement_incomplete_context'] = (
+                        analyzed.get('measurement_incomplete_context') or {}
+                    )
+                    stream_detail['bitrate_recheck_required'] = True
                 else:
                     stream_detail['status'] = 'completed'
                     if quality_reason:

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -46,7 +46,7 @@ from apps.udi import get_udi_manager
 
 # Import dead streams tracker
 from apps.stream.dead_streams_tracker import DeadStreamsTracker
-from apps.stream.stream_check_utils import analyze_stream
+from apps.stream.stream_check_utils import analyze_stream, _stream_analysis_timeout
 from apps.stream.queue_start import order_channels_for_queue_start
 from apps.stream.connectivity_guard import ConnectivityCheckResult, StreamConnectivityGuard
 from apps.stream.stream_session_manager import get_session_manager
@@ -1256,6 +1256,9 @@ class StreamCheckerService:
             logger.warning("No stream_id in stream data. Skipping stats update.")
             return False
         
+        bitrate_value = self._bitrate_payload_value(stream_data.get("bitrate_kbps"))
+        preserve_existing_bitrate = self._should_preserve_existing_bitrate(stream_data)
+
         # Construct the stream stats payload from the analyzed stream data
         stream_stats_payload = {
             "resolution": stream_data.get("resolution"),
@@ -1268,7 +1271,7 @@ class StreamCheckerService:
             "audio_channels": stream_data.get("audio_channels"),
             "channel_layout": stream_data.get("channel_layout"),
             "audio_bitrate": stream_data.get("audio_bitrate"),
-            "ffmpeg_output_bitrate": int(stream_data.get("bitrate_kbps")) if stream_data.get("bitrate_kbps") not in ["N/A", None] else None,
+            "ffmpeg_output_bitrate": bitrate_value,
             "bitrate_source": stream_data.get("bitrate_source"),
             "quality_score": stream_data.get("score"),
             "quality_reason": stream_data.get("quality_reason"),
@@ -1278,6 +1281,16 @@ class StreamCheckerService:
             "measurement_incomplete_reason": stream_data.get("measurement_incomplete_reason") or "none",
             "measurement_incomplete_context": stream_data.get("measurement_incomplete_context") or {},
             "bitrate_recheck_required": bool(stream_data.get("bitrate_recheck_required")),
+            "visual_probe_ran": True if stream_data.get("visual_probe_ran") else (False if "visual_probe_ran" in stream_data else None),
+            "visual_probe_completed": stream_data.get("visual_probe_completed") if "visual_probe_completed" in stream_data else None,
+            "visual_probe_incomplete": stream_data.get("visual_probe_incomplete") if "visual_probe_incomplete" in stream_data else None,
+            "visual_probe_incomplete_reason": (
+                stream_data.get("visual_probe_incomplete_reason") or "none"
+                if "visual_probe_ran" in stream_data or "visual_probe_incomplete_reason" in stream_data
+                else None
+            ),
+            "visual_probe_duration_seconds": stream_data.get("visual_probe_duration_seconds"),
+            "visual_probe_elapsed_time": stream_data.get("visual_probe_elapsed_time"),
             # PRESERVE_FALSE: emit False (not None) so the None-filter below keeps these
             # fields in the payload even when the probe ran but found no loop.
             # Without this, Dispatcharr's PATCH merge leaves a stale loop_probe_ran: true
@@ -1306,12 +1319,15 @@ class StreamCheckerService:
             "blank_detected",
             "freeze_probe_ran",
             "freeze_detected",
+            "visual_probe_ran",
+            "visual_probe_completed",
+            "visual_probe_incomplete",
             "measurement_incomplete",
             "bitrate_recheck_required",
         }
-        PRESERVE_NULL = {
-            "ffmpeg_output_bitrate",
-        }
+        PRESERVE_NULL = set()
+        if not preserve_existing_bitrate:
+            PRESERVE_NULL.add("ffmpeg_output_bitrate")
         stream_stats_payload = {
             k: v for k, v in stream_stats_payload.items()
             if v not in [None, "N/A"] or (v is None and k in PRESERVE_NULL)
@@ -1383,6 +1399,9 @@ class StreamCheckerService:
             logger.warning("No stream_id in stream data. Skipping stats preparation.")
             return None
         
+        bitrate_value = self._bitrate_payload_value(stream_data.get("bitrate_kbps"))
+        preserve_existing_bitrate = self._should_preserve_existing_bitrate(stream_data)
+
         # Construct the stream stats payload from the analyzed stream data
         stream_stats_payload = {
             "resolution": stream_data.get("resolution"),
@@ -1395,7 +1414,7 @@ class StreamCheckerService:
             "audio_channels": stream_data.get("audio_channels"),
             "channel_layout": stream_data.get("channel_layout"),
             "audio_bitrate": stream_data.get("audio_bitrate"),
-            "ffmpeg_output_bitrate": int(stream_data.get("bitrate_kbps")) if stream_data.get("bitrate_kbps") not in ["N/A", None] else None,
+            "ffmpeg_output_bitrate": bitrate_value,
             "bitrate_source": stream_data.get("bitrate_source"),
             "quality_score": stream_data.get("score"),
             "quality_reason": stream_data.get("quality_reason"),
@@ -1405,6 +1424,16 @@ class StreamCheckerService:
             "measurement_incomplete_reason": stream_data.get("measurement_incomplete_reason") or "none",
             "measurement_incomplete_context": stream_data.get("measurement_incomplete_context") or {},
             "bitrate_recheck_required": bool(stream_data.get("bitrate_recheck_required")),
+            "visual_probe_ran": True if stream_data.get("visual_probe_ran") else False,
+            "visual_probe_completed": stream_data.get("visual_probe_completed") if "visual_probe_completed" in stream_data else False,
+            "visual_probe_incomplete": stream_data.get("visual_probe_incomplete") if "visual_probe_incomplete" in stream_data else False,
+            "visual_probe_incomplete_reason": (
+                stream_data.get("visual_probe_incomplete_reason") or "none"
+                if "visual_probe_ran" in stream_data or "visual_probe_incomplete_reason" in stream_data
+                else None
+            ),
+            "visual_probe_duration_seconds": stream_data.get("visual_probe_duration_seconds"),
+            "visual_probe_elapsed_time": stream_data.get("visual_probe_elapsed_time"),
             # PRESERVE_FALSE: emit False (not None) so the None-filter below keeps these
             # fields in the payload even when the probe ran but found no loop.
             # Without this, Dispatcharr's PATCH merge leaves a stale loop_probe_ran: true
@@ -1433,6 +1462,9 @@ class StreamCheckerService:
             "blank_detected",
             "freeze_probe_ran",
             "freeze_detected",
+            "visual_probe_ran",
+            "visual_probe_completed",
+            "visual_probe_incomplete",
             "measurement_incomplete",
             "bitrate_recheck_required",
         }
@@ -1445,7 +1477,12 @@ class StreamCheckerService:
             k: v for k, v in stream_stats_payload.items()
             if (
                 v not in [None, "N/A"]
-                or (v is None and k not in PRESERVE_FALSE and k not in QUALITY_FIELDS)
+                or (
+                    v is None
+                    and k not in PRESERVE_FALSE
+                    and k not in QUALITY_FIELDS
+                    and not (k == "ffmpeg_output_bitrate" and preserve_existing_bitrate)
+                )
             )
         }
         for k in PRESERVE_FALSE:
@@ -1460,6 +1497,65 @@ class StreamCheckerService:
             'stream_id': stream_id,
             'stream_stats': stream_stats_payload
         }
+
+    @staticmethod
+    def _bitrate_payload_value(value: Any) -> Optional[int]:
+        parsed = parse_bitrate_value(value)
+        if parsed is None or parsed <= 0:
+            return None
+        return int(parsed)
+
+    @staticmethod
+    def _load_stream_stats_blob(stream_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        if not isinstance(stream_data, dict):
+            return {}
+        stream_stats = stream_data.get("stream_stats") or {}
+        if isinstance(stream_stats, str):
+            try:
+                stream_stats = json.loads(stream_stats) or {}
+            except json.JSONDecodeError:
+                stream_stats = {}
+        return stream_stats if isinstance(stream_stats, dict) else {}
+
+    @classmethod
+    def _previous_stream_bitrate(cls, stream_data: Optional[Dict[str, Any]]) -> Optional[int]:
+        stream_stats = cls._load_stream_stats_blob(stream_data)
+        return cls._bitrate_payload_value(
+            stream_stats.get("ffmpeg_output_bitrate")
+            or stream_stats.get("bitrate_kbps")
+            or stream_stats.get("bitrate")
+        )
+
+    @classmethod
+    def _should_preserve_existing_bitrate(cls, stream_data: Dict[str, Any]) -> bool:
+        if cls._bitrate_payload_value(stream_data.get("bitrate_kbps")) is not None:
+            return False
+        return bool(
+            stream_data.get("measurement_incomplete")
+            or stream_data.get("bitrate_recheck_required")
+        )
+
+    @classmethod
+    def _apply_previous_bitrate_fallback(
+        cls,
+        analyzed: Dict[str, Any],
+        existing_stream: Optional[Dict[str, Any]],
+    ) -> None:
+        if not cls._should_preserve_existing_bitrate(analyzed):
+            return
+        previous_bitrate = cls._previous_stream_bitrate(existing_stream)
+        if previous_bitrate is None:
+            return
+        analyzed["scoring_bitrate_kbps"] = previous_bitrate
+        analyzed["bitrate_preserved_from_previous_measurement"] = True
+        analyzed["preserved_bitrate_kbps"] = previous_bitrate
+        analyzed["preserved_bitrate_source"] = "previous_stream_stats"
+        context = analyzed.get("measurement_incomplete_context")
+        if not isinstance(context, dict):
+            context = {}
+        context.setdefault("preserved_bitrate_kbps", previous_bitrate)
+        context.setdefault("preserved_bitrate_source", "previous_stream_stats")
+        analyzed["measurement_incomplete_context"] = context
     
     def _start_batch_changelog(self):
         """Start a new batch for changelog entries."""
@@ -2555,6 +2651,11 @@ class StreamCheckerService:
                 }
                 for s in streams_to_check
             }
+            streams_by_id = {
+                s.get('id'): s
+                for s in streams_to_check
+                if s.get('id') is not None
+            }
 
             profile_slot_account_ids = sorted({
                 account_id
@@ -2656,6 +2757,10 @@ class StreamCheckerService:
                             'message': result.get('error_message') or 'Stream analysis worker returned no result',
                         }
                     else:
+                        self._apply_previous_bitrate_fallback(
+                            result,
+                            streams_by_id.get(stream_id),
+                        )
                         # Calculate temp score for UI display
                         temp_score = self._calculate_stream_score(result, priority_m3u_ids, priority_mode, scoring_weights)
 
@@ -2835,6 +2940,10 @@ class StreamCheckerService:
 
                     # Check if stream is dead using pre-resolved threshold config
                     # so forced_profile_id selections are honoured.
+                    self._apply_previous_bitrate_fallback(
+                        analyzed,
+                        streams_by_id.get(analyzed.get('stream_id')),
+                    )
                     dead_result = self._is_stream_dead(analyzed, channel_id, threshold_config=_threshold_config)
                     self._apply_quality_classification(analyzed, dead_result)
                     is_dead, dead_reason = dead_result
@@ -4839,6 +4948,8 @@ class StreamCheckerService:
         
         # Bitrate score (0-1, normalized to typical range 1000-8000 kbps)
         bitrate = stream_data.get('bitrate_kbps', 0)
+        if self._bitrate_payload_value(bitrate) is None:
+            bitrate = stream_data.get('scoring_bitrate_kbps', 0)
         if isinstance(bitrate, (int, float)) and bitrate > 0:
             bitrate_score = min(bitrate / 8000, 1.0)
             score += bitrate_score * weights.get('bitrate', 0.40)
@@ -5081,7 +5192,11 @@ class StreamCheckerService:
         provider_wait = self._queue_number(self.config.get('concurrent_streams.provider_wait_timeout', 180)) or 180.0
 
         attempts = max(1.0, retries + 1.0)
-        probe_budget = attempts * (analysis_duration + analysis_timeout + startup_buffer)
+        probe_budget = attempts * _stream_analysis_timeout(
+            analysis_timeout,
+            analysis_duration,
+            startup_buffer,
+        )
         retry_budget = max(0.0, retries) * retry_delay
         loop_budget = loop_duration * 3.0
         stale_after = probe_budget + retry_budget + loop_budget + provider_wait + 60.0
@@ -5284,10 +5399,10 @@ class StreamCheckerService:
             configured_timeout = self._queue_number(analysis_config.get('timeout'))
             startup_buffer = self._queue_number(analysis_config.get('stream_startup_buffer'))
             if configured_timeout > 0 or startup_buffer > 0:
-                configured_timeout_floor_seconds = (
-                    configured_stream_seconds
-                    + configured_timeout
-                    + startup_buffer
+                configured_timeout_floor_seconds = _stream_analysis_timeout(
+                    configured_timeout,
+                    configured_stream_seconds,
+                    startup_buffer,
                 )
         effective_stream_seconds = max(
             avg_seconds,

--- a/backend/apps/telemetry/telemetry_db.py
+++ b/backend/apps/telemetry/telemetry_db.py
@@ -1,6 +1,6 @@
 import os
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from sqlalchemy.orm import sessionmaker
 
 from apps.core.logging_config import setup_logging
@@ -10,6 +10,45 @@ logger = setup_logging(__name__)
 from apps.database.connection import get_session
 from apps.database.models import Run, ChannelHealth, StreamTelemetry
 from apps.telemetry.run_classification import classify_run_metadata
+
+CHANGELOG_RETENTION_DAYS = 7
+TELEMETRY_CLEANUP_BATCH_SIZE = 500
+
+
+def _cleanup_old_telemetry(days: int = CHANGELOG_RETENTION_DAYS) -> int:
+    """Delete old changelog/telemetry runs and their dependent rows."""
+    cutoff = datetime.utcnow() - timedelta(days=max(1, int(days or CHANGELOG_RETENTION_DAYS)))
+    deleted = 0
+    session = get_session()
+    try:
+        while True:
+            old_runs = (
+                session.query(Run)
+                .filter(Run.timestamp < cutoff)
+                .order_by(Run.timestamp.asc())
+                .limit(TELEMETRY_CLEANUP_BATCH_SIZE)
+                .all()
+            )
+            if not old_runs:
+                break
+            for run in old_runs:
+                session.delete(run)
+                deleted += 1
+            session.flush()
+        session.commit()
+        if deleted:
+            logger.info(
+                "Pruned %s changelog/telemetry run(s) older than %s day(s)",
+                deleted,
+                days,
+            )
+        return deleted
+    except Exception as exc:
+        session.rollback()
+        logger.warning(f"Failed to prune old telemetry runs: {exc}", exc_info=True)
+        return 0
+    finally:
+        session.close()
 
 def _sanitize_bitrate(bitrate_str):
     if not bitrate_str:
@@ -185,6 +224,7 @@ def save_automation_run_telemetry(action, details, subentries=None, timestamp=No
                             session.add(dtel)
                             
         session.commit()
+        _cleanup_old_telemetry()
     except Exception as e:
         session.rollback()
         logger.error(f"Error saving telemetry data: {e}", exc_info=True)
@@ -266,6 +306,7 @@ def save_generic_telemetry(action, details, subentries=None, timestamp=None):
                             session.add(dtel)
 
         session.commit()
+        _cleanup_old_telemetry()
     except Exception as e:
         session.rollback()
         logger.error(f"Error saving generic telemetry: {e}", exc_info=True)

--- a/backend/tests/test_bitrate_detection.py
+++ b/backend/tests/test_bitrate_detection.py
@@ -120,7 +120,7 @@ frame=  750 fps= 25 q=-1.0 size=   15000kB time=00:00:30.00 bitrate=4000.0kbits/
     def test_bitrate_timeout_handling(self, mock_run):
         """Test that timeout is handled gracefully."""
         test_timeout = 10
-        expected_timeout = test_timeout + 30 + 10  # timeout + duration + buffer
+        expected_timeout = test_timeout + 30 + 10 + 20  # timeout + duration + startup + completion headroom
         mock_run.side_effect = subprocess.TimeoutExpired(cmd='ffmpeg', timeout=expected_timeout)
         
         bitrate, status, elapsed = get_stream_bitrate(

--- a/backend/tests/test_blank_detection.py
+++ b/backend/tests/test_blank_detection.py
@@ -2,6 +2,7 @@
 """Tests for quality-check blank-screen detection."""
 
 import os
+import subprocess
 import sys
 import unittest
 from unittest.mock import Mock, patch
@@ -104,13 +105,16 @@ class TestFreezeDetectionParsing(unittest.TestCase):
 
 class TestBlankDetectionFfmpegCommand(unittest.TestCase):
     @patch.object(stream_check_utils.subprocess, "run")
-    def test_blank_detection_uses_one_input_connection(self, mock_run):
-        mock_run.return_value = Mock(
-            stderr=_ffmpeg_output(
-                "[blackdetect @ 000] black_start:0 black_end:30 black_duration:30"
+    def test_blank_detection_runs_separate_visual_probe(self, mock_run):
+        mock_run.side_effect = [
+            Mock(stderr=_ffmpeg_output(), returncode=0),
+            Mock(
+                stderr=_ffmpeg_output(
+                    "[blackdetect @ 000] black_start:0 black_end:8 black_duration:8"
+                ),
+                returncode=0,
             ),
-            returncode=0,
-        )
+        ]
 
         result = get_stream_info_and_bitrate(
             "http://example.com/test.m3u8",
@@ -119,25 +123,35 @@ class TestBlankDetectionFfmpegCommand(unittest.TestCase):
             blank_check_enabled=True,
         )
 
-        command = mock_run.call_args.args[0]
-        self.assertEqual(command[0], "ffmpeg")
-        self.assertEqual(command.count("-i"), 1)
-        self.assertNotIn("ffprobe", command)
-        self.assertIn("-vf", command)
-        self.assertTrue(any("blackdetect=d=2:pix_th=0.1" in arg for arg in command))
+        self.assertEqual(mock_run.call_count, 2)
+        basis_command = mock_run.call_args_list[0].args[0]
+        visual_command = mock_run.call_args_list[1].args[0]
+        self.assertEqual(basis_command[0], "ffmpeg")
+        self.assertEqual(basis_command.count("-i"), 1)
+        self.assertNotIn("ffprobe", basis_command)
+        self.assertNotIn("-vf", basis_command)
+        self.assertEqual(visual_command.count("-i"), 1)
+        self.assertIn("-vf", visual_command)
+        self.assertTrue(any("blackdetect=d=2:pix_th=0.1" in arg for arg in visual_command))
+        self.assertEqual(result["bitrate_kbps"], 3333.3)
+        self.assertTrue(result["visual_probe_ran"])
+        self.assertTrue(result["visual_probe_completed"])
         self.assertTrue(result["blank_probe_ran"])
         self.assertTrue(result["blank_detected"])
 
     @patch.object(stream_check_utils.subprocess, "run")
-    def test_freeze_detection_uses_same_input_connection(self, mock_run):
-        mock_run.return_value = Mock(
-            stderr=_ffmpeg_output(
-                "[freezedetect @ 000] lavfi.freezedetect.freeze_start: 0\n"
-                "[freezedetect @ 000] lavfi.freezedetect.freeze_duration: 30\n"
-                "[freezedetect @ 000] lavfi.freezedetect.freeze_end: 30"
+    def test_freeze_detection_runs_separate_visual_probe(self, mock_run):
+        mock_run.side_effect = [
+            Mock(stderr=_ffmpeg_output(), returncode=0),
+            Mock(
+                stderr=_ffmpeg_output(
+                    "[freezedetect @ 000] lavfi.freezedetect.freeze_start: 0\n"
+                    "[freezedetect @ 000] lavfi.freezedetect.freeze_duration: 10\n"
+                    "[freezedetect @ 000] lavfi.freezedetect.freeze_end: 10"
+                ),
+                returncode=0,
             ),
-            returncode=0,
-        )
+        ]
 
         result = get_stream_info_and_bitrate(
             "http://example.com/test.m3u8",
@@ -146,11 +160,18 @@ class TestBlankDetectionFfmpegCommand(unittest.TestCase):
             freeze_check_enabled=True,
         )
 
-        command = mock_run.call_args.args[0]
-        self.assertEqual(command[0], "ffmpeg")
-        self.assertEqual(command.count("-i"), 1)
-        self.assertIn("-vf", command)
-        self.assertTrue(any("freezedetect=n=0.001:d=5" in arg for arg in command))
+        self.assertEqual(mock_run.call_count, 2)
+        basis_command = mock_run.call_args_list[0].args[0]
+        visual_command = mock_run.call_args_list[1].args[0]
+        self.assertEqual(basis_command[0], "ffmpeg")
+        self.assertEqual(basis_command.count("-i"), 1)
+        self.assertNotIn("-vf", basis_command)
+        self.assertEqual(visual_command.count("-i"), 1)
+        self.assertIn("-vf", visual_command)
+        self.assertTrue(any("freezedetect=n=0.001:d=5" in arg for arg in visual_command))
+        self.assertEqual(result["bitrate_kbps"], 3333.3)
+        self.assertTrue(result["visual_probe_ran"])
+        self.assertTrue(result["visual_probe_completed"])
         self.assertTrue(result["freeze_probe_ran"])
         self.assertTrue(result["freeze_detected"])
 
@@ -169,6 +190,35 @@ class TestBlankDetectionFfmpegCommand(unittest.TestCase):
         self.assertFalse(any("blackdetect" in arg for arg in command))
         self.assertFalse(result["blank_probe_ran"])
         self.assertFalse(result["blank_detected"])
+
+    @patch.object(stream_check_utils.subprocess, "run")
+    def test_visual_probe_timeout_preserves_basis_bitrate(self, mock_run):
+        def run_side_effect(command, **kwargs):
+            if "-vf" in command:
+                raise subprocess.TimeoutExpired(command, kwargs.get("timeout", 30))
+            return Mock(stderr=_ffmpeg_output(), returncode=0)
+
+        mock_run.side_effect = run_side_effect
+
+        result = get_stream_info_and_bitrate(
+            "http://example.com/test.m3u8",
+            duration=30,
+            timeout=30,
+            blank_check_enabled=True,
+            freeze_check_enabled=True,
+        )
+
+        self.assertEqual(result["bitrate_kbps"], 3333.3)
+        self.assertEqual(result["bitrate_source"], "ffmpeg_progress")
+        self.assertTrue(result["blank_probe_ran"])
+        self.assertFalse(result["blank_detected"])
+        self.assertTrue(result["freeze_probe_ran"])
+        self.assertFalse(result["freeze_detected"])
+        self.assertTrue(result["visual_probe_ran"])
+        self.assertFalse(result["visual_probe_completed"])
+        self.assertTrue(result["visual_probe_incomplete"])
+        self.assertEqual(result["visual_probe_incomplete_reason"], "timeout")
+        self.assertTrue(result["measurement_incomplete"])
 
 
 class TestBlankDetectionAnalysis(unittest.TestCase):

--- a/backend/tests/test_ffmpeg_hardware_acceleration.py
+++ b/backend/tests/test_ffmpeg_hardware_acceleration.py
@@ -366,6 +366,34 @@ class TestHardwareAccelerationFfmpegCommand(unittest.TestCase):
         self.assertIn("-hwaccel", first_command)
         self.assertNotIn("-hwaccel", second_command)
 
+    @patch.object(stream_check_utils.subprocess, "run")
+    def test_hwaccel_timeout_retries_without_hwaccel(self, mock_run):
+        mock_run.side_effect = [
+            subprocess.TimeoutExpired(cmd="ffmpeg", timeout=90),
+            Mock(stderr=_ffmpeg_output(), stdout="", returncode=0),
+        ]
+
+        result = get_stream_info_and_bitrate(
+            "http://example.com/test.m3u8",
+            duration=30,
+            timeout=30,
+            stream_startup_buffer=10,
+            hardware_acceleration={
+                "enabled": True,
+                "mode": "auto",
+                "allow_fallback": True,
+            },
+        )
+
+        self.assertEqual(result["status"], "OK")
+        self.assertEqual(result["bitrate_kbps"], 3333.3)
+        self.assertFalse(result["ffprobe_fallback_ran"])
+        self.assertEqual(mock_run.call_count, 2)
+        first_command = mock_run.call_args_list[0].args[0]
+        second_command = mock_run.call_args_list[1].args[0]
+        self.assertIn("-hwaccel", first_command)
+        self.assertNotIn("-hwaccel", second_command)
+
 
 class TestHardwareAccelerationAnalysis(unittest.TestCase):
     def test_analyze_stream_passes_hardware_config(self):

--- a/backend/tests/test_quality_reason_transparency.py
+++ b/backend/tests/test_quality_reason_transparency.py
@@ -103,6 +103,54 @@ def test_missing_bitrate_incomplete_fields_are_prepared_for_stream_stats_payload
     assert payload["stream_stats"]["bitrate_recheck_required"] is True
 
 
+def test_incomplete_bitrate_status_overrides_clean_completed_reason():
+    target = {
+        "status": "completed",
+        "quality_reason": "none",
+        "quality_reason_detail": "none",
+        "quality_reason_context": {},
+    }
+    source = {
+        "bitrate_kbps": None,
+        "measurement_incomplete": True,
+        "measurement_incomplete_reason": "missing_bitrate",
+        "measurement_incomplete_context": {
+            "bitrate_source": "ffprobe_media_fallback_no_bitrate",
+        },
+        "bitrate_recheck_required": True,
+    }
+
+    StreamCheckerService._apply_incomplete_bitrate_status(target, source)
+
+    assert target["status"] == "incomplete_bitrate"
+    assert target["reason_detail"] == "missing_bitrate"
+    assert target["quality_reason"] == "missing_bitrate"
+    assert target["quality_reason_detail"] == "missing_bitrate"
+    assert target["quality_reason_context"] == {
+        "bitrate_source": "ffprobe_media_fallback_no_bitrate",
+    }
+    assert target["measurement_incomplete"] is True
+    assert target["bitrate_recheck_required"] is True
+
+
+def test_incomplete_bitrate_counts_as_playable_but_not_clean_completed():
+    result = {
+        "checked_streams": [
+            {"status": "completed", "quality_reason_detail": "none"},
+            {
+                "status": "incomplete_bitrate",
+                "quality_reason_detail": "missing_bitrate",
+                "measurement_incomplete_reason": "missing_bitrate",
+            },
+            {"status": "completed", "quality_reason_detail": "bitrate_below_threshold"},
+            {"status": "completed", "blank_detected": True},
+            {"status": "dead"},
+        ],
+    }
+
+    assert StreamCheckerService._count_good_checked_streams(result) == 2
+
+
 def test_incomplete_bitrate_can_reuse_previous_value_for_scoring_without_persisting_null():
     service = object.__new__(StreamCheckerService)
     service.config = {"dead_stream_handling": {}}

--- a/backend/tests/test_quality_reason_transparency.py
+++ b/backend/tests/test_quality_reason_transparency.py
@@ -94,10 +94,43 @@ def test_missing_bitrate_incomplete_fields_are_prepared_for_stream_stats_payload
 
     payload = service._prepare_stream_stats_for_batch(stream_data)
 
-    assert payload["stream_stats"]["ffmpeg_output_bitrate"] is None
+    assert "ffmpeg_output_bitrate" not in payload["stream_stats"]
     assert payload["stream_stats"]["measurement_incomplete"] is True
     assert payload["stream_stats"]["measurement_incomplete_reason"] == "missing_bitrate"
     assert payload["stream_stats"]["measurement_incomplete_context"] == {
         "bitrate_source": "ffprobe_media_fallback_no_bitrate",
     }
+    assert payload["stream_stats"]["bitrate_recheck_required"] is True
+
+
+def test_incomplete_bitrate_can_reuse_previous_value_for_scoring_without_persisting_null():
+    service = object.__new__(StreamCheckerService)
+    service.config = {"dead_stream_handling": {}}
+    stream_data = {
+        "stream_id": 42,
+        "resolution": "3840x2160",
+        "fps": 60,
+        "video_codec": "hevc",
+        "audio_codec": "aac",
+        "bitrate_kbps": None,
+        "measurement_incomplete": True,
+        "measurement_incomplete_reason": "missing_bitrate",
+        "measurement_incomplete_context": {},
+        "bitrate_recheck_required": True,
+    }
+    existing_stream = {
+        "stream_stats": {
+            "ffmpeg_output_bitrate": 12000,
+        }
+    }
+
+    service._apply_previous_bitrate_fallback(stream_data, existing_stream)
+    score = service._calculate_stream_score(stream_data)
+    payload = service._prepare_stream_stats_for_batch(stream_data)
+
+    assert stream_data["scoring_bitrate_kbps"] == 12000
+    assert stream_data["bitrate_preserved_from_previous_measurement"] is True
+    assert score == 1.0
+    assert "ffmpeg_output_bitrate" not in payload["stream_stats"]
+    assert payload["stream_stats"]["measurement_incomplete"] is True
     assert payload["stream_stats"]["bitrate_recheck_required"] is True

--- a/backend/tests/test_stream_check_utils.py
+++ b/backend/tests/test_stream_check_utils.py
@@ -352,7 +352,7 @@ class TestGetStreamInfoAndBitrate(unittest.TestCase):
             ],
         }
         mock_run.side_effect = [
-            subprocess.TimeoutExpired(cmd='ffmpeg', timeout=70),
+            subprocess.TimeoutExpired(cmd='ffmpeg', timeout=90),
             MagicMock(returncode=0, stdout=json.dumps(ffprobe_payload), stderr=''),
         ]
 

--- a/backend/tests/test_stream_checker_queue_lifecycle.py
+++ b/backend/tests/test_stream_checker_queue_lifecycle.py
@@ -391,8 +391,8 @@ class TestStreamCheckQueueLifecycle(unittest.TestCase):
         eta_seconds = service._calculate_queue_eta_seconds(queue_status)
 
         self.assertGreaterEqual(eta_seconds, 7 * 3600)
-        self.assertEqual(queue_status['eta_stream_timeout_floor_seconds'], 70)
-        self.assertEqual(queue_status['eta_channel_floor_seconds'], 26460)
+        self.assertEqual(queue_status['eta_stream_timeout_floor_seconds'], 90)
+        self.assertEqual(queue_status['eta_channel_floor_seconds'], 34020)
         self.assertEqual(queue_status['eta_basis'], 'channel')
         self.assertEqual(queue_status['eta_basis_detail'], 'channel_floor')
 

--- a/backend/tests/test_udi_cache_sync_after_stats_update.py
+++ b/backend/tests/test_udi_cache_sync_after_stats_update.py
@@ -84,7 +84,11 @@ class TestUDICacheSyncAfterStatsUpdate(unittest.TestCase):
             'source_fps': 30,
             'video_codec': 'h265',
             'audio_codec': 'aac',
-            'ffmpeg_output_bitrate': 5000
+            'ffmpeg_output_bitrate': 5000,
+            'measurement_incomplete': False,
+            'measurement_incomplete_reason': 'none',
+            'measurement_incomplete_context': {},
+            'bitrate_recheck_required': False,
         }
         self.assertEqual(patch_payload['stream_stats'], expected_stats)
         

--- a/backend/tests/test_v6_job_history.py
+++ b/backend/tests/test_v6_job_history.py
@@ -1,12 +1,13 @@
 import json
+from datetime import datetime, timedelta
 
 from flask import Flask
 from werkzeug.datastructures import MultiDict
 
 from apps.api.telemetry_handlers import export_changelog_run_response, get_changelog_response
-from apps.database.models import Run
+from apps.database.models import ChannelHealth, Run, StreamTelemetry
 from apps.telemetry.run_classification import classify_run_metadata
-from apps.telemetry.telemetry_db import get_session, save_generic_telemetry
+from apps.telemetry.telemetry_db import _cleanup_old_telemetry, get_session, save_generic_telemetry
 
 
 def test_classify_single_channel_metadata():
@@ -74,6 +75,39 @@ def test_save_generic_telemetry_persists_v6_job_fields():
         assert run.job_outcome == "completed"
         assert run.job_subject_ref == "channel:456"
         assert run.job_correlation_id == "single-456"
+    finally:
+        session.close()
+
+
+def test_telemetry_cleanup_prunes_runs_older_than_retention_with_children():
+    session = get_session()
+    try:
+        old_run = Run(
+            timestamp=datetime.utcnow() - timedelta(days=8),
+            run_type="automation_run",
+        )
+        recent_run = Run(
+            timestamp=datetime.utcnow() - timedelta(days=1),
+            run_type="automation_run",
+        )
+        session.add_all([old_run, recent_run])
+        session.flush()
+        old_run_id = old_run.id
+        recent_run_id = recent_run.id
+        session.add(ChannelHealth(run_id=old_run_id, channel_id=10, channel_name="Old"))
+        session.add(StreamTelemetry(run_id=old_run_id, channel_id=10, stream_id=99, is_dead=False))
+        session.commit()
+    finally:
+        session.close()
+
+    assert _cleanup_old_telemetry(days=7) == 1
+
+    session = get_session()
+    try:
+        assert session.query(Run).filter(Run.id == old_run_id).first() is None
+        assert session.query(Run).filter(Run.id == recent_run_id).first() is not None
+        assert session.query(ChannelHealth).filter(ChannelHealth.run_id == old_run_id).count() == 0
+        assert session.query(StreamTelemetry).filter(StreamTelemetry.run_id == old_run_id).count() == 0
     finally:
         session.close()
 

--- a/frontend/src/lib/dashboard-run-counts.js
+++ b/frontend/src/lib/dashboard-run-counts.js
@@ -8,11 +8,14 @@ const countProgressStatus = (streams = [], status) => (
 
 const countGoodProgressStreams = (streams = []) => (
   streams.filter(stream => (
-    stream?.status === 'completed' &&
+    ['completed', 'incomplete_bitrate'].includes(stream?.status) &&
     stream?.blank_detected !== true &&
     stream?.freeze_detected !== true &&
     !['blank', 'freeze', 'low_quality', 'offline', 'unstable'].includes(stream?.dead_reason) &&
-    [undefined, null, '', 'none'].includes(stream?.quality_reason_detail)
+    (
+      stream?.status === 'incomplete_bitrate' ||
+      [undefined, null, '', 'none'].includes(stream?.quality_reason_detail)
+    )
   )).length
 )
 

--- a/frontend/src/lib/dashboard-run-counts.test.js
+++ b/frontend/src/lib/dashboard-run-counts.test.js
@@ -85,6 +85,28 @@ describe('dashboard run counts', () => {
     expect(counts.freeze).toBe(2)
   })
 
+  it('counts incomplete bitrate streams as playable during active quality checks', () => {
+    const counts = getDashboardRunCounts({
+      streamQueueActive: true,
+      batchTotal: 1,
+      completed: 0,
+      streamCheckerStatus: {
+        progress: {
+          streams_detail: [
+            { status: 'completed', quality_reason_detail: 'none' },
+            { status: 'incomplete_bitrate', quality_reason_detail: 'missing_bitrate' },
+            { status: 'completed', quality_reason_detail: 'bitrate_below_threshold' },
+          ],
+        },
+      },
+    })
+
+    expect(counts.good).toBe(2)
+    expect(counts.dead).toBe(0)
+    expect(counts.blank).toBe(0)
+    expect(counts.freeze).toBe(0)
+  })
+
   it('uses cumulative stream-checker queue problem counts while a batch is active', () => {
     const counts = getDashboardRunCounts({
       streamQueueActive: true,

--- a/frontend/src/lib/dashboard-run-display.js
+++ b/frontend/src/lib/dashboard-run-display.js
@@ -32,6 +32,8 @@ const SINGLE_CHANNEL_STATUS_STAGE = {
   cache_sync: 'cache_sync',
   stream_matching: 'stream_matching',
   matching: 'stream_matching',
+  analyzing: 'quality_checking',
+  analysis: 'quality_checking',
   quality_checking: 'quality_checking',
   checking: 'quality_checking',
   finalizing: 'finalizing',
@@ -55,17 +57,27 @@ const getSingleChannelStageId = (progress = {}) => {
   }
 
   const text = `${progress?.step || ''} ${progress?.step_detail || ''}`.toLowerCase()
+  const currentStream = Number(progress?.current_stream)
+  const totalStreams = Number(progress?.total_streams)
   if (text.includes('cache') || text.includes('udi')) {
     return 'cache_sync'
-  }
-  if (text.includes('m3u') || text.includes('playlist') || text.includes('provider')) {
-    return 'm3u_refresh'
   }
   if (text.includes('match') || text.includes('validating')) {
     return 'stream_matching'
   }
-  if (text.includes('quality') || text.includes('checking streams')) {
+  if (
+    text.includes('quality') ||
+    text.includes('analyz') ||
+    text.includes('checking streams') ||
+    text.includes('account limits') ||
+    Number.isFinite(currentStream) ||
+    Number.isFinite(totalStreams) ||
+    (Array.isArray(progress?.streams_detail) && progress.streams_detail.length > 0)
+  ) {
     return 'quality_checking'
+  }
+  if (text.includes('m3u') || text.includes('playlist') || text.includes('provider')) {
+    return 'm3u_refresh'
   }
   if (text.includes('final')) {
     return 'finalizing'

--- a/frontend/src/lib/dashboard-run-display.test.js
+++ b/frontend/src/lib/dashboard-run-display.test.js
@@ -254,6 +254,48 @@ describe('dashboard stream checker run display', () => {
     })
   })
 
+  it('maps single-channel provider-limit analysis as quality checking, not M3U refresh', () => {
+    const display = getStreamCheckerRunDisplay({
+      runState: 'queued',
+      runStage: 'm3u_refresh',
+      batchTotal: 0,
+      completed: 0,
+      now: Date.parse('2026-06-28T11:50:00Z'),
+      streamCheckerStatus: {
+        checking: true,
+        stream_checking_mode: true,
+        queue: {
+          state: 'idle',
+          queue_size: 0,
+          in_progress: 0,
+          completed: 0,
+        },
+        progress: {
+          is_single_channel_check: true,
+          status: 'analyzing',
+          step: 'Analyzing streams with provider account limits',
+          channel_name: 'FUSSBALL.TV 2',
+          current_stream: 26,
+          total_streams: 35,
+          timestamp: '2026-06-28T11:47:00Z',
+        },
+      },
+    })
+
+    expect(display.isProcessing).toBe(true)
+    expect(display.streamCheckerOnlyActive).toBe(true)
+    expect(display.streamQueueActive).toBe(false)
+    expect(display.displayMessage).toBe('Running single channel check')
+    expect(display.displayStageId).toBe('quality_checking')
+    expect(display.displayStageLabel).toBe('Quality Check')
+    expect(display.stageCards[0]).toMatchObject({
+      key: 'quality_checking',
+      label: 'Quality Check',
+      current: 26,
+      total: 35,
+    })
+  })
+
   it('ignores completed queue history when the stream checker is idle', () => {
     const display = getStreamCheckerRunDisplay({
       runState: 'skipped',

--- a/frontend/src/lib/quality-reason-display.js
+++ b/frontend/src/lib/quality-reason-display.js
@@ -5,6 +5,7 @@ const REASON_LABELS = {
   zero_resolution: 'No video resolution',
   zero_resolution_dimension: 'Invalid video resolution',
   zero_bitrate: 'No bitrate detected',
+  missing_bitrate: 'Needs bitrate recheck',
   resolution_width_below_threshold: 'Resolution width below threshold',
   resolution_height_below_threshold: 'Resolution height below threshold',
   bitrate_below_threshold: 'Bitrate below threshold',
@@ -39,6 +40,7 @@ const STATUS_REASON_FALLBACKS = {
   viewer_preempted: 'viewer_preempted',
   provider_limit_wait_timeout: 'provider_wait_timeout',
   waiting_provider_limit: 'provider_capacity_unavailable',
+  incomplete_bitrate: 'missing_bitrate',
   error: 'error',
 }
 

--- a/frontend/src/lib/quality-reason-display.test.js
+++ b/frontend/src/lib/quality-reason-display.test.js
@@ -18,6 +18,27 @@ describe('getQualityReasonDisplay', () => {
     expect(getQualityReasonDisplay({ quality_reason_detail: 'none' })).toBeNull()
   })
 
+  it('explains incomplete bitrate rows from status fallback', () => {
+    expect(getQualityReasonDisplay({
+      status: 'incomplete_bitrate',
+    })).toEqual({
+      code: 'missing_bitrate',
+      text: 'Needs bitrate recheck',
+      title: 'missing_bitrate',
+    })
+  })
+
+  it('explains incomplete bitrate rows even when the backend sends the reason detail explicitly', () => {
+    expect(getQualityReasonDisplay({
+      status: 'incomplete_bitrate',
+      quality_reason_detail: 'missing_bitrate',
+    })).toEqual({
+      code: 'missing_bitrate',
+      text: 'Needs bitrate recheck',
+      title: 'missing_bitrate',
+    })
+  })
+
   it('uses provider-capacity wording without leaking raw detail as primary text', () => {
     expect(getQualityReasonDisplay({
       reason_detail: 'provider_capacity_unavailable',

--- a/frontend/src/pages/StreamChecker.jsx
+++ b/frontend/src/pages/StreamChecker.jsx
@@ -895,8 +895,8 @@ export default function StreamChecker() {
               // normal analysis phase floats completed streams to top by score.
               const isLoopPhase = progress.step === 'Loop testing'
               const STATUS_ORDER = isLoopPhase
-                ? { probing: 0, loop_detected: 1, completed: 2, checking: 3, pending: 4, error: 5, low_quality: 6, blank: 7, freeze: 8, dead: 9 }
-                : { checking: 0, waiting_provider_limit: 1, pending: 2, completed: 3, viewer_preempted: 4, provider_limit_wait_timeout: 5, error: 6, low_quality: 7, blank: 8, freeze: 9, dead: 10 }
+                ? { probing: 0, loop_detected: 1, completed: 2, incomplete_bitrate: 3, checking: 4, pending: 5, error: 6, low_quality: 7, blank: 8, freeze: 9, dead: 10 }
+                : { checking: 0, waiting_provider_limit: 1, pending: 2, completed: 3, incomplete_bitrate: 4, viewer_preempted: 5, provider_limit_wait_timeout: 6, error: 7, low_quality: 8, blank: 9, freeze: 10, dead: 11 }
 
               // Dynamic height: sized to min(max_workers, stream count), floor 6 rows
               const maxWorkers = status?.parallel?.max_workers || 6
@@ -949,7 +949,7 @@ export default function StreamChecker() {
                             }
                           }
                           const qualityReason = getQualityReasonDisplay(stream)
-                          const showMeasuredSpecs = ['completed', 'loop_detected', 'low_quality', 'dead', 'blank', 'freeze'].includes(stream.status)
+                          const showMeasuredSpecs = ['completed', 'incomplete_bitrate', 'loop_detected', 'low_quality', 'dead', 'blank', 'freeze'].includes(stream.status)
                           const reservedProfileTitle = [
                             stream.reserved_profile_name ? `Profile: ${stream.reserved_profile_name}` : null,
                             stream.reserved_profile_id != null ? `ID: ${stream.reserved_profile_id}` : null,
@@ -988,6 +988,18 @@ export default function StreamChecker() {
                                 {stream.status === 'viewer_preempted' && <Badge variant="outline" className="text-[10px] border-cyan-500/40 bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300">Preempted</Badge>}
                                 {stream.status === 'provider_limit_wait_timeout' && <Badge variant="outline" className="text-[10px] text-muted-foreground">Skipped</Badge>}
                                 {stream.status === 'completed' && <Badge variant="outline" className="text-[10px] bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">Completed</Badge>}
+                                {stream.status === 'incomplete_bitrate' && (
+                                  <div className="mx-auto flex max-w-[180px] flex-col items-center gap-1" title={qualityReason?.title}>
+                                    <Badge variant="outline" className="text-[10px] border-amber-500/40 bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                                      Needs Recheck
+                                    </Badge>
+                                    {qualityReason && (
+                                      <span className="max-w-full truncate text-[10px] leading-tight text-amber-700 dark:text-amber-300">
+                                        {qualityReason.text}
+                                      </span>
+                                    )}
+                                  </div>
+                                )}
                                 {stream.status === 'error' && <Badge variant="destructive" className="text-[10px]">Error</Badge>}
                                 {stream.status === 'dead' && <Badge variant="destructive" className="text-[10px]">Dead</Badge>}
                                 {stream.status === 'blank' && <Badge variant="destructive" className="text-[10px]">Blank</Badge>}
@@ -1026,7 +1038,7 @@ export default function StreamChecker() {
                                 ) : '-'}
                               </td>
                               <td className="px-3 py-1.5 align-middle text-right text-xs font-mono">
-                                {(stream.status === 'completed' || stream.status === 'loop_detected') && stream.score !== undefined ? stream.score.toFixed(2) : '-'}
+                                {(['completed', 'incomplete_bitrate', 'loop_detected'].includes(stream.status)) && stream.score !== undefined ? stream.score.toFixed(2) : '-'}
                               </td>
                             </tr>
                           )


### PR DESCRIPTION
## Summary

This PR fixes unstable bitrate capture by splitting stream checking into two separate probe paths:

- a lightweight basis probe that measures media stats and bitrate with remux/copy
- a bounded visual probe that only runs blank/freeze detection and cannot mark a stream blank/frozen when the visual probe itself is incomplete

It also preserves the last known good bitrate when a current probe is media-valid but returns no bitrate, so a transient timeout no longer overwrites Dispatcharr stream stats with `null` and unfairly pushes otherwise good streams down the ranking. Changelog/telemetry retention is now pruned to 7 days, which is enough operational history and prevents the DB from growing forever.

## Root Cause

Some provider streams intermittently produced valid media metadata but no bitrate during the existing all-in-one ffmpeg probe. The checker then stored missing bitrate back into stats, so good streams could show `N/A` and score lower than weaker streams.

The old visual detection path was also coupled to the same expensive probe, so timeout pressure could blur together bitrate measurement, blank/freeze detection, and score persistence.

## Validation

Automated tests:

- `python -m pytest backend/tests/test_quality_reason_transparency.py backend/tests/test_stream_check_utils.py backend/tests/test_bitrate_detection.py backend/tests/test_udi_cache_sync_after_stats_update.py backend/tests/test_v6_job_history.py`
- Result: `44 passed`

Previous broader local gate on this branch:

- `127 passed`

Live Home-Unraid validation via normal DockerMan update path:

- Deployed `ghcr.io/bttfw/streamflow:split-visual-probes`
- Image revision: `cac5bb85d2d2499d980c568362e852c1d9d721ec`
- Health: `/api/health` healthy

Live single-channel checks:

- `FUSSBALL.TV 2`: completed successfully, exported changelog run `1832`, 33 completed stream rows, 0 completed-without-bitrate, 0 blank/freeze
- `FUSSBALL.TV 1`: completed successfully, exported changelog run `1834`, 34 completed stream rows, 0 completed-without-bitrate, 0 blank/freeze

Live full-run observation:

- Started a full stream checker queue with 231 channels
- Observed for 30 minutes
- Reached 13 completed channels / 0 failed
- Progress stayed non-stale
- Observed window had 0 completed-without-bitrate, 0 unexpected blank/freeze flags, 0 queue stalls
- The previously suspicious `Kabel eins Doku HD` area completed cleanly during the observed window

## Notes

- Missing bitrate is still surfaced as an incomplete/recheck condition when there is no previous good bitrate to preserve.
- Visual blank/freeze detection remains enabled, but incomplete visual probes are treated conservatively and do not create false blank/freeze results.
- The full run is intentionally long-running; the PR gate was the observed stability window, not waiting for the entire multi-hour queue to finish.
