### PR TITLE
Fix changelog provider metadata and visibility run counts

### DIFF
--- a/backend/apps/api/telemetry_handlers.py
+++ b/backend/apps/api/telemetry_handlers.py
@@ -297,18 +297,38 @@ def _coerce_dead_stream_rows(raw: Any) -> List[Dict[str, Any]]:
     return []
 
 
-def _provider_context_by_stream_id() -> Dict[int, Dict[str, Any]]:
+def _provider_value_missing(value: Any) -> bool:
+    return value is None or (isinstance(value, str) and value.strip() == "")
+
+
+def _provider_is_numeric(value: Any) -> bool:
+    return str(value or "").strip().isdigit()
+
+
+def _provider_reference_context() -> Dict[str, Any]:
     try:
         from apps.udi import get_udi_manager
 
         udi = get_udi_manager()
         if not udi:
-            return {}
+            return {"streams": {}, "account_names_by_id": {}, "account_ids_by_name": {}}
         accounts = udi.get_m3u_accounts() if hasattr(udi, "get_m3u_accounts") else []
-        account_names = {
-            str(account.get("id")): account.get("name")
-            for account in accounts or []
-            if isinstance(account, dict)
+        account_names_by_id: Dict[str, Any] = {}
+        account_name_candidates: Dict[str, List[Any]] = {}
+        for account in accounts or []:
+            if not isinstance(account, dict):
+                continue
+            account_id = account.get("id")
+            account_name = account.get("name")
+            if not _provider_value_missing(account_id):
+                account_names_by_id[str(account_id)] = account_name
+            if not _provider_value_missing(account_id) and account_name:
+                account_name_candidates.setdefault(_text(account_name), []).append(account_id)
+
+        account_ids_by_name = {
+            name: ids[0]
+            for name, ids in account_name_candidates.items()
+            if len({str(item) for item in ids}) == 1
         }
 
         context = {}
@@ -319,20 +339,63 @@ def _provider_context_by_stream_id() -> Dict[int, Dict[str, Any]]:
             stream_id = stream.get("id")
             if stream_id is None:
                 continue
-            provider_id = stream.get("m3u_account_id") or stream.get("m3u_account")
-            provider_name = (
-                stream.get("m3u_account_name")
-                or account_names.get(str(provider_id))
-                or stream.get("m3u_account")
+            m3u_account = stream.get("m3u_account")
+            provider_id = _first_present(
+                stream.get("provider_id"),
+                stream.get("m3u_account_id"),
+                stream.get("m3u_account_id_id"),
             )
+            if _provider_value_missing(provider_id) and _provider_is_numeric(m3u_account):
+                provider_id = m3u_account
+            provider_name = (
+                stream.get("provider_name")
+                or stream.get("m3u_account_name")
+                or account_names_by_id.get(str(provider_id))
+                or (m3u_account if not _provider_is_numeric(m3u_account) else None)
+            )
+            if _provider_value_missing(provider_id) and not _provider_value_missing(provider_name):
+                provider_id = account_ids_by_name.get(_text(provider_name))
             context[int(stream_id)] = {
                 "provider_id": provider_id,
                 "provider_name": provider_name,
             }
-        return context
+        return {
+            "streams": context,
+            "account_names_by_id": account_names_by_id,
+            "account_ids_by_name": account_ids_by_name,
+        }
     except Exception as exc:
-        logger.debug(f"Dead-stream export provider enrichment unavailable: {exc}")
-        return {}
+        logger.debug(f"Provider reference enrichment unavailable: {exc}")
+        return {"streams": {}, "account_names_by_id": {}, "account_ids_by_name": {}}
+
+
+def _provider_context_by_stream_id() -> Dict[int, Dict[str, Any]]:
+    return _provider_reference_context().get("streams", {})
+
+
+def _enrich_run_stream_provider_fields(
+    row: Dict[str, Any],
+    provider_refs: Dict[str, Any],
+) -> Dict[str, Any]:
+    enriched = dict(row)
+    provider_id = enriched.get("provider_id")
+    provider_name = enriched.get("provider_name")
+    stream_context = (provider_refs.get("streams") or {}).get(_as_int(enriched.get("stream_id")), {})
+    account_names_by_id = provider_refs.get("account_names_by_id") or {}
+    account_ids_by_name = provider_refs.get("account_ids_by_name") or {}
+
+    if _provider_value_missing(provider_id):
+        provider_id = stream_context.get("provider_id")
+    if _provider_value_missing(provider_name):
+        provider_name = stream_context.get("provider_name")
+    if _provider_value_missing(provider_name) and not _provider_value_missing(provider_id):
+        provider_name = account_names_by_id.get(str(provider_id))
+    if _provider_value_missing(provider_id) and not _provider_value_missing(provider_name):
+        provider_id = account_ids_by_name.get(_text(provider_name))
+
+    enriched["provider_id"] = None if _provider_value_missing(provider_id) else provider_id
+    enriched["provider_name"] = None if _provider_value_missing(provider_name) else provider_name
+    return enriched
 
 
 def _prepare_dead_stream_export_rows(
@@ -351,8 +414,10 @@ def _prepare_dead_stream_export_rows(
     provider_context = _provider_context_by_stream_id() if enrich_providers else {}
     for row in rows:
         context = provider_context.get(_as_int(row.get("stream_id")), {})
-        row.setdefault("provider_id", context.get("provider_id"))
-        row.setdefault("provider_name", context.get("provider_name"))
+        if _provider_value_missing(row.get("provider_id")):
+            row["provider_id"] = context.get("provider_id")
+        if _provider_value_missing(row.get("provider_name")):
+            row["provider_name"] = context.get("provider_name")
 
     search_text = str(search or "").strip().casefold()
     reason_text = str(reason or "").strip().casefold()
@@ -648,7 +713,7 @@ def _run_stream_row(
         return None
 
     m3u_account = item.get("m3u_account")
-    provider_id = item.get("provider_id") or item.get("m3u_account_id")
+    provider_id = _first_present(item.get("provider_id"), item.get("m3u_account_id"))
     if provider_id in (None, "") and _text(m3u_account).isdigit():
         provider_id = m3u_account
     provider_name = item.get("provider_name") or item.get("m3u_account_name")
@@ -720,6 +785,7 @@ def _extract_changelog_run_stream_rows(run: Any, details: Dict[str, Any], subent
         "job_outcome": getattr(run, "job_outcome", None),
     }
     rows: List[Dict[str, Any]] = []
+    provider_refs = _provider_reference_context()
 
     def walk(node: Any, channel_context: Optional[Dict[str, Any]] = None) -> None:
         context = dict(channel_context or {})
@@ -771,7 +837,7 @@ def _extract_changelog_run_stream_rows(run: Any, details: Dict[str, Any], subent
     deduped: List[Dict[str, Any]] = []
     seen = set()
     for raw_row in rows:
-        row = _enrich_run_stream_row(raw_row)
+        row = _enrich_run_stream_provider_fields(_enrich_run_stream_row(raw_row), provider_refs)
         key = (
             row.get("bucket"),
             row.get("channel_id"),

--- a/backend/apps/stream/stream_checker_service.py
+++ b/backend/apps/stream/stream_checker_service.py
@@ -332,6 +332,9 @@ class StreamCheckerService:
             'dead_streams_count': 0,
             'blank_streams_count': 0,
             'freeze_streams_count': 0,
+            'channels_hidden': 0,
+            'channels_ready': 0,
+            'channel_visibility_changed': 0,
         }
         
         # Event for immediate triggering of updated channels check
@@ -5644,6 +5647,9 @@ class StreamCheckerService:
             queue_status['dead_streams_count'] = sync_state.get('dead_streams_count', 0)
             queue_status['blank_streams_count'] = sync_state.get('blank_streams_count', 0)
             queue_status['freeze_streams_count'] = sync_state.get('freeze_streams_count', 0)
+            queue_status['channels_hidden'] = sync_state.get('channels_hidden', 0)
+            queue_status['channels_ready'] = sync_state.get('channels_ready', 0)
+            queue_status['channel_visibility_changed'] = sync_state.get('channel_visibility_changed', 0)
             
             # Use real queue averages if available, otherwise 0
             queue_snapshot = self.check_queue.get_status()
@@ -6253,6 +6259,9 @@ class StreamCheckerService:
                 'dead_streams_count': 0,
                 'blank_streams_count': 0,
                 'freeze_streams_count': 0,
+                'channels_hidden': 0,
+                'channels_ready': 0,
+                'channel_visibility_changed': 0,
                 'started_at': datetime.now().isoformat(),
                 'generation': sync_generation,
             }
@@ -6318,6 +6327,15 @@ class StreamCheckerService:
                                     channel_result,
                                     'freeze_streams_count',
                                     fallback_status='freeze',
+                                )
+                                visibility_summary = self._single_channel_visibility_summary(
+                                    channel_result.get('channel_visibility')
+                                )
+                                self.sync_batch_state['channels_hidden'] += visibility_summary.get('channels_hidden', 0)
+                                self.sync_batch_state['channels_ready'] += visibility_summary.get('channels_ready', 0)
+                                self.sync_batch_state['channel_visibility_changed'] += visibility_summary.get(
+                                    'channel_visibility_changed',
+                                    0,
                                 )
 
                     if isinstance(channel_result, dict) and channel_result.get('aborted'):
@@ -7594,6 +7612,9 @@ class StreamCheckerService:
                     'dead_streams_count': 0,
                     'blank_streams_count': 0,
                     'freeze_streams_count': 0,
+                    'channels_hidden': 0,
+                    'channels_ready': 0,
+                    'channel_visibility_changed': 0,
                     'generation': self._sync_batch_generation,
                 }
                 self.checking = False

--- a/backend/tests/test_stream_checker_queue_lifecycle.py
+++ b/backend/tests/test_stream_checker_queue_lifecycle.py
@@ -788,6 +788,9 @@ class TestStreamCheckQueueLifecycle(unittest.TestCase):
             'dead_streams_count': 3,
             'blank_streams_count': 1,
             'freeze_streams_count': 2,
+            'channels_hidden': 1,
+            'channels_ready': 1,
+            'channel_visibility_changed': 2,
             'generation': 4,
         }
         service.checking = True
@@ -806,6 +809,9 @@ class TestStreamCheckQueueLifecycle(unittest.TestCase):
         self.assertEqual(service.sync_batch_state['dead_streams_count'], 0)
         self.assertEqual(service.sync_batch_state['blank_streams_count'], 0)
         self.assertEqual(service.sync_batch_state['freeze_streams_count'], 0)
+        self.assertEqual(service.sync_batch_state['channels_hidden'], 0)
+        self.assertEqual(service.sync_batch_state['channels_ready'], 0)
+        self.assertEqual(service.sync_batch_state['channel_visibility_changed'], 0)
         self.assertEqual(service._sync_batch_generation, 5)
         self.assertFalse(service.checking)
 
@@ -826,6 +832,9 @@ class TestStreamCheckQueueLifecycle(unittest.TestCase):
             'dead_streams_count': 3,
             'blank_streams_count': 1,
             'freeze_streams_count': 2,
+            'channels_hidden': 1,
+            'channels_ready': 1,
+            'channel_visibility_changed': 2,
             'started_at': '2026-05-29T18:03:41',
             'generation': 1,
         }
@@ -848,6 +857,9 @@ class TestStreamCheckQueueLifecycle(unittest.TestCase):
         self.assertEqual(status['queue']['dead_streams_count'], 3)
         self.assertEqual(status['queue']['blank_streams_count'], 1)
         self.assertEqual(status['queue']['freeze_streams_count'], 2)
+        self.assertEqual(status['queue']['channels_hidden'], 1)
+        self.assertEqual(status['queue']['channels_ready'], 1)
+        self.assertEqual(status['queue']['channel_visibility_changed'], 2)
         self.assertEqual(status['queue']['started_at'], '2026-05-29T18:03:41')
         self.assertTrue(status['stream_checking_mode'])
 
@@ -1050,6 +1062,10 @@ class TestStreamCheckQueueLifecycle(unittest.TestCase):
                 'dead_streams_count': 2,
                 'blank_streams_count': 1,
                 'freeze_streams_count': 0,
+                'channel_visibility': {
+                    'action': 'hidden',
+                    'changed': True,
+                },
             },
             {
                 'success': True,
@@ -1058,6 +1074,10 @@ class TestStreamCheckQueueLifecycle(unittest.TestCase):
                 'dead_streams_count': 1,
                 'blank_streams_count': 0,
                 'freeze_streams_count': 2,
+                'channel_visibility': {
+                    'action': 'unhidden',
+                    'changed': True,
+                },
             },
         ])
 
