### PR TITLE
Fix all-dead channel visibility after visual probes

### DIFF
--- a/backend/apps/automation/channel_visibility_automation.py
+++ b/backend/apps/automation/channel_visibility_automation.py
@@ -100,6 +100,7 @@ class ChannelVisibilityAutomation:
         *,
         good_streams_count: int,
         dead_streams_count: int,
+        failed_streams_count: Optional[int] = None,
         revived_streams_count: int = 0,
         config: Optional[Dict[str, Any]] = None,
         details: Optional[Dict[str, Any]] = None,
@@ -118,7 +119,21 @@ class ChannelVisibilityAutomation:
         if total_streams == 0 and merged.get("hide_on_no_streams"):
             return self.hide_channel(channel, reason="no_streams", details=details)
 
-        if good_streams_count <= 0 and dead_streams_count > 0 and merged.get("hide_on_all_failed"):
+        try:
+            effective_failed_streams_count = int(failed_streams_count)
+        except (TypeError, ValueError):
+            effective_failed_streams_count = int(dead_streams_count or 0)
+        effective_failed_streams_count = max(
+            int(dead_streams_count or 0),
+            effective_failed_streams_count,
+        )
+        details.setdefault("failed_streams_count", effective_failed_streams_count)
+
+        if (
+            good_streams_count <= 0
+            and effective_failed_streams_count > 0
+            and merged.get("hide_on_all_failed")
+        ):
             return self.hide_channel(channel, reason="all_failed", details=details)
 
         if total_streams and total_streams > 0 and merged.get("unhide_on_recovered"):

--- a/backend/apps/automation/channel_visibility_automation.py
+++ b/backend/apps/automation/channel_visibility_automation.py
@@ -118,6 +118,9 @@ class ChannelVisibilityAutomation:
         if total_streams == 0 and merged.get("hide_on_no_streams"):
             return self.hide_channel(channel, reason="no_streams", details=details)
 
+        if good_streams_count <= 0 and dead_streams_count > 0 and merged.get("hide_on_all_failed"):
+            return self.hide_channel(channel, reason="all_failed", details=details)
+
         if total_streams and total_streams > 0 and merged.get("unhide_on_recovered"):
             state_entry = self._state_entry_for_channel(channel)
             if state_entry and state_entry.get("reason") == "no_streams":
@@ -125,8 +128,6 @@ class ChannelVisibilityAutomation:
 
         if (good_streams_count > 0 or revived_streams_count > 0) and merged.get("unhide_on_recovered"):
             return self.unhide_channel(channel, reason="recovered", details=details)
-        if good_streams_count <= 0 and dead_streams_count > 0 and merged.get("hide_on_all_failed"):
-            return self.hide_channel(channel, reason="all_failed", details=details)
         return self._skipped(channel, "no_visibility_change", "quality_result")
 
     def hide_channel(

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -3447,10 +3447,15 @@ class StreamCheckerService:
                 self._count_good_checked_streams({'checked_streams': stream_stats})
                 + len(protected_active_stream_ids)
             )
+            visibility_failed_streams_count = max(
+                len(dead_stream_ids),
+                self._count_failed_checked_streams({'checked_streams': stream_stats}),
+            )
             visibility_result = self._apply_channel_visibility_after_check(
                 channel_data,
                 good_streams_count=visibility_good_streams_count,
                 dead_streams_count=len(dead_stream_ids),
+                failed_streams_count=visibility_failed_streams_count,
                 revived_streams_count=len(revived_stream_ids),
                 total_streams=len(streams),
                 profile=profile,
@@ -4602,10 +4607,15 @@ class StreamCheckerService:
                 self._count_good_checked_streams({'checked_streams': stream_stats})
                 + len(protected_active_stream_ids)
             )
+            visibility_failed_streams_count = max(
+                len(dead_stream_ids),
+                self._count_failed_checked_streams({'checked_streams': stream_stats}),
+            )
             visibility_result = self._apply_channel_visibility_after_check(
                 channel_data,
                 good_streams_count=visibility_good_streams_count,
                 dead_streams_count=len(dead_stream_ids),
+                failed_streams_count=visibility_failed_streams_count,
                 revived_streams_count=len(revived_stream_ids),
                 total_streams=len(streams),
                 profile=profile,
@@ -5979,6 +5989,7 @@ class StreamCheckerService:
         *,
         good_streams_count: int,
         dead_streams_count: int,
+        failed_streams_count: Optional[int] = None,
         revived_streams_count: int,
         total_streams: int,
         profile: Optional[Dict[str, Any]] = None,
@@ -5995,12 +6006,14 @@ class StreamCheckerService:
                 channel_data,
                 good_streams_count=good_streams_count,
                 dead_streams_count=dead_streams_count,
+                failed_streams_count=failed_streams_count,
                 revived_streams_count=revived_streams_count,
                 config=config,
                 details={
                     'total_streams': total_streams,
                     'good_streams_count': good_streams_count,
                     'dead_streams_count': dead_streams_count,
+                    'failed_streams_count': failed_streams_count,
                     'revived_streams_count': revived_streams_count,
                 },
             )
@@ -6112,6 +6125,29 @@ class StreamCheckerService:
             and (
                 stream.get('status') == 'incomplete_bitrate'
                 or stream.get('quality_reason_detail') in {None, '', 'none'}
+            )
+        )
+
+    @staticmethod
+    def _count_failed_checked_streams(result: Dict) -> int:
+        checked_streams = result.get('checked_streams', []) if isinstance(result, dict) else []
+        if not isinstance(checked_streams, list):
+            return 0
+        bad_statuses = {'blank', 'freeze', 'low_quality', 'dead', 'offline', 'error', 'failed', 'timeout', 'unstable'}
+        bad_reasons = bad_statuses
+        return sum(
+            1
+            for stream in checked_streams
+            if isinstance(stream, dict)
+            and (
+                stream.get('status') in bad_statuses
+                or stream.get('blank_detected') is True
+                or stream.get('freeze_detected') is True
+                or stream.get('dead_reason') in bad_reasons
+                or stream.get('reason') in bad_reasons
+                or stream.get('reason_detail') in bad_reasons
+                or stream.get('quality_reason') in bad_reasons
+                or stream.get('quality_reason_detail') in bad_reasons
             )
         )
 

