### PR TITLE
Fix aborted scheduler runs and stale bitrate details

### DIFF
--- a/backend/apps/api/automation_handlers.py
+++ b/backend/apps/api/automation_handlers.py
@@ -369,6 +369,29 @@ def stop_automation_service_api_response(*, get_automation_manager: Callable[[],
         return jsonify({"error": "Internal Server Error"}), 500
 
 
+def abort_automation_run_api_response(*, get_automation_manager: Callable[[], Any]):
+    """Handle stop request for the active automation run without stopping the scheduler."""
+    try:
+        manager = get_automation_manager()
+        requested = bool(manager.request_active_run_stop())
+        return (
+            jsonify(
+                {
+                    "message": (
+                        "Active automation run stop requested"
+                        if requested
+                        else "No active automation run to stop"
+                    ),
+                    "stop_requested": requested,
+                }
+            ),
+            200,
+        )
+    except Exception as exc:
+        logger.error(f"Error aborting active automation run: {exc}")
+        return jsonify({"error": "Internal Server Error"}), 500
+
+
 def trigger_automation_cycle_response(*, payload: Optional[Dict[str, Any]], get_automation_manager: Callable[[], Any]):
     """Handle manual trigger of an automation cycle, optionally for a single period."""
     try:

--- a/backend/apps/api/web_api.py
+++ b/backend/apps/api/web_api.py
@@ -103,6 +103,7 @@ from apps.api.automation_handlers import (
     invalidate_automation_events_cache_response,
     remove_period_from_channels_response,
     remove_period_from_groups_response,
+    abort_automation_run_api_response,
     start_automation_service_api_response,
     stop_automation_service_api_response,
     trigger_automation_cycle_response,
@@ -1842,6 +1843,13 @@ def start_automation_service_api():
 def stop_automation_service_api():
     """Stop the automation background service."""
     return stop_automation_service_api_response(get_automation_manager=get_automation_manager)
+
+
+@app.route('/api/automation/abort-run', methods=['POST'])
+@log_function_call
+def abort_automation_run_api():
+    """Stop the active automation run without stopping the background scheduler."""
+    return abort_automation_run_api_response(get_automation_manager=get_automation_manager)
 
 
 @app.route('/api/automation/trigger', methods=['POST'])

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -2948,6 +2948,15 @@ class AutomatedStreamManager:
         )
         return "failed"
 
+    def _normalize_manual_cycle_abort(
+        self,
+        cycle_abort_message: Optional[str],
+    ) -> Tuple[Optional[str], bool]:
+        manual_stop_abort = self._is_manual_stop_requested()
+        if manual_stop_abort and not cycle_abort_message:
+            cycle_abort_message = self._manual_stop_message()
+        return cycle_abort_message, manual_stop_abort
+
     def _advance_period_run_timestamps(
         self,
         active_periods: Dict[Any, Dict[str, Any]],
@@ -6441,6 +6450,9 @@ class AutomatedStreamManager:
                 if playlists_refreshed
                 else "skipped"
             )
+            cycle_abort_message, manual_stop_abort = self._normalize_manual_cycle_abort(
+                cycle_abort_message
+            )
             run_job_outcome = (
                 "aborted"
                 if cycle_abort_message
@@ -6462,7 +6474,11 @@ class AutomatedStreamManager:
             if has_work and self.config.get("enabled_features", {}).get("changelog_tracking", True):
                 self.changelog.add_automation_run_entry(run_results)
             
-            self._advance_period_run_timestamps(active_periods, run_job_outcome)
+            self._advance_period_run_timestamps(
+                active_periods,
+                run_job_outcome,
+                manual_stop=manual_stop_abort,
+            )
 
             self._update_run_status(
                 counts={
@@ -6490,7 +6506,10 @@ class AutomatedStreamManager:
                 cycle_failed_message=cycle_failed_message,
                 refresh_degraded=refresh_degraded,
             )
-            
+            if manual_stop_abort:
+                self._manual_stop_requested.clear()
+                self._clear_persisted_manual_stop_request()
+
             if cycle_outcome == "completed":
                 logger.info("Automation cycle completed")
             elif cycle_outcome == "completed_degraded":

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -6585,7 +6585,6 @@ class AutomatedStreamManager:
         self._update_run_status(
             message="Stop requested; active automation run is shutting down",
         )
-        self.automation_wake_event.set()
         return True
             
     def start_automation(self):

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -2835,6 +2835,29 @@ class AutomatedStreamManager:
         )
         return "failed"
 
+    def _advance_period_run_timestamps(self, active_periods: Dict[Any, Dict[str, Any]], run_job_outcome: str) -> bool:
+        """Advance scheduler timers only for runs that successfully completed work."""
+        if not active_periods:
+            return False
+
+        if run_job_outcome not in {"completed", "completed_degraded"}:
+            logger.info(
+                "Not advancing automation period timers after %s run; next scheduler pass may retry",
+                run_job_outcome,
+            )
+            return False
+
+        now = datetime.now()
+        for p_id_tuple in active_periods.keys():
+            # active_periods keys are (p_id, p_name)
+            pid = p_id_tuple[0]
+            self.period_last_run[pid] = now
+
+        # Keep legacy last_playlist_update synced for legacy backward compatibility if any
+        self.last_playlist_update = now
+        self._save_state()
+        return True
+
     @staticmethod
     def _summarize_quality_check_results(check_results, expected_count: int) -> Dict[str, Any]:
         checked_count = len(check_results or {})
@@ -6204,16 +6227,7 @@ class AutomatedStreamManager:
             if has_work and self.config.get("enabled_features", {}).get("changelog_tracking", True):
                 self.changelog.add_automation_run_entry(run_results)
             
-            # Update last run times ONLY for periods that actually had work / were due
-            for p_id_tuple in active_periods.keys():
-                # active_periods keys are (p_id, p_name)
-                pid = p_id_tuple[0]
-                self.period_last_run[pid] = datetime.now()
-                
-            # Keep legacy last_playlist_update synced for legacy backward compatibility if any
-            if active_periods:
-                self.last_playlist_update = datetime.now()
-                self._save_state()
+            self._advance_period_run_timestamps(active_periods, run_job_outcome)
 
             self._update_run_status(
                 counts={
@@ -6320,6 +6334,23 @@ class AutomatedStreamManager:
             # If not running, we could potentially run it synchronously or just log warning.
             # But the requirement is likely to trigger the *service*.
             logger.warning("Automation service not running, manual trigger queueing for next run or ignored")
+
+    def request_active_run_stop(self) -> bool:
+        """Request that the current automation run abort without stopping the scheduler."""
+        self._ensure_run_status_fields()
+        with self._run_status_lock:
+            active_run = bool(
+                self._run_status.get("active") or self._run_status.get("state") == "running"
+            )
+        if not active_run:
+            return False
+
+        self._manual_stop_requested.set()
+        self._update_run_status(
+            message="Stop requested; active automation run is shutting down",
+        )
+        self.automation_wake_event.set()
+        return True
             
     def start_automation(self):
         """Start the automation background thread."""

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -89,6 +89,7 @@ from apps.core.api_utils import (
 
 # Import UDI for direct data access
 from apps.udi import get_udi_manager
+from apps.udi.fetcher import FetchCancelled
 from apps.stream.stale_status_snapshot import build_dispatcharr_stale_snapshot, build_stale_warnings
 from apps.automation.automation_config_manager import get_automation_config_manager
 from apps.automation.channel_visibility_automation import (
@@ -2220,6 +2221,9 @@ class AutomatedStreamManager:
                 message=f"Syncing stream cache{page_detail}",
             )
 
+        def cache_sync_cancelled() -> bool:
+            return self._is_manual_stop_requested()
+
         self._update_run_progress(
             stage_key="cache_sync",
             current=1,
@@ -2227,7 +2231,20 @@ class AutomatedStreamManager:
             message="Syncing stream cache",
         )
         try:
-            streams_success = bool(udi_manager.refresh_streams(progress_callback=update_stream_fetch_progress))
+            streams_success = bool(
+                udi_manager.refresh_streams(
+                    progress_callback=update_stream_fetch_progress,
+                    cancel_check=cache_sync_cancelled,
+                )
+            )
+        except FetchCancelled:
+            self._update_run_progress(
+                stage_key="cache_sync",
+                current=1,
+                total=progress_total,
+                message="Cache sync stopped by user",
+            )
+            raise
         except Exception as exc:
             logger.warning("UDI streams cache sync failed: %s", exc)
             streams_success = False
@@ -2857,10 +2874,20 @@ class AutomatedStreamManager:
             return True
         return False
 
-    def _abort_run_if_manual_stop_requested(self) -> bool:
+    def _abort_run_if_manual_stop_requested(
+        self,
+        *,
+        active_periods: Optional[Dict[Any, Dict[str, Any]]] = None,
+    ) -> bool:
         if not self._is_manual_stop_requested():
             return False
 
+        if active_periods:
+            self._advance_period_run_timestamps(
+                active_periods,
+                "aborted",
+                manual_stop=True,
+            )
         message = self._manual_stop_message()
         self._finish_run_status(
             state="aborted",
@@ -2921,12 +2948,21 @@ class AutomatedStreamManager:
         )
         return "failed"
 
-    def _advance_period_run_timestamps(self, active_periods: Dict[Any, Dict[str, Any]], run_job_outcome: str) -> bool:
-        """Advance scheduler timers only for runs that successfully completed work."""
+    def _advance_period_run_timestamps(
+        self,
+        active_periods: Dict[Any, Dict[str, Any]],
+        run_job_outcome: str,
+        *,
+        manual_stop: bool = False,
+    ) -> bool:
+        """Advance scheduler timers for completed runs and deliberate manual stops."""
         if not active_periods:
             return False
 
-        if run_job_outcome not in {"completed", "completed_degraded"}:
+        should_advance = run_job_outcome in {"completed", "completed_degraded"} or (
+            manual_stop and run_job_outcome == "aborted"
+        )
+        if not should_advance:
             logger.info(
                 "Not advancing automation period timers after %s run; next scheduler pass may retry",
                 run_job_outcome,
@@ -5408,7 +5444,7 @@ class AutomatedStreamManager:
             )
             logger.info(f"Processing {channels_with_periods} channel assignments across {len(active_periods)} active period(s)")
             logger.info(f"UDI cache {udi.get_cache_age_description()}")
-            if self._abort_run_if_manual_stop_requested():
+            if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                 return
             
             # Determine playlists to update
@@ -5649,7 +5685,7 @@ class AutomatedStreamManager:
                     else "Current cache selected for stream matching"
                 ),
             )
-            if self._abort_run_if_manual_stop_requested():
+            if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                 return
 
             validation_details = []
@@ -5670,7 +5706,7 @@ class AutomatedStreamManager:
                     durations={"m3u_refresh_seconds": time.time() - m3u_refresh_started},
                     message=wait_result.get("message", "Playlist refresh wait completed"),
                 )
-                if self._abort_run_if_manual_stop_requested():
+                if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                     return
                 if not wait_result.get("ok"):
                     cycle_abort_message = wait_result.get("message") or "Playlist refresh did not settle"
@@ -5727,6 +5763,10 @@ class AutomatedStreamManager:
                             "UDI cache sync after provider refresh reported warnings - "
                             "proceeding with available cache"
                         )
+                except FetchCancelled:
+                    if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
+                        return
+                    raise
                 except Exception as _sync_err:
                     logger.warning(
                         f"UDI sync after provider refresh failed: {_sync_err} — "
@@ -5831,9 +5871,9 @@ class AutomatedStreamManager:
                     stage="cache_sync" if refresh_success else "aborted",
                     stage_label="Syncing Cache" if refresh_success else "Aborted",
                 )
-                if self._abort_run_if_manual_stop_requested():
+                if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                     return
-            
+
             if refresh_success:
                 if channels_to_quality_check:
                     try:
@@ -5868,9 +5908,9 @@ class AutomatedStreamManager:
                         f"Waiting {post_refresh_delay:.2f}s after playlist refresh before stream matching"
                     )
                     if self._manual_stop_requested.wait(timeout=post_refresh_delay):
-                        if self._abort_run_if_manual_stop_requested():
+                        if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                             return
-                
+
                 # 4. Stream Matching (Validation & Assignment)
                 # Group results by channel for easier joining later
                 matching_started = time.time()
@@ -5884,11 +5924,11 @@ class AutomatedStreamManager:
                 try:
                     val_res = self.validate_and_remove_non_matching_streams(force=forced, forced_period_id=forced_period_id, skip_changelog=True)
                     validation_details = val_res.get("details", [])
-                    if val_res.get("aborted") or self._abort_run_if_manual_stop_requested():
+                    if val_res.get("aborted") or self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                         return
                 except Exception as e:
                     logger.error(f"✗ Failed to validate streams: {e}")
-                if self._abort_run_if_manual_stop_requested():
+                if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                     return
 
                 # Discover and assign new streams
@@ -5897,13 +5937,13 @@ class AutomatedStreamManager:
                     assignment_details = assign_res.get("assignment_details", [])
                     assigned_stream_ids = assign_res.get("assigned_stream_ids", {})
                     channel_visibility_events.extend(assign_res.get("channel_visibility_events", []) or [])
-                    if assign_res.get("aborted") or self._abort_run_if_manual_stop_requested():
+                    if assign_res.get("aborted") or self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                         return
                 except Exception as e:
                     logger.error(f"✗ Failed to assign streams: {e}")
                     assigned_stream_ids = {}
 
-                if self._abort_run_if_manual_stop_requested():
+                if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                     return
 
                 visibility_summary = self._summarize_channel_visibility_events(channel_visibility_events)
@@ -5919,7 +5959,7 @@ class AutomatedStreamManager:
 
                 # 4.5. Trigger Quality Checks for all channels in the period(s)
                 if channels_to_quality_check:
-                    if self._abort_run_if_manual_stop_requested():
+                    if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                         return
                     quality_stage_started = time.time()
                     self._update_run_status(
@@ -5946,7 +5986,7 @@ class AutomatedStreamManager:
                         _target_stream_ids = {}
 
                         for ch_id in channels_to_quality_check:
-                            if self._abort_run_if_manual_stop_requested():
+                            if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                                 return
                             # Normalise ch_id to int for all lookups. channels_to_quality_check
                             # may contain mixed int/str entries if populated from multiple sources.
@@ -6057,7 +6097,7 @@ class AutomatedStreamManager:
                                 progress_callback=_quality_progress_callback,
                                 run_mode="automation_quality_check",
                             )
-                            if self._abort_run_if_manual_stop_requested():
+                            if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                                 return
                             self._update_run_progress(
                                 stage_key="quality_checking",

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -6651,6 +6651,7 @@ class AutomatedStreamManager:
                 # Reset forced flags before running
                 self.force_next_run = False
                 self.forced_period_id = None
+                self.automation_wake_event.clear()
                 
                 self.run_automation_cycle(forced=forced, forced_period_id=period_id)
                 

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -2957,6 +2957,20 @@ class AutomatedStreamManager:
             cycle_abort_message = self._manual_stop_message()
         return cycle_abort_message, manual_stop_abort
 
+    def _handle_child_stage_abort(
+        self,
+        result: Optional[Dict[str, Any]],
+        active_periods: Dict[Any, Dict[str, Any]],
+        fallback_message: str,
+    ) -> Tuple[Optional[str], bool]:
+        if not isinstance(result, dict) or not result.get("aborted"):
+            return None, False
+
+        if self._abort_run_if_manual_stop_requested(active_periods=active_periods):
+            return None, True
+
+        return result.get("error") or fallback_message, False
+
     def _advance_period_run_timestamps(
         self,
         active_periods: Dict[Any, Dict[str, Any]],
@@ -5933,7 +5947,17 @@ class AutomatedStreamManager:
                 try:
                     val_res = self.validate_and_remove_non_matching_streams(force=forced, forced_period_id=forced_period_id, skip_changelog=True)
                     validation_details = val_res.get("details", [])
-                    if val_res.get("aborted") or self._abort_run_if_manual_stop_requested(active_periods=active_periods):
+                    child_abort_message, child_abort_handled = self._handle_child_stage_abort(
+                        val_res,
+                        active_periods,
+                        "Stream validation aborted",
+                    )
+                    if child_abort_handled:
+                        return
+                    if child_abort_message:
+                        cycle_abort_message = child_abort_message
+                        refresh_success = False
+                    elif self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                         return
                 except Exception as e:
                     logger.error(f"✗ Failed to validate streams: {e}")
@@ -5946,7 +5970,17 @@ class AutomatedStreamManager:
                     assignment_details = assign_res.get("assignment_details", [])
                     assigned_stream_ids = assign_res.get("assigned_stream_ids", {})
                     channel_visibility_events.extend(assign_res.get("channel_visibility_events", []) or [])
-                    if assign_res.get("aborted") or self._abort_run_if_manual_stop_requested(active_periods=active_periods):
+                    child_abort_message, child_abort_handled = self._handle_child_stage_abort(
+                        assign_res,
+                        active_periods,
+                        "Stream discovery aborted",
+                    )
+                    if child_abort_handled:
+                        return
+                    if child_abort_message:
+                        cycle_abort_message = child_abort_message
+                        refresh_success = False
+                    elif self._abort_run_if_manual_stop_requested(active_periods=active_periods):
                         return
                 except Exception as e:
                     logger.error(f"✗ Failed to assign streams: {e}")

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -2545,6 +2545,31 @@ class AutomatedStreamManager:
         retry_accepted_count = 0
 
         while True:
+            if self._is_manual_stop_requested():
+                message = self._manual_stop_message()
+                elapsed = int(time.time() - started)
+                if progress_callback:
+                    progress_callback({
+                        "state": "aborted",
+                        "current": 0,
+                        "total": 1,
+                        "message": message,
+                        "wait_elapsed_seconds": elapsed,
+                        "wait_stable_polls": stable_polls,
+                        "wait_busy_accounts": last_snapshot.get("busy_count"),
+                        "wait_streams_seen": last_snapshot.get("stream_count"),
+                        "wait_failed_accounts": last_snapshot.get("failed_count"),
+                        "wait_retry_count": retry_accepted_count,
+                    })
+                return {
+                    "ok": False,
+                    "state": "aborted",
+                    "message": message,
+                    "snapshot": last_snapshot,
+                    "elapsed_seconds": elapsed,
+                    "retry_accepted_count": retry_accepted_count,
+                }
+
             snapshot = self._build_m3u_refresh_monitor_snapshot(udi_manager, target_account_ids)
             last_snapshot = snapshot
             elapsed = int(time.time() - started)
@@ -2616,7 +2641,7 @@ class AutomatedStreamManager:
                 last_signature = None
                 sleep_for = min(poll_interval, max(0.0, deadline - time.time()))
                 if sleep_for > 0:
-                    time.sleep(sleep_for)
+                    self._manual_stop_requested.wait(timeout=sleep_for)
                 continue
 
             if all_monitored_accounts_failed:
@@ -2684,7 +2709,7 @@ class AutomatedStreamManager:
 
             sleep_for = min(poll_interval, max(0.0, deadline - time.time()))
             if sleep_for > 0:
-                time.sleep(sleep_for)
+                self._manual_stop_requested.wait(timeout=sleep_for)
 
     def _finish_run_status(
         self,

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -1360,6 +1360,7 @@ class AutomatedStreamManager:
     RUN_SNAPSHOT_SETTINGS_KEY = "streamflow_run_snapshot_settings"
     RUN_SNAPSHOT_DEFAULT_MAX_BYTES = 50 * 1024
     RUN_SNAPSHOT_DEFAULT_RETENTION = 50
+    MANUAL_STOP_REQUEST_KEY = "automation_manual_stop_request"
     
     def __init__(self, config_file=None):
         self._explicit_config_file = config_file is not None
@@ -1986,6 +1987,7 @@ class AutomatedStreamManager:
     def _start_run_status(self, *, forced: bool = False, forced_period_id: Optional[str] = None) -> None:
         self._ensure_run_status_fields()
         self._manual_stop_requested.clear()
+        self._clear_persisted_manual_stop_request()
         with self._run_status_lock:
             self._run_sequence += 1
             run_id = f"automation-{int(time.time())}-{self._run_sequence}"
@@ -2793,9 +2795,67 @@ class AutomatedStreamManager:
     def _manual_stop_message(self) -> str:
         return "Automation run was stopped by the user"
 
+    def _current_run_id(self) -> Optional[str]:
+        self._ensure_run_status_fields()
+        with self._run_status_lock:
+            run_id = self._run_status.get("run_id")
+        return str(run_id) if run_id else None
+
+    def _persist_manual_stop_request(self) -> None:
+        try:
+            from apps.database.manager import get_db_manager
+
+            get_db_manager().set_system_setting(
+                self.MANUAL_STOP_REQUEST_KEY,
+                {
+                    "run_id": self._current_run_id(),
+                    "all_active": True,
+                    "requested_at": datetime.now().isoformat(),
+                },
+            )
+        except Exception as exc:
+            logger.debug(f"Could not persist automation stop request: {exc}")
+
+    def _clear_persisted_manual_stop_request(self) -> None:
+        try:
+            from apps.database.manager import get_db_manager
+
+            get_db_manager().set_system_setting(self.MANUAL_STOP_REQUEST_KEY, None)
+        except Exception as exc:
+            logger.debug(f"Could not clear automation stop request: {exc}")
+
+    def _persisted_manual_stop_matches_current_run(self) -> bool:
+        try:
+            from apps.database.manager import get_db_manager
+
+            request = get_db_manager().get_system_setting(self.MANUAL_STOP_REQUEST_KEY, None)
+        except Exception as exc:
+            logger.debug(f"Could not read automation stop request: {exc}")
+            return False
+
+        if not isinstance(request, dict):
+            return False
+
+        self._ensure_run_status_fields()
+        with self._run_status_lock:
+            current_run_id = self._run_status.get("run_id")
+            active_run = bool(
+                self._run_status.get("active") or self._run_status.get("state") == "running"
+            )
+
+        requested_run_id = request.get("run_id")
+        if requested_run_id and current_run_id and str(requested_run_id) == str(current_run_id):
+            return True
+        return bool(request.get("all_active") and active_run)
+
     def _is_manual_stop_requested(self) -> bool:
         self._ensure_run_status_fields()
-        return self._manual_stop_requested.is_set()
+        if self._manual_stop_requested.is_set():
+            return True
+        if self._persisted_manual_stop_matches_current_run():
+            self._manual_stop_requested.set()
+            return True
+        return False
 
     def _abort_run_if_manual_stop_requested(self) -> bool:
         if not self._is_manual_stop_requested():
@@ -2810,6 +2870,7 @@ class AutomatedStreamManager:
             error=message,
         )
         self._manual_stop_requested.clear()
+        self._clear_persisted_manual_stop_request()
         return True
 
     def _finish_cycle_outcome(
@@ -6479,6 +6540,7 @@ class AutomatedStreamManager:
         if not active_run:
             return False
 
+        self._persist_manual_stop_request()
         self._manual_stop_requested.set()
         self._update_run_status(
             message="Stop requested; active automation run is shutting down",
@@ -6513,6 +6575,7 @@ class AutomatedStreamManager:
             )
         if active_run:
             self._manual_stop_requested.set()
+            self._persist_manual_stop_request()
             self._update_run_status(
                 message="Stop requested; automation is shutting down",
             )

--- a/backend/apps/automation/automated_stream_manager.py
+++ b/backend/apps/automation/automated_stream_manager.py
@@ -4145,6 +4145,24 @@ class AutomatedStreamManager:
                 total=total_streams,
                 message=f"Matching 0/{total_streams} streams",
             )
+            if self._is_manual_stop_requested():
+                message = self._manual_stop_message()
+                logger.info("Stream matching skipped because the automation run stop was requested")
+                self._update_run_progress(
+                    stage_key="stream_matching",
+                    current=0,
+                    total=total_streams,
+                    message=message,
+                )
+                return {
+                    "assignment_count": {},
+                    "assignment_details": [],
+                    "assigned_stream_ids": {},
+                    "channel_visibility_events": channel_visibility_events,
+                    "aborted": True,
+                    "success": False,
+                    "error": message,
+                }
             
             # Resolve dead stream removal setting.
             # When the caller provides allow_dead_streams explicitly (e.g. check_single_channel
@@ -4161,8 +4179,10 @@ class AutomatedStreamManager:
             completed_count = 0
             last_log_pct = -1
             
-            # Process batches in parallel
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            aborted = False
+            future_to_batch = {}
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+            try:
                 future_to_batch = {
                     executor.submit(self._match_streams_batch, batch, channel_streams, 
                                    dead_stream_removal_enabled,
@@ -4171,8 +4191,14 @@ class AutomatedStreamManager:
                 }
                 
                 for future in concurrent.futures.as_completed(future_to_batch):
+                    if self._is_manual_stop_requested():
+                        aborted = True
+                        break
                     try:
                         batch_assignments, batch_details = future.result()
+                        if self._is_manual_stop_requested():
+                            aborted = True
+                            break
                         
                         # Merge results
                         for channel_id, stream_ids in batch_assignments.items():
@@ -4198,6 +4224,34 @@ class AutomatedStreamManager:
                              
                     except Exception as e:
                         logger.error(f"Error in stream matching batch: {e}")
+            finally:
+                if aborted:
+                    for pending in future_to_batch:
+                        pending.cancel()
+                    executor.shutdown(wait=False, cancel_futures=True)
+                else:
+                    executor.shutdown(wait=True)
+
+            if aborted:
+                message = self._manual_stop_message()
+                logger.info(
+                    f"Stream matching aborted after {completed_count}/{total_streams} streams"
+                )
+                self._update_run_progress(
+                    stage_key="stream_matching",
+                    current=completed_count,
+                    total=total_streams,
+                    message=message,
+                )
+                return {
+                    "assignment_count": {},
+                    "assignment_details": [],
+                    "assigned_stream_ids": {},
+                    "channel_visibility_events": channel_visibility_events,
+                    "aborted": True,
+                    "success": False,
+                    "error": message,
+                }
             
             logger.info(f"✓ Completed processing {total_streams} streams. Found {sum(len(s) for s in assignments.values())} new stream assignments across {len(assignments)} channels")
             
@@ -4608,7 +4662,10 @@ class AutomatedStreamManager:
             
             completed_count = 0
             
-            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            aborted = False
+            future_to_batch = {}
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+            try:
                 future_to_batch = {
                     executor.submit(self._validate_channels_batch, batch, stream_lookup,
                                     matching_enabled_channel_ids, channel_validation_settings,
@@ -4617,13 +4674,22 @@ class AutomatedStreamManager:
                 }
                 
                 for future in concurrent.futures.as_completed(future_to_batch):
+                    if self._is_manual_stop_requested():
+                        aborted = True
+                        break
                     try:
                         batch_results = future.result()
+                        if self._is_manual_stop_requested():
+                            aborted = True
+                            break
                         
                         validation_results["channels_checked"] += batch_results["channels_checked"]
                         
                         # Process results and update UDI if needed
                         for detail in batch_results.get("details", []):
+                            if self._is_manual_stop_requested():
+                                aborted = True
+                                break
                             channel_id = detail["channel_id"]
                             channel_name = detail["channel_name"]
                             kept_ids = detail["kept_ids"]
@@ -4664,6 +4730,25 @@ class AutomatedStreamManager:
 
                     except Exception as e:
                         logger.error(f"Error in channel validation batch: {e}")
+                    if aborted:
+                        break
+            finally:
+                if aborted:
+                    for pending in future_to_batch:
+                        pending.cancel()
+                    executor.shutdown(wait=False, cancel_futures=True)
+                else:
+                    executor.shutdown(wait=True)
+
+            if aborted:
+                validation_results["aborted"] = True
+                validation_results["success"] = False
+                validation_results["error"] = self._manual_stop_message()
+                logger.info(
+                    "Stream validation aborted after checking "
+                    f"{validation_results['channels_checked']} channel(s)"
+                )
+                return validation_results
             
             logger.info(f"Stream validation completed: Checked {validation_results['channels_checked']} channels, " +
                        f"removed {validation_results['streams_removed']} streams from {validation_results['channels_modified']} channels")
@@ -5721,7 +5806,9 @@ class AutomatedStreamManager:
                     logger.info(
                         f"Waiting {post_refresh_delay:.2f}s after playlist refresh before stream matching"
                     )
-                    time.sleep(post_refresh_delay)
+                    if self._manual_stop_requested.wait(timeout=post_refresh_delay):
+                        if self._abort_run_if_manual_stop_requested():
+                            return
                 
                 # 4. Stream Matching (Validation & Assignment)
                 # Group results by channel for easier joining later
@@ -5736,18 +5823,27 @@ class AutomatedStreamManager:
                 try:
                     val_res = self.validate_and_remove_non_matching_streams(force=forced, forced_period_id=forced_period_id, skip_changelog=True)
                     validation_details = val_res.get("details", [])
+                    if val_res.get("aborted") or self._abort_run_if_manual_stop_requested():
+                        return
                 except Exception as e:
                     logger.error(f"✗ Failed to validate streams: {e}")
-                
+                if self._abort_run_if_manual_stop_requested():
+                    return
+
                 # Discover and assign new streams
                 try:
                     assign_res = self.discover_and_assign_streams(force=forced, skip_check_trigger=True, forced_period_id=forced_period_id, skip_changelog=True)
                     assignment_details = assign_res.get("assignment_details", [])
                     assigned_stream_ids = assign_res.get("assigned_stream_ids", {})
                     channel_visibility_events.extend(assign_res.get("channel_visibility_events", []) or [])
+                    if assign_res.get("aborted") or self._abort_run_if_manual_stop_requested():
+                        return
                 except Exception as e:
                     logger.error(f"✗ Failed to assign streams: {e}")
                     assigned_stream_ids = {}
+
+                if self._abort_run_if_manual_stop_requested():
+                    return
 
                 visibility_summary = self._summarize_channel_visibility_events(channel_visibility_events)
                 self._update_run_status(
@@ -5762,6 +5858,8 @@ class AutomatedStreamManager:
 
                 # 4.5. Trigger Quality Checks for all channels in the period(s)
                 if channels_to_quality_check:
+                    if self._abort_run_if_manual_stop_requested():
+                        return
                     quality_stage_started = time.time()
                     self._update_run_status(
                         stage="quality_queueing",
@@ -5787,6 +5885,8 @@ class AutomatedStreamManager:
                         _target_stream_ids = {}
 
                         for ch_id in channels_to_quality_check:
+                            if self._abort_run_if_manual_stop_requested():
+                                return
                             # Normalise ch_id to int for all lookups. channels_to_quality_check
                             # may contain mixed int/str entries if populated from multiple sources.
                             _ch_id_int = int(ch_id)
@@ -5858,6 +5958,11 @@ class AutomatedStreamManager:
                         # Run checks synchronously and collect results
                         if channels_to_check_sync:
                             def _quality_progress_callback(completed_count, total_count, channel_result):
+                                if self._is_manual_stop_requested():
+                                    try:
+                                        stream_checker.abort_current_check.set()
+                                    except Exception:
+                                        pass
                                 channel_name = ""
                                 if isinstance(channel_result, dict):
                                     channel_name = channel_result.get("channel_name") or ""
@@ -5882,6 +5987,8 @@ class AutomatedStreamManager:
                                 },
                             )
                             target_stream_ids = _target_stream_ids if _target_stream_ids else None
+                            if self._is_manual_stop_requested():
+                                stream_checker.abort_current_check.set()
                             check_results = stream_checker.check_channels_synchronously(
                                 channel_ids=channels_to_check_sync,
                                 force_check=forced,
@@ -5889,6 +5996,8 @@ class AutomatedStreamManager:
                                 progress_callback=_quality_progress_callback,
                                 run_mode="automation_quality_check",
                             )
+                            if self._abort_run_if_manual_stop_requested():
+                                return
                             self._update_run_progress(
                                 stage_key="quality_checking",
                                 current=len(check_results),

--- a/backend/apps/automation/automation_events_scheduler.py
+++ b/backend/apps/automation/automation_events_scheduler.py
@@ -7,6 +7,7 @@ Cache is invalidated when automation periods are modified.
 """
 
 import json
+import sys
 import threading
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional, Any
@@ -174,9 +175,15 @@ class AutomationEventsScheduler:
             # Try to align the schedule track with the *actual* last run time for this period
             base_time = current_time
             try:
-                from web_api import get_automation_manager
-                manager = get_automation_manager()
-                last_run = manager.period_last_run.get(period_id)
+                manager = None
+                for module_name in ("apps.api.web_api", "web_api", "__main__"):
+                    module = sys.modules.get(module_name)
+                    manager_factory = getattr(module, "get_automation_manager", None) if module else None
+                    if callable(manager_factory):
+                        manager = manager_factory()
+                        break
+
+                last_run = manager.period_last_run.get(period_id) if manager else None
                 if last_run:
                     if isinstance(last_run, datetime):
                         base_time = last_run

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -1557,6 +1557,16 @@ class StreamCheckerService:
         context.setdefault("preserved_bitrate_source", "previous_stream_stats")
         analyzed["measurement_incomplete_context"] = context
 
+    @staticmethod
+    def _current_probe_stats_source(
+        stream_data: Optional[Dict[str, Any]],
+        analyzed: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Return current probe stats when present, avoiding stale cache display."""
+        if isinstance(analyzed, dict):
+            return analyzed
+        return stream_data if isinstance(stream_data, dict) else {}
+
     @classmethod
     def _has_incomplete_bitrate_measurement(cls, stream_data: Optional[Dict[str, Any]]) -> bool:
         if not isinstance(stream_data, dict):
@@ -7048,8 +7058,11 @@ class StreamCheckerService:
                 reverse=True
             )
             for stream in streams_sorted:
+                analyzed = analyzed_lookup.get(stream.get('id'))
+
                 # Extract stats using centralized utility
-                extracted_stats = extract_stream_stats(stream)
+                detail_stats_source = self._current_probe_stats_source(stream, analyzed)
+                extracted_stats = extract_stream_stats(detail_stats_source)
                 formatted_stats = format_stream_stats_for_display(extracted_stats)
                 
                 # Calculate score for this stream using its stats
@@ -7085,7 +7098,6 @@ class StreamCheckerService:
                 # settings at the time of the check. Recalculate only as a fallback
                 # for streams not present in the lookup (e.g. pre-existing streams
                 # not re-analyzed in this run).
-                analyzed = analyzed_lookup.get(stream.get('id'))
                 if analyzed and analyzed.get('score') is not None:
                     score = analyzed.get('score')
                 else:

--- a/backend/apps/udi/fetcher.py
+++ b/backend/apps/udi/fetcher.py
@@ -73,6 +73,10 @@ class FetchResult:
         return self.items[index]
 
 
+class FetchCancelled(Exception):
+    """Raised when a long Dispatcharr fetch is cancelled by the caller."""
+
+
 class UDIFetcher:
     """Fetches data from the Dispatcharr API for the UDI system."""
     
@@ -427,6 +431,7 @@ class UDIFetcher:
         page_size: int = 1000,
         max_workers: int = 10,
         progress_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
     ) -> FetchResult:
         """Fetch paginated data from an API endpoint.
 
@@ -454,11 +459,17 @@ class UDIFetcher:
         page_size = max(1, page_size)
         max_workers = max(1, max_workers)
 
+        def raise_if_cancelled() -> None:
+            if cancel_check and cancel_check():
+                raise FetchCancelled("Paginated fetch cancelled")
+
         # Include page=1 explicitly so ChannelPagination does not short-circuit
         # into bare-list mode (it disables pagination when no 'page' param is
         # present, which drops the DRF count/results envelope).
         query_joiner = '&' if '?' in base_url else '?'
+        raise_if_cancelled()
         response = self._fetch_url(f"{base_url}{query_joiner}page_size={page_size}&page=1")
+        raise_if_cancelled()
         if not response:
             return FetchResult()
 
@@ -491,6 +502,7 @@ class UDIFetcher:
                     "items_fetched": items_fetched,
                     "expected_count": expected_count,
                 })
+            raise_if_cancelled()
             return FetchResult(items=all_items, expected_count=expected_count)
 
         total_pages = math.ceil(expected_count / page_size)
@@ -501,6 +513,7 @@ class UDIFetcher:
                 "items_fetched": items_fetched,
                 "expected_count": expected_count,
             })
+        raise_if_cancelled()
         remaining = range(2, total_pages + 1)
         logger.debug(
             f"Fetching {total_pages - 1} remaining pages of {base_url} concurrently "
@@ -510,18 +523,22 @@ class UDIFetcher:
         # Fetch remaining pages concurrently. Auth retries inside _fetch_url are
         # serialised by _token_refresh_lock so 401 bursts are safe.
         page_results: Dict[int, List] = {}
-        with ThreadPoolExecutor(max_workers=min(max_workers, len(remaining))) as executor:
-            future_to_page = {
-                executor.submit(
+        executor = ThreadPoolExecutor(max_workers=min(max_workers, len(remaining)))
+        future_to_page = {}
+        try:
+            for p in remaining:
+                raise_if_cancelled()
+                future = executor.submit(
                     self._fetch_url,
                     f"{base_url}{query_joiner}page_size={page_size}&page={p}",
-                ): p
-                for p in remaining
-            }
+                )
+                future_to_page[future] = p
             for future in as_completed(future_to_page):
+                raise_if_cancelled()
                 page_num = future_to_page[future]
                 try:
                     result = future.result()
+                    raise_if_cancelled()
                     if result and isinstance(result, dict) and 'results' in result:
                         page_results[page_num] = result['results']
                         items_fetched += len(result['results'])
@@ -538,6 +555,17 @@ class UDIFetcher:
                         "items_fetched": items_fetched,
                         "expected_count": expected_count,
                     })
+                raise_if_cancelled()
+        except FetchCancelled:
+            for future in future_to_page:
+                future.cancel()
+            try:
+                executor.shutdown(wait=False, cancel_futures=True)
+            except TypeError:
+                executor.shutdown(wait=False)
+            raise
+        else:
+            executor.shutdown(wait=True)
 
         # Merge pages in page-number order so item ordering is deterministic.
         for page_num in sorted(page_results):
@@ -597,6 +625,7 @@ class UDIFetcher:
     def fetch_streams(
         self,
         progress_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
     ) -> FetchResult:
         """Fetch all streams from Dispatcharr.
         
@@ -614,6 +643,8 @@ class UDIFetcher:
         fetch_kwargs = {"page_size": page_size, "max_workers": max_workers}
         if progress_callback is not None:
             fetch_kwargs["progress_callback"] = progress_callback
+        if cancel_check is not None:
+            fetch_kwargs["cancel_check"] = cancel_check
         result = self._fetch_paginated(url, **fetch_kwargs)
         logger.info(
             f"Fetched {len(result)} streams"

--- a/backend/apps/udi/manager.py
+++ b/backend/apps/udi/manager.py
@@ -33,7 +33,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Set, Tuple
 
-from apps.udi.fetcher import UDIFetcher, FetchResult
+from apps.udi.fetcher import UDIFetcher, FetchResult, FetchCancelled
 from apps.udi.cache import UDICache
 from apps.udi.storage import UDIStorage
 from apps.core.auth import _get_auth_headers
@@ -1681,7 +1681,7 @@ class UDIManager:
             logger.error(f"Error refreshing channel {channel_id}: {e}")
             return False
     
-    def refresh_streams(self, progress_callback=None) -> bool:
+    def refresh_streams(self, progress_callback=None, cancel_check=None) -> bool:
         """Refresh only streams data.
         
         Returns:
@@ -1689,7 +1689,10 @@ class UDIManager:
         """
         logger.info("Refreshing streams...")
         try:
-            result = self.fetcher.fetch_streams(progress_callback=progress_callback)
+            result = self.fetcher.fetch_streams(
+                progress_callback=progress_callback,
+                cancel_check=cancel_check,
+            )
             existing_stream_count = len(self._streams_cache)
             if not (
                 _check_fetch_integrity('streams', result)
@@ -1721,6 +1724,9 @@ class UDIManager:
                 self._has_custom_streams = any(st.get('is_custom', False) for st in result.items)
             self.cache.mark_refreshed('streams')
             return True
+        except FetchCancelled:
+            logger.info("Stream cache refresh cancelled")
+            raise
         except Exception as e:
             logger.error(f"Error refreshing streams: {e}")
             return False

--- a/backend/tests/test_dispatcharr_fetch_pressure_config.py
+++ b/backend/tests/test_dispatcharr_fetch_pressure_config.py
@@ -194,6 +194,74 @@ def test_fetch_streams_forwards_progress_callback(monkeypatch):
     callback.assert_called_once_with({"completed_pages": 1, "total_pages": 2})
 
 
+def test_fetch_streams_forwards_cancel_check(monkeypatch):
+    from apps.udi import fetcher as fetcher_module
+
+    fetcher = fetcher_module.UDIFetcher.__new__(fetcher_module.UDIFetcher)
+    fetcher.base_url = "http://dispatcharr.test"
+
+    config = Mock()
+    config.get_stream_fetch_page_size.return_value = 5000
+    config.get_stream_fetch_max_workers.return_value = 2
+    monkeypatch.setattr(fetcher_module, "get_dispatcharr_config", lambda: config)
+
+    cancel_check = Mock(return_value=False)
+    calls = {}
+
+    def fake_fetch_paginated(
+        url,
+        page_size=1000,
+        max_workers=10,
+        progress_callback=None,
+        cancel_check=None,
+    ):
+        calls["cancel_check"] = cancel_check
+        return fetcher_module.FetchResult(items=[{"id": 1}], expected_count=1)
+
+    monkeypatch.setattr(fetcher, "_fetch_paginated", fake_fetch_paginated)
+
+    result = fetcher.fetch_streams(cancel_check=cancel_check)
+
+    assert len(result) == 1
+    assert calls["cancel_check"] is cancel_check
+
+
+def test_fetch_paginated_cancel_check_stops_after_progress(monkeypatch):
+    from apps.udi import fetcher as fetcher_module
+
+    fetcher = fetcher_module.UDIFetcher.__new__(fetcher_module.UDIFetcher)
+    fetcher.base_url = "http://dispatcharr.test"
+
+    def fake_fetch_url(url):
+        assert "page=1" in url
+        return {"count": 2000, "results": [{"id": 1}]}
+
+    monkeypatch.setattr(fetcher, "_fetch_url", fake_fetch_url)
+    progress_calls = []
+
+    def progress_callback(payload):
+        progress_calls.append(payload)
+
+    cancel_check = Mock(side_effect=[False, False, True])
+
+    with pytest.raises(fetcher_module.FetchCancelled):
+        fetcher._fetch_paginated(
+            "http://dispatcharr.test/api/channels/streams/",
+            page_size=1000,
+            progress_callback=progress_callback,
+            cancel_check=cancel_check,
+        )
+
+    assert progress_calls == [
+        {
+            "completed_pages": 1,
+            "total_pages": 2,
+            "items_fetched": 1,
+            "expected_count": 2000,
+        }
+    ]
+
+
 def test_fetch_url_retries_transient_timeout(monkeypatch):
     from apps.udi import fetcher as fetcher_module
 

--- a/backend/tests/test_quality_reason_transparency.py
+++ b/backend/tests/test_quality_reason_transparency.py
@@ -1,4 +1,8 @@
-from apps.core.stream_stats_utils import is_stream_dead
+from apps.core.stream_stats_utils import (
+    extract_stream_stats,
+    format_stream_stats_for_display,
+    is_stream_dead,
+)
 from apps.stream.stream_checker_service import StreamCheckerService
 
 
@@ -182,3 +186,36 @@ def test_incomplete_bitrate_can_reuse_previous_value_for_scoring_without_persist
     assert "ffmpeg_output_bitrate" not in payload["stream_stats"]
     assert payload["stream_stats"]["measurement_incomplete"] is True
     assert payload["stream_stats"]["bitrate_recheck_required"] is True
+
+
+def test_single_channel_details_do_not_mix_cached_bitrate_with_current_missing_bitrate():
+    cached_stream = {
+        "id": 42,
+        "stream_stats": {
+            "resolution": "3840x2160",
+            "source_fps": 59.9,
+            "ffmpeg_output_bitrate": 19300,
+            "video_codec": "hevc",
+        },
+    }
+    analyzed = {
+        "stream_id": 42,
+        "resolution": "3840x2160",
+        "fps": 59.9,
+        "bitrate_kbps": None,
+        "video_codec": "hevc",
+        "measurement_incomplete": True,
+        "measurement_incomplete_reason": "missing_bitrate",
+        "bitrate_recheck_required": True,
+    }
+
+    cached_display = format_stream_stats_for_display(extract_stream_stats(cached_stream))
+    current_display = format_stream_stats_for_display(
+        extract_stream_stats(
+            StreamCheckerService._current_probe_stats_source(cached_stream, analyzed)
+        )
+    )
+
+    assert cached_display["bitrate"] == "19.3 Mbps"
+    assert current_display["bitrate"] == "N/A"
+    assert StreamCheckerService._has_incomplete_bitrate_measurement(analyzed) is True

--- a/backend/tests/test_quality_reason_transparency.py
+++ b/backend/tests/test_quality_reason_transparency.py
@@ -219,3 +219,34 @@ def test_single_channel_details_do_not_mix_cached_bitrate_with_current_missing_b
     assert cached_display["bitrate"] == "19.3 Mbps"
     assert current_display["bitrate"] == "N/A"
     assert StreamCheckerService._has_incomplete_bitrate_measurement(analyzed) is True
+
+
+def test_single_channel_details_use_current_probe_bitrate_when_present():
+    cached_stream = {
+        "id": 42,
+        "stream_stats": {
+            "resolution": "3840x2160",
+            "source_fps": 59.9,
+            "ffmpeg_output_bitrate": 3000,
+            "video_codec": "hevc",
+        },
+    }
+    analyzed = {
+        "stream_id": 42,
+        "resolution": "3840x2160",
+        "fps": 59.9,
+        "bitrate_kbps": 19300,
+        "video_codec": "hevc",
+        "measurement_incomplete": False,
+        "measurement_incomplete_reason": "none",
+        "bitrate_recheck_required": False,
+    }
+
+    current_display = format_stream_stats_for_display(
+        extract_stream_stats(
+            StreamCheckerService._current_probe_stats_source(cached_stream, analyzed)
+        )
+    )
+
+    assert current_display["bitrate"] == "19.3 Mbps"
+    assert StreamCheckerService._has_incomplete_bitrate_measurement(analyzed) is False

--- a/backend/tests/test_run_observability.py
+++ b/backend/tests/test_run_observability.py
@@ -582,9 +582,11 @@ class AutomationRunStatusTests(unittest.TestCase):
         udi.refresh_streams.side_effect = AssertionError("M3U refresh wait must not sync full stream cache")
         udi.get_streams.return_value = [{"id": 10}, {"id": 11}]
 
-        with patch("apps.automation.automated_stream_manager.get_udi_manager", return_value=udi), patch(
-            "apps.automation.automated_stream_manager.time.sleep"
-        ) as sleep_mock:
+        with patch("apps.automation.automated_stream_manager.get_udi_manager", return_value=udi), patch.object(
+            manager._manual_stop_requested,
+            "wait",
+            return_value=False,
+        ) as wait_mock:
             result = manager._wait_for_m3u_refresh_completion([{"id": 1, "name": "One"}], events.append)
 
         self.assertTrue(result["ok"])
@@ -592,7 +594,7 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertEqual(events[-1]["state"], "settled")
         self.assertEqual(events[-1]["wait_streams_seen"], 2)
         udi.refresh_streams.assert_not_called()
-        sleep_mock.assert_called_once_with(1)
+        wait_mock.assert_called_once_with(timeout=1)
 
     def test_m3u_refresh_wait_treats_parsing_account_as_busy(self):
         manager = self._manager()
@@ -614,9 +616,11 @@ class AutomationRunStatusTests(unittest.TestCase):
         udi.refresh_streams.side_effect = AssertionError("M3U refresh wait must not sync full stream cache")
         udi.get_streams.return_value = [{"id": 10}, {"id": 11}]
 
-        with patch("apps.automation.automated_stream_manager.get_udi_manager", return_value=udi), patch(
-            "apps.automation.automated_stream_manager.time.sleep"
-        ) as sleep_mock:
+        with patch("apps.automation.automated_stream_manager.get_udi_manager", return_value=udi), patch.object(
+            manager._manual_stop_requested,
+            "wait",
+            return_value=False,
+        ) as wait_mock:
             result = manager._wait_for_m3u_refresh_completion([{"id": 1, "name": "One"}], events.append)
 
         self.assertTrue(result["ok"])
@@ -627,7 +631,42 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertIn("playlist parsing", events[0]["message"])
         self.assertEqual(events[-1]["state"], "settled")
         udi.refresh_streams.assert_not_called()
-        sleep_mock.assert_called_once_with(1)
+        wait_mock.assert_called_once_with(timeout=1)
+
+    def test_m3u_refresh_wait_aborts_when_manual_stop_requested(self):
+        manager = self._manager()
+        manager.config = {
+            "m3u_refresh_wait": {
+                "timeout_seconds": 30,
+                "poll_interval_seconds": 60,
+                "stable_polls_required": 1,
+                "min_wait_seconds": 0,
+            },
+        }
+        events = []
+        udi = Mock()
+        udi.refresh_m3u_accounts.return_value = True
+        udi.get_m3u_accounts.return_value = [{"id": 1, "name": "One", "status": "parsing"}]
+        udi.refresh_streams.side_effect = AssertionError("M3U refresh wait must not sync full stream cache")
+        udi.get_streams.return_value = [{"id": 10}]
+
+        def record_and_stop(payload):
+            events.append(payload)
+            if payload.get("state") == "waiting":
+                manager._manual_stop_requested.set()
+
+        with patch("apps.automation.automated_stream_manager.get_udi_manager", return_value=udi):
+            result = manager._wait_for_m3u_refresh_completion(
+                [{"id": 1, "name": "One"}],
+                record_and_stop,
+            )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["state"], "aborted")
+        self.assertEqual(result["message"], "Automation run was stopped by the user")
+        self.assertEqual(events[-1]["state"], "aborted")
+        self.assertTrue(manager._manual_stop_requested.is_set())
+        udi.refresh_streams.assert_not_called()
 
     def test_m3u_refresh_wait_reports_failed_account_status(self):
         manager = self._manager()
@@ -710,8 +749,10 @@ class AutomationRunStatusTests(unittest.TestCase):
         with patch("apps.automation.automated_stream_manager.get_udi_manager", return_value=udi), patch(
             "apps.automation.automated_stream_manager.refresh_m3u_playlists",
             return_value=response,
-        ) as refresh_mock, patch(
-            "apps.automation.automated_stream_manager.time.sleep"
+        ) as refresh_mock, patch.object(
+            manager._manual_stop_requested,
+            "wait",
+            return_value=False,
         ):
             result = manager._wait_for_m3u_refresh_completion(
                 [{"id": 1, "name": "One"}, {"id": 2, "name": "Two"}],

--- a/backend/tests/test_run_observability.py
+++ b/backend/tests/test_run_observability.py
@@ -757,6 +757,50 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertTrue(manager._manual_stop_requested.is_set())
         manager.changelog.add_entry.assert_not_called()
 
+    def test_manual_stop_request_is_persisted_for_other_manager_instances(self):
+        manager = self._manager()
+        fake_db = FakeSettingsDB()
+        manager._start_run_status(forced=True)
+
+        with patch("apps.database.manager.get_db_manager", return_value=fake_db):
+            requested = manager.request_active_run_stop()
+
+        self.assertTrue(requested)
+        token = fake_db.get_system_setting(AutomatedStreamManager.MANUAL_STOP_REQUEST_KEY)
+        self.assertIsInstance(token, dict)
+        self.assertEqual(token["run_id"], manager.get_run_status()["run_id"])
+        self.assertTrue(token["all_active"])
+
+    def test_manual_stop_request_can_be_seen_from_persisted_token(self):
+        manager = self._manager()
+        fake_db = FakeSettingsDB()
+        manager._start_run_status(forced=True)
+        run_id = manager.get_run_status()["run_id"]
+        fake_db.set_system_setting(
+            AutomatedStreamManager.MANUAL_STOP_REQUEST_KEY,
+            {"run_id": run_id, "all_active": True},
+        )
+
+        with patch("apps.database.manager.get_db_manager", return_value=fake_db):
+            self.assertTrue(manager._is_manual_stop_requested())
+
+        self.assertTrue(manager._manual_stop_requested.is_set())
+
+    def test_manual_stop_abort_clears_persisted_token(self):
+        manager = self._manager()
+        fake_db = FakeSettingsDB()
+        manager._start_run_status(forced=True)
+        fake_db.set_system_setting(
+            AutomatedStreamManager.MANUAL_STOP_REQUEST_KEY,
+            {"all_active": True},
+        )
+
+        with patch("apps.database.manager.get_db_manager", return_value=fake_db):
+            self.assertTrue(manager._abort_run_if_manual_stop_requested())
+
+        self.assertEqual(manager.get_run_status()["state"], "aborted")
+        self.assertIsNone(fake_db.get_system_setting(AutomatedStreamManager.MANUAL_STOP_REQUEST_KEY))
+
     def test_m3u_refresh_wait_reports_failed_account_status(self):
         manager = self._manager()
         manager.config = {"m3u_refresh_wait": {"stable_polls_required": 2, "min_wait_seconds": 0}}

--- a/backend/tests/test_run_observability.py
+++ b/backend/tests/test_run_observability.py
@@ -330,6 +330,29 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertGreater(manager.last_playlist_update, original_last_run)
         manager._save_state.assert_called_once()
 
+    def test_late_manual_stop_finalizer_advances_period_schedule_clock(self):
+        manager = self._manager()
+        original_last_run = datetime.now() - timedelta(minutes=90)
+        active_periods = {("period-1", "Full Check"): {"channels": [1, 2, 3]}}
+        manager.period_last_run = {"period-1": original_last_run}
+        manager.last_playlist_update = original_last_run
+        manager._save_state = Mock()
+        manager._manual_stop_requested.set()
+
+        cycle_abort_message, manual_stop_abort = manager._normalize_manual_cycle_abort(None)
+        run_job_outcome = "aborted" if cycle_abort_message else "completed"
+        advanced = manager._advance_period_run_timestamps(
+            active_periods,
+            run_job_outcome,
+            manual_stop=manual_stop_abort,
+        )
+
+        self.assertEqual(cycle_abort_message, "Automation run was stopped by the user")
+        self.assertTrue(manual_stop_abort)
+        self.assertTrue(advanced)
+        self.assertGreater(manager.period_last_run["period-1"], original_last_run)
+        manager._save_state.assert_called_once()
+
     def test_manual_stop_abort_marks_active_periods_to_prevent_immediate_retry(self):
         manager = self._manager()
         original_last_run = datetime.now() - timedelta(minutes=90)

--- a/backend/tests/test_run_observability.py
+++ b/backend/tests/test_run_observability.py
@@ -381,6 +381,7 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertTrue(manager._manual_stop_requested.is_set())
         self.assertTrue(manager.automation_running)
         self.assertTrue(manager.running)
+        self.assertFalse(manager.automation_wake_event.is_set())
         self.assertEqual(status["state"], "running")
         self.assertEqual(status["message"], "Stop requested; active automation run is shutting down")
 

--- a/backend/tests/test_run_observability.py
+++ b/backend/tests/test_run_observability.py
@@ -295,6 +295,57 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertEqual(status["message"], "Automation run was stopped by the user")
         self.assertEqual(status["last_error"], "Automation run was stopped by the user")
 
+    def test_aborted_cycle_does_not_advance_period_schedule_clock(self):
+        manager = self._manager()
+        original_last_run = datetime.now() - timedelta(minutes=90)
+        manager.period_last_run = {"period-1": original_last_run}
+        manager.last_playlist_update = original_last_run
+        manager._save_state = Mock()
+
+        advanced = manager._advance_period_run_timestamps(
+            {("period-1", "Full Check"): {"channels": [1, 2, 3]}},
+            "aborted",
+        )
+
+        self.assertFalse(advanced)
+        self.assertEqual(manager.period_last_run["period-1"], original_last_run)
+        self.assertEqual(manager.last_playlist_update, original_last_run)
+        manager._save_state.assert_not_called()
+
+    def test_completed_cycle_advances_period_schedule_clock(self):
+        manager = self._manager()
+        original_last_run = datetime.now() - timedelta(minutes=90)
+        manager.period_last_run = {"period-1": original_last_run}
+        manager.last_playlist_update = original_last_run
+        manager._save_state = Mock()
+
+        advanced = manager._advance_period_run_timestamps(
+            {("period-1", "Full Check"): {"channels": [1, 2, 3]}},
+            "completed",
+        )
+
+        self.assertTrue(advanced)
+        self.assertGreater(manager.period_last_run["period-1"], original_last_run)
+        self.assertGreater(manager.last_playlist_update, original_last_run)
+        manager._save_state.assert_called_once()
+
+    def test_request_active_run_stop_keeps_scheduler_service_running(self):
+        manager = self._manager()
+
+        manager._start_run_status(forced=False, forced_period_id=None)
+        manager.automation_running = True
+        manager.running = True
+
+        requested = manager.request_active_run_stop()
+
+        status = manager.get_run_status()
+        self.assertTrue(requested)
+        self.assertTrue(manager._manual_stop_requested.is_set())
+        self.assertTrue(manager.automation_running)
+        self.assertTrue(manager.running)
+        self.assertEqual(status["state"], "running")
+        self.assertEqual(status["message"], "Stop requested; active automation run is shutting down")
+
     def test_stop_automation_requests_abort_for_active_run(self):
         manager = self._manager()
 

--- a/backend/tests/test_run_observability.py
+++ b/backend/tests/test_run_observability.py
@@ -668,6 +668,95 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertTrue(manager._manual_stop_requested.is_set())
         udi.refresh_streams.assert_not_called()
 
+    def test_stream_matching_parallel_loop_aborts_when_manual_stop_requested(self):
+        manager = self._manager()
+        manager.config = {
+            "enabled_features": {"auto_stream_discovery": True},
+            "enabled_m3u_accounts": [],
+        }
+        manager._lock = threading.Lock()
+        manager._m3u_accounts_cache = [{"id": 1, "name": "Provider", "is_active": True}]
+        manager.regex_matcher = Mock()
+        manager.regex_matcher.reload_patterns.return_value = None
+        manager.regex_matcher.has_regex_patterns.return_value = True
+        manager.regex_matcher.get_match_by_tvg_id.return_value = False
+        manager._filter_channels_by_profile = Mock(side_effect=lambda channels, _reason: channels)
+        manager._record_channel_visibility_events = Mock()
+        manager._is_dead_stream_removal_enabled = Mock(return_value=False)
+        manager._update_run_progress = Mock()
+        manager._get_channel_visibility_config = Mock(return_value={})
+
+        streams = [{"id": i, "name": f"Stream {i}", "m3u_account": 1} for i in range(2000)]
+        channels = [{"id": 10, "name": "Channel 10"}]
+        automation_config = Mock()
+        automation_config.get_effective_configuration.return_value = {
+            "profile": {
+                "stream_matching": {"enabled": True, "match_priority_order": ["regex"]},
+                "stream_checking": {"enabled": False},
+            }
+        }
+        udi = Mock()
+        udi.get_channel_streams.return_value = []
+        session_manager = Mock()
+        session_manager.get_channels_in_active_sessions.return_value = []
+
+        def stop_during_batch(*_args, **_kwargs):
+            manager._manual_stop_requested.set()
+            return {}, {}
+
+        manager._match_streams_batch = Mock(side_effect=stop_during_batch)
+
+        with patch("apps.automation.automated_stream_manager.get_streams", return_value=streams), \
+             patch("apps.automation.automated_stream_manager.get_channels", return_value=channels), \
+             patch("apps.automation.automated_stream_manager.get_udi_manager", return_value=udi), \
+             patch("apps.automation.automated_stream_manager.get_automation_config_manager", return_value=automation_config), \
+             patch("apps.stream.stream_session_manager.get_session_manager", return_value=session_manager):
+            result = manager._discover_and_assign_streams_impl(force=True, skip_check_trigger=True)
+
+        self.assertTrue(result["aborted"])
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Automation run was stopped by the user")
+        self.assertEqual(result["assignment_count"], {})
+        self.assertTrue(manager._manual_stop_requested.is_set())
+
+    def test_stream_validation_parallel_loop_aborts_when_manual_stop_requested(self):
+        manager = self._manager()
+        manager.config = {}
+        manager._lock = threading.Lock()
+        manager._filter_channels_by_profile = Mock(side_effect=lambda channels, _reason: channels)
+        manager.changelog = Mock()
+
+        channels = [{"id": i, "name": f"Channel {i}"} for i in range(60)]
+        streams = [{"id": i, "name": f"Stream {i}"} for i in range(10)]
+        udi = Mock()
+        udi.get_channels.return_value = channels
+        udi.get_streams.return_value = streams
+        automation_config = Mock()
+        automation_config.get_effective_configuration.return_value = {
+            "profile": {
+                "stream_matching": {
+                    "enabled": True,
+                    "validate_existing_streams": True,
+                }
+            }
+        }
+
+        def stop_during_batch(*_args, **_kwargs):
+            manager._manual_stop_requested.set()
+            return {"channels_checked": 0, "details": []}
+
+        manager._validate_channels_batch = Mock(side_effect=stop_during_batch)
+
+        with patch("apps.automation.automated_stream_manager.get_udi_manager", return_value=udi), \
+             patch("apps.automation.automation_config_manager.get_automation_config_manager", return_value=automation_config):
+            result = manager._validate_and_remove_non_matching_streams_impl(force=True)
+
+        self.assertTrue(result["aborted"])
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "Automation run was stopped by the user")
+        self.assertTrue(manager._manual_stop_requested.is_set())
+        manager.changelog.add_entry.assert_not_called()
+
     def test_m3u_refresh_wait_reports_failed_account_status(self):
         manager = self._manager()
         manager.config = {"m3u_refresh_wait": {"stable_polls_required": 2, "min_wait_seconds": 0}}

--- a/backend/tests/test_run_observability.py
+++ b/backend/tests/test_run_observability.py
@@ -385,6 +385,28 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertEqual(status["state"], "running")
         self.assertEqual(status["message"], "Stop requested; active automation run is shutting down")
 
+    def test_automation_loop_consumes_trigger_wake_event_before_running_cycle(self):
+        manager = self._manager()
+        manager.automation_running = True
+        manager.running = True
+        manager.force_next_run = True
+        manager.forced_period_id = None
+        manager.automation_wake_event.set()
+
+        udi = Mock()
+        udi.is_network_ready.return_value = True
+
+        def run_once(*_args, **_kwargs):
+            self.assertFalse(manager.automation_wake_event.is_set())
+            manager.automation_running = False
+
+        manager.run_automation_cycle = Mock(side_effect=run_once)
+
+        with patch("apps.automation.automated_stream_manager.get_udi_manager", return_value=udi):
+            manager._automation_loop()
+
+        manager.run_automation_cycle.assert_called_once_with(forced=True, forced_period_id=None)
+
     def test_stop_automation_requests_abort_for_active_run(self):
         manager = self._manager()
 

--- a/backend/tests/test_run_observability.py
+++ b/backend/tests/test_run_observability.py
@@ -353,6 +353,40 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertGreater(manager.period_last_run["period-1"], original_last_run)
         manager._save_state.assert_called_once()
 
+    def test_child_stage_abort_still_invokes_manual_stop_handler(self):
+        manager = self._manager()
+        active_periods = {("period-1", "Full Check"): {"channels": [1, 2, 3]}}
+        manager._abort_run_if_manual_stop_requested = Mock(return_value=True)
+
+        message, handled = manager._handle_child_stage_abort(
+            {"aborted": True, "error": "child stopped"},
+            active_periods,
+            "fallback",
+        )
+
+        self.assertIsNone(message)
+        self.assertTrue(handled)
+        manager._abort_run_if_manual_stop_requested.assert_called_once_with(
+            active_periods=active_periods
+        )
+
+    def test_child_stage_abort_without_manual_stop_returns_abort_message(self):
+        manager = self._manager()
+        active_periods = {("period-1", "Full Check"): {"channels": [1, 2, 3]}}
+        manager._abort_run_if_manual_stop_requested = Mock(return_value=False)
+
+        message, handled = manager._handle_child_stage_abort(
+            {"aborted": True},
+            active_periods,
+            "fallback",
+        )
+
+        self.assertEqual(message, "fallback")
+        self.assertFalse(handled)
+        manager._abort_run_if_manual_stop_requested.assert_called_once_with(
+            active_periods=active_periods
+        )
+
     def test_manual_stop_abort_marks_active_periods_to_prevent_immediate_retry(self):
         manager = self._manager()
         original_last_run = datetime.now() - timedelta(minutes=90)

--- a/backend/tests/test_run_observability.py
+++ b/backend/tests/test_run_observability.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from apps.automation.automated_stream_manager import AutomatedStreamManager, ChangelogManager
-from apps.udi.fetcher import UDIFetcher
+from apps.udi.fetcher import UDIFetcher, FetchCancelled
 
 
 class FakeSettingsDB:
@@ -311,6 +311,44 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertEqual(manager.period_last_run["period-1"], original_last_run)
         self.assertEqual(manager.last_playlist_update, original_last_run)
         manager._save_state.assert_not_called()
+
+    def test_manual_stop_aborted_cycle_advances_period_schedule_clock(self):
+        manager = self._manager()
+        original_last_run = datetime.now() - timedelta(minutes=90)
+        manager.period_last_run = {"period-1": original_last_run}
+        manager.last_playlist_update = original_last_run
+        manager._save_state = Mock()
+
+        advanced = manager._advance_period_run_timestamps(
+            {("period-1", "Full Check"): {"channels": [1, 2, 3]}},
+            "aborted",
+            manual_stop=True,
+        )
+
+        self.assertTrue(advanced)
+        self.assertGreater(manager.period_last_run["period-1"], original_last_run)
+        self.assertGreater(manager.last_playlist_update, original_last_run)
+        manager._save_state.assert_called_once()
+
+    def test_manual_stop_abort_marks_active_periods_to_prevent_immediate_retry(self):
+        manager = self._manager()
+        original_last_run = datetime.now() - timedelta(minutes=90)
+        manager.period_last_run = {"period-1": original_last_run}
+        manager.last_playlist_update = original_last_run
+        manager._save_state = Mock()
+        manager._clear_persisted_manual_stop_request = Mock()
+        manager._manual_stop_requested.set()
+
+        aborted = manager._abort_run_if_manual_stop_requested(
+            active_periods={("period-1", "Full Check"): {"channels": [1, 2, 3]}},
+        )
+
+        status = manager.get_run_status()
+        self.assertTrue(aborted)
+        self.assertEqual(status["state"], "aborted")
+        self.assertGreater(manager.period_last_run["period-1"], original_last_run)
+        manager._save_state.assert_called_once()
+        manager._clear_persisted_manual_stop_request.assert_called_once()
 
     def test_completed_cycle_advances_period_schedule_clock(self):
         manager = self._manager()
@@ -909,7 +947,7 @@ class AutomationRunStatusTests(unittest.TestCase):
 
         udi = Mock()
 
-        def refresh_streams(progress_callback=None):
+        def refresh_streams(progress_callback=None, cancel_check=None):
             status = manager.get_run_status()
             self.assertEqual(status["current"], 1)
             self.assertEqual(status["total"], 100)
@@ -917,6 +955,8 @@ class AutomationRunStatusTests(unittest.TestCase):
             stages = {stage["key"]: stage for stage in status["stages"]}
             self.assertEqual(stages["cache_sync"]["percent"], 1)
             self.assertIsNotNone(progress_callback)
+            self.assertIsNotNone(cancel_check)
+            self.assertFalse(cancel_check())
             progress_callback({
                 "completed_pages": 2,
                 "total_pages": 4,
@@ -946,6 +986,34 @@ class AutomationRunStatusTests(unittest.TestCase):
         self.assertEqual(status["percent"], 100)
         self.assertEqual(status["counts"]["cache_sync_successful_steps"], 2)
         self.assertEqual(status["counts"]["cache_sync_total_steps"], 2)
+
+    def test_cache_sync_propagates_manual_stop_cancellation(self):
+        manager = self._manager()
+        manager._start_run_status(forced=True)
+        manager._update_run_status(
+            stage="cache_sync",
+            stage_label="Syncing Cache",
+            message="Refreshing cache after playlist update",
+        )
+        manager._manual_stop_requested.set()
+
+        udi = Mock()
+
+        def refresh_streams(progress_callback=None, cancel_check=None):
+            self.assertIsNotNone(cancel_check)
+            self.assertTrue(cancel_check())
+            raise FetchCancelled("stopped")
+
+        udi.refresh_streams.side_effect = refresh_streams
+
+        with self.assertRaises(FetchCancelled):
+            manager._sync_udi_cache_after_playlist_refresh(udi)
+
+        status = manager.get_run_status()
+        self.assertEqual(status["current"], 1)
+        self.assertEqual(status["percent"], 1)
+        self.assertEqual(status["message"], "Cache sync stopped by user")
+        udi.refresh_channels.assert_not_called()
 
 
 class FetcherTimingSummaryTests(unittest.TestCase):

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -413,7 +413,7 @@ export default function Dashboard() {
         await streamCheckerAPI.clearQueue()
       }
       if (activeAutomationRun) {
-        await automationAPI.stop()
+        await automationAPI.abortRun()
       }
 
       toast({

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -38,6 +38,7 @@ export const automationAPI = {
   getStatus: () => api.get('/automation/status'),
   start: () => api.post('/automation/start'),
   stop: () => api.post('/automation/stop'),
+  abortRun: () => api.post('/automation/abort-run'),
   runCycle: (data) => api.post('/automation/trigger', data),  // Trigger immediate automation cycle
   trigger: () => api.post('/automation/trigger'),
 


### PR DESCRIPTION
## Summary
- keep the automation scheduler service running when the Dashboard Stop Run button aborts only the active run
- do not advance scheduler period timestamps for aborted automation runs, so an aborted/stopped run cannot make the next scheduled run look completed
- make M3U-refresh wait interruptible by the run abort request, including while Dispatcharr is still parsing/settling playlists
- keep single-channel/preflight changelog details tied to the current probe stats instead of mixing a current `missing_bitrate` status with an older cached Dispatcharr bitrate

## Why
A stopped automation run could previously leave the dashboard at `Aborted` and still advance `period_last_run`, which could delay/skip the next scheduler cycle. The Dashboard Stop Run action also used the service stop endpoint, which stopped the scheduler instead of only aborting the active run.

A user changelog from a real Teamarr preflight run also showed rows like `status=incomplete_bitrate` and `reason=missing_bitrate` while the exported `bitrate` column displayed values such as `19.3 Mbps`. That was caused by single-channel result details using cached Dispatcharr stream stats for display while the current probe result was missing bitrate.

## Validation so far
- `python -m pytest backend/tests/test_run_observability.py backend/tests/test_quality_reason_transparency.py`
- `python -m pytest backend/tests/test_run_observability.py backend/tests/test_quality_reason_transparency.py backend/tests/test_stream_check_utils.py backend/tests/test_last_quality_stats_api.py`
- CI was green before the latest commit; waiting for the updated branch checks and PR image build.

## Draft gate
Keep this PR Draft until the updated PR image is live-tested on Home Unraid:
- abort an active run during M3U refresh and verify the scheduler remains running
- run single-channel/preflight checks and verify current missing-bitrate probes export `N/A` instead of stale cached Mbps
- start the Full Run profile at the end after all tests are green; no need to monitor that final run