@@ -1076,12 +1096,15 @@ class TestStreamCheckQueueLifecycle(unittest.TestCase):
                     service.sync_batch_state.get('blank_streams_count'),
                     service.sync_batch_state.get('freeze_streams_count'),
                     service.sync_batch_state.get('good_streams_count'),
+                    service.sync_batch_state.get('channels_hidden'),
+                    service.sync_batch_state.get('channels_ready'),
+                    service.sync_batch_state.get('channel_visibility_changed'),
                 )),
             )
 
         self.assertEqual(list(result.keys()), [101, 102])
         self.assertEqual(progress_events, [(1, 2, 'One'), (2, 2, 'Two')])
-        self.assertEqual(sync_counts, [(2, 1, 0, 4), (3, 1, 2, 7)])
+        self.assertEqual(sync_counts, [(2, 1, 0, 4, 1, 0, 1), (3, 1, 2, 7, 1, 1, 2)])
         self.assertFalse(service.sync_batch_state['active'])
 
     def test_sync_batch_counts_blank_and_freeze_from_checked_streams_fallback(self):

--- a/backend/tests/test_v6_job_history.py
+++ b/backend/tests/test_v6_job_history.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 from flask import Flask
 from werkzeug.datastructures import MultiDict
@@ -419,3 +420,76 @@ def test_changelog_run_export_dead_scope_enriches_reasons_and_profiles():
     assert rows[302]["reason_detail"] == "inferred_from_run_metrics"
     assert rows[304]["status"] == "freeze"
     assert rows[304]["reason"] == "freeze"