--- a/backend/tests/test_channel_visibility_automation.py
+++ b/backend/tests/test_channel_visibility_automation.py
@@ -142,6 +142,30 @@ def test_all_failed_hide_uses_quality_result_gate():
     assert db.settings[STATE_KEY]["14"]["reason"] == "all_failed"
 
 
+def test_all_failed_hide_accepts_visual_failure_count_without_dead_streams():
+    db = FakeDb()
+    patch = Mock(return_value=FakeResponse())
+    service = make_service(db, patch_request=patch)
+
+    result = service.handle_quality_result(
+        {"id": 21, "name": "NASA", "hidden_from_output": False},
+        good_streams_count=0,
+        dead_streams_count=0,
+        failed_streams_count=2,
+        config={"enabled": True, "hide_on_all_failed": True},
+        details={
+            "total_streams": 2,
+            "blank_streams_count": 2,
+            "freeze_streams_count": 2,
+        },
+    )
+
+    assert result["action"] == "hidden"
+    assert result["reason"] == "all_failed"
+    assert result["details"]["failed_streams_count"] == 2
+    assert db.settings[STATE_KEY]["21"]["reason"] == "all_failed"
+
+
 def test_no_streams_hide_uses_quality_result_total_streams_gate():
     db = FakeDb()
     patch = Mock(return_value=FakeResponse())

--- a/backend/tests/test_channel_visibility_automation.py
+++ b/backend/tests/test_channel_visibility_automation.py
@@ -178,6 +178,37 @@ def test_streams_recovered_unhides_only_no_streams_state():
     assert "19" not in db.settings[STATE_KEY]
 
 
+def test_all_failed_wins_over_no_streams_recovery_after_visual_probe():
+    db = FakeDb(state={"20": {"hidden_by": "streamflow", "reason": "no_streams"}})
+    patch = Mock(return_value=FakeResponse())
+    service = make_service(db, patch_request=patch)
+
+    result = service.handle_quality_result(
+        {"id": 20, "name": "NASA", "hidden_from_output": True},
+        good_streams_count=0,
+        dead_streams_count=2,
+        revived_streams_count=2,
+        config={
+            "enabled": True,
+            "hide_on_no_streams": True,
+            "hide_on_all_failed": True,
+            "unhide_on_recovered": True,
+        },
+        details={
+            "total_streams": 2,
+            "good_streams_count": 0,
+            "dead_streams_count": 2,
+            "revived_streams_count": 2,
+        },
+    )
+
+    assert result["action"] == "hidden_already_managed"
+    assert result["reason"] == "all_failed"
+    assert result["changed"] is False
+    assert db.settings[STATE_KEY]["20"]["reason"] == "all_failed"
+    patch.assert_not_called()
+
+
 def test_disabled_visibility_automation_is_read_only():
     db = FakeDb()
     patch = Mock(return_value=FakeResponse())

--- a/backend/tests/test_stream_checker_single_channel_profile_flags.py
+++ b/backend/tests/test_stream_checker_single_channel_profile_flags.py
@@ -170,6 +170,27 @@ class TestSingleChannelM3uUpdateFlagDisabled(unittest.TestCase):
         self.assertNotIn('Provider A', snapshot_json)
         self.assertNotIn('Processing completed', snapshot_json)
 
+    def test_failed_stream_count_includes_visual_failures_but_not_missing_bitrate(self):
+        from apps.stream.stream_checker_service import StreamCheckerService
+
+        count = StreamCheckerService._count_failed_checked_streams(
+            {
+                'checked_streams': [
+                    {'stream_id': 1, 'status': 'blank', 'blank_detected': True},
+                    {'stream_id': 2, 'status': 'freeze', 'freeze_detected': True},
+                    {
+                        'stream_id': 3,
+                        'status': 'incomplete_bitrate',
+                        'quality_reason': 'missing_bitrate',
+                        'quality_reason_detail': 'missing_bitrate',
+                    },
+                    {'stream_id': 4, 'status': 'completed'},
+                ],
+            }
+        )
+
+        self.assertEqual(count, 2)
+
     @patch('stream_checker_service.get_udi_manager')
     @patch('stream_checker_service.StreamCheckConfig')
     @patch('stream_checker_service.get_automation_config_manager')


### PR DESCRIPTION
## What changed

Fixes channel visibility after quality checks when every checked stream is dead/blank/frozen.

## Root cause

A channel that was previously hidden for `no_streams` could be unhidden as soon as `total_streams > 0`, before StreamFlow considered the current quality result. NASA exposed this: the run found two streams, both were detected as blank/freeze/dead and removed, but visibility still logged `streams_recovered` and left the channel visible.

## Fix

`hide_on_all_failed` now wins before any recovered/unhide path when a quality result reports `good_streams_count <= 0` and `dead_streams_count > 0`.

## Validation plan

- Targeted backend regression test for the NASA-style case.
- Broader visibility/single-channel backend tests.
- Live Unraid deployment through the normal Docker update path using `ghcr.io/bttfw/streamflow:visibility-all-dead-after-visual`.
- Live NASA check must hide the channel when all assigned streams are dead/blank/frozen.