+
+
+def test_changelog_run_export_enriches_provider_fields_from_current_udi_reference():
+    save_generic_telemetry(
+        "single_channel_check",
+        {
+            "channel_id": 31,
+            "channel_name": "Fixture Provider Enrichment",
+            "success": True,
+            "stream_details": [
+                {
+                    "stream_id": 701,
+                    "stream_name": "Name Only Provider",
+                    "status": "completed",
+                    "m3u_account": "Provider One",
+                },
+                {
+                    "stream_id": 702,
+                    "stream_name": "ID Only Provider",
+                    "status": "completed",
+                    "m3u_account": 8,
+                },
+                {
+                    "stream_id": 703,
+                    "stream_name": "Stream Context Provider",
+                    "status": "completed",
+                },
+            ],
+        },
+    )
+
+    session = get_session()
+    try:
+        run = session.query(Run).filter(Run.job_subject_ref == "channel:31").one()
+        run_id = run.id
+    finally:
+        session.close()
+
+    provider_refs = {
+        "streams": {
+            703: {"provider_id": 9, "provider_name": "Provider Three"},
+        },
+        "account_names_by_id": {
+            "7": "Provider One",
+            "8": "Provider Two",
+            "9": "Provider Three",
+        },
+        "account_ids_by_name": {
+            "provider one": 7,
+            "provider two": 8,
+            "provider three": 9,
+        },
+    }
+
+    app = Flask(__name__)
+    with app.app_context(), patch(
+        "apps.api.telemetry_handlers._provider_reference_context",
+        return_value=provider_refs,
+    ):
+        response = export_changelog_run_response(
+            run_id=run_id,
+            request_args=MultiDict({"format": "json", "include_url": "false"}),
+        )
+
+    payload = response.get_json()
+    rows = {row["stream_id"]: row for row in payload["streams"]}
+
+    assert rows[701]["provider_id"] == 7
+    assert rows[701]["provider_name"] == "Provider One"
+    assert rows[702]["provider_id"] == 8
+    assert rows[702]["provider_name"] == "Provider Two"
+    assert rows[703]["provider_id"] == 9
+    assert rows[703]["provider_name"] == "Provider Three"


### PR DESCRIPTION
﻿## Summary
- Enrich changelog run stream exports with provider_id/provider_name from the current Dispatcharr UDI stream/account reference, including name-only, ID-only, and null provider cases.
- Surface channel visibility automation counters in active synchronous Stream Checker batches so hidden/restored counts update live, not only after the changelog is written.
- Add regressions for provider enrichment, dead-stream provider null replacement, active visibility counters, and existing changelog visibility display helpers.

## Test Plan
- python -m pytest backend/tests/test_v6_job_history.py backend/tests/test_dead_stream_export.py
- python -m pytest backend/tests/test_stream_checker_queue_lifecycle.py
- python -m pytest backend/tests/test_channel_visibility_automation.py backend/tests/test_run_observability.py backend/tests/test_stream_checker_single_channel_profile_flags.py
- npm.cmd test -- --run src/lib/changelog-run-summary.test.js src/lib/dashboard-run-counts.test.js

## Required Before Ready
- Deploy the PR image through the normal Unraid Docker update path.
- Run a live single-channel visibility/check validation against current dev data.
- Start a final StreamFlow Full Run before shutdown; it does not need to be monitored